### PR TITLE
HTTP Event Class: Remove duplicate `http_method` from HTTP Trait

### DIFF
--- a/includes/http.json
+++ b/includes/http.json
@@ -2,10 +2,6 @@
   "name": "HTTP Traffic Trait",
   "description": "HTTP Traffic trait defines attributes shared by HTTP traffic and alert events.",
   "attributes": {
-    "http_method": {
-      "requirement": "recommended",
-      "group": "primary"
-    },
     "http_status": {
       "group": "primary"
     },


### PR DESCRIPTION
The method should be located within the request object