### PR TITLE
Update container object attributes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1698,6 +1698,11 @@
       "name": "Namespace",
       "type": "string_t"
     },
+    "network_driver": {
+      "description": "The network driver used by the container. For example, bridge, overlay, host, none, etc.",
+      "name": "Network Driver",
+      "type": "string_t"
+    },
     "network_interface": {
       "description": "The network interface that is associated with the device.",
       "name": "Network Interface",
@@ -1772,6 +1777,11 @@
     "operation": {
       "description": "Verb/Operation associated with the request",
       "name": "Operation",
+      "type": "string_t"
+    },
+    "orchestrator": {
+      "description": "The orchestrator managing the container, such as ECS, EKS, K8s, OpenShift, None.",
+      "name": "Orchestrator",
       "type": "string_t"
     },
     "org_uid": {

--- a/objects/container.json
+++ b/objects/container.json
@@ -18,6 +18,26 @@
     "uid": {
       "description": "The container unique identifier. For example: <code>a3bf90e006b2</code>",
       "requirement": "required"
+    },
+    "orchestrator": {
+      "description": "The orchestrator managing the container, such as ECS, EKS, K8s, OpenShift, None.",
+      "requirement": "optional"
+    },
+    "tag": {
+      "description": "The tag used by the container. It can indicate version, format, OS.",
+      "requirement": "optional"
+    },
+    "size": {
+      "description": "The size of the container image",
+      "requirement": "recommended"
+    },
+    "sha2": {
+      "description": "The SHA256 hash of the container",
+      "requirement": "recommemded"
+    },
+    "network_driver": {
+      "description": "The network driver used by the container",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
Added the following fields to the container.json object to provide more valuable information:

- orchestrator
- network driver
- tag
- size
- sha2

Updated the dictionary.json with missing attributes:

- orchestrator
- network_driver

Tested on my local ocsf-server instance with no errors. Evidence below.
<img width="1618" alt="Screen Shot 2022-06-29 at 10 43 09 AM" src="https://user-images.githubusercontent.com/1558043/176469881-a6bc6ec3-9031-434a-a301-a11991b9bd10.png">

