### PR TITLE
Correcting plurality of an array attribute

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2290,10 +2290,10 @@
       "name": "Reference UID",
       "type": "string_t"
     },
-    "reference": {
+    "references": {
       "description": "Supporting reference URLs",
       "is_array": true,
-      "name": "Reference",
+      "name": "References",
       "type": "string_t"
     },
     "referrer": {

--- a/objects/vulernability.json
+++ b/objects/vulernability.json
@@ -17,7 +17,7 @@
     "packages": {
       "requirement": "optional"
     },
-    "reference": {
+    "references": {
       "requirement": "recommended"
     },
     "related_vulns": {


### PR DESCRIPTION
* Renaming `reference` to `references` to be inline with OCSF grammar, in the dictionary
* Consequent modification in the `vulnerability` object