### PR TITLE
Moving attributes from aws_extension to core

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -707,6 +707,11 @@
       "object_type": "cloud",
       "type": "object_t"
     },
+    "cloud_partition": {
+      "description": "The canonical cloud partition name to which the region is assigned (e.g. AWS Partitions: aws, aws-cn, aws-us-gov).",
+      "name": "Cloud Partition",
+      "type": "string_t"
+    },
     "cmd_line": {
       "description": "The full command line used to launch an application, service, process, or job. For example: <code>ssh user@10.0.0.10</code>",
       "name": "Command Line",
@@ -877,6 +882,11 @@
       "name": "User Credential ID",
       "type": "string_t"
     },
+    "criticality": {
+      "description": "Criticality of a resource/object in question",
+      "name": "Criticality",
+      "type": "string_t"
+    },
     "customer_uid": {
       "description": "The unique customer identifier.",
       "name": "Customer UID",
@@ -902,6 +912,11 @@
     "desc": {
       "description": "The description that pertains to the object or event. See specific usage.",
       "name": "Description",
+      "type": "string_t"
+    },
+    "details": {
+      "description": "Details of an entity. See specific usage",
+      "name": "Details",
       "type": "string_t"
     },
     "detection_end_time": {

--- a/extensions/aws/dictionary.json
+++ b/extensions/aws/dictionary.json
@@ -49,11 +49,7 @@
       "object_type": "aws_malware",
       "type": "object_t"
     },
-    "cloud_partition": {
-      "description": "The canonical cloud partition name to which the region is assigned (e.g. AWS Partitions: aws, aws-cn, aws-us-gov).",
-      "name": "Cloud Partition",
-      "type": "string_t"
-    },
+ 
     "aws_rule": {
       "description": "The rule object describes rules associated with a policy or event.",
       "name": "Rule",
@@ -108,11 +104,6 @@
       "name": "CPU Allocation",
       "type": "integer_t"
     },
-    "criticality": {
-      "description": "Criticality of a resource/object in question",
-      "name": "Criticality",
-      "type": "string_t"
-    },
     "decision": {
       "description": "Decision/outcome of the authorization mechanism (e.g. Approved, Denied)",
       "name": "Authorization Decision/Outcome",
@@ -128,11 +119,7 @@
       "name": "Desired Status",
       "type": "string_t"
     },
-    "details": {
-      "description": "Details of an entity",
-      "name": "Details",
-      "type": "string_t"
-    },
+
     "error": {
       "description": "Error Code",
       "name": "Error Code",


### PR DESCRIPTION
Moving cloud_partition, details & criticality (Resource object) from AWS extension to core