### PR TITLE
Correcting array definition error in the vulnerability object

### DIFF
--- a/objects/vulernability.json
+++ b/objects/vulernability.json
@@ -31,7 +31,6 @@
       "requirement": "optional"
     },
     "uid": {
-      "is_array": true,
       "requirement": "required"
     },
     "vendor": {


### PR DESCRIPTION
`uid` should not be an array in the object, considering every other field in the object provides context about uniquely identified vulnerability  