### PR TITLE
Fix PR for boot_time

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -278,6 +278,11 @@
       "name": "OS Bits",
       "type": "integer_t"
     },
+    "boot_time": {
+      "description": "The endpoint boot or reboot time",
+      "name": "Boot Time",
+      "type": "timestamp_t"
+      },
     "build": {
       "description": "The operating system build number.",
       "name": "OS Build",

--- a/objects/device.json
+++ b/objects/device.json
@@ -8,6 +8,9 @@
     "caption": {
       "requirement": "optional"
     },
+    "boot_time": {
+      "requirement": "optional"
+    },
     "desc": {
       "description": "The description of the device, ordinarily as reported by the operating system.",
       "name": "Description",


### PR DESCRIPTION
Adjusted PR on request. Adding new attribute to device object. Device seems to be the best place for this attribute type. 