### PR TITLE
HTTP Event Class: Relocate URL

### DIFF
--- a/includes/http.json
+++ b/includes/http.json
@@ -14,11 +14,6 @@
     },
     "http_response": {
       "requirement": "required"
-    },
-    "url": {
-      "description": "The URL object that pertains to the event.",
-      "requirement": "required",
-      "group": "primary"
     }
   }
 }

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -21,17 +21,9 @@
       "description": "",
       "requirement": "recommended"
     },
-    "path": {
-      "description": "The URL path as extracted from the URL. For example: <code>/download/trouble</code>.",
-      "requirement": "required"
-    },
     "prefix": {
       "description": "Domain prefix.",
       "requirement": "optional"
-    },
-    "port": {
-      "description": "The port number. For example: <code>80</code>.",
-      "requirement": "recommended"
     },
     "referrer": {
       "requirement": "optional"
@@ -45,6 +37,11 @@
     },
     "x_forwarded_for": {
       "requirement": "optional"
+    },
+    "url": {
+      "description": "The URL object that pertains to the request.",
+      "requirement": "required",
+      "group": "primary"
     }
   }
 }


### PR DESCRIPTION
This PR relocates the `url` from the root of the HTTP Event Class into `http_request` while removing `path` and `port` as they are made redundant with `url`. Port is a valid URL fragment but the real source of truth should be the `port` that is located in the `dst_endpoint` object. 