### PR TITLE
Update K8s object attributes 

### DIFF
--- a/extensions/aws/dictionary.json
+++ b/extensions/aws/dictionary.json
@@ -42,9 +42,14 @@
       "object_type": "certificate",
       "type": "object_t"
     },
+    "cluster_name": {
+      "description": "The name for the container cluster",
+      "name": "Cluster Name",
+      "type": "string_t"
+    },
     "cluster_uid": {
       "description": "The unique identifer for the container cluster",
-      "name": "cluster_uid",
+      "name": "Cluster UID",
       "type": "string_t"
     },
     "configuration": {
@@ -214,13 +219,23 @@
       "object_type": "network_traffic",
       "type": "object_t"
     },
+    "node_name": {
+      "description": "The Name of the Node inside the Kubernetes cluster",
+      "name": "Node Name",
+      "type": "string_t"
+    },
+    "node_ip": {
+      "description": "The IP of the Node inside the Kubernetes cluster",
+      "name": "Node IP",
+      "type": "string_t"
+    },
     "not_after": {
-      "description": "A TLS certificate's validty period",
+      "description": "The maximum TLS certificate's validty period",
       "name": "Not After",
       "type": "string_t"
     },
     "not_before": {
-      "description": "A TLS certificate's validty period",
+      "description": "The minimum TLS certificate's validty period",
       "name": "Not Before",
       "type": "string_t"
     },
@@ -244,6 +259,26 @@
     "pem": {
       "description": "An identifier for an associated PEM format for certificates",
       "name": "PEM",
+      "type": "string_t"
+    },
+    "pod_uid": {
+      "description": "The unique ID of the pod inside the Kubernetes cluster",
+      "name": "Pod ID",
+      "type": "string_t"
+    },
+    "pod_ip": {
+      "description": "The IP of the pod inside the Kubernetes cluster",
+      "name": "Pod IP",
+      "type": "string_t"
+    },
+    "pod_name": {
+      "description": "The name of the pod inside the Kubernetes cluster",
+      "name": "Pod Name",
+      "type": "string_t"
+    },
+    "pod_namespace": {
+      "description": "The Namespace where the pod is located inside the Kubernetes cluster",
+      "name": "Pod Name",
       "type": "string_t"
     },
     "redirect_url": {

--- a/extensions/aws/objects/kubernetes.json
+++ b/extensions/aws/objects/kubernetes.json
@@ -38,6 +38,42 @@
     "stage_timestamp": {
       "description": "Time the request reached current audit stage",
       "requirement": "required"
+    },
+    "pod_name": {
+      "description": "The name of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_uid": {
+      "description": "The ID of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_ip": {
+      "description": "The IP of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_namespace": {
+      "description": "The Namespace where the pod is located inside the Kubernetes cluster",
+      "requirement": ""
+    },
+    "container": {
+      "description": "The Container object inside the pod in a Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "cluster_uid": {
+      "description": "The ID of the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "cluster_name": {
+      "description": "The Name of the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "node_name": {
+      "description": "The Name of the Node inside the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "node_ip": {
+      "description": "The IP of the Node inside the Kubernetes cluster",
+      "requirement": "recommended"
     }
   }
 }


### PR DESCRIPTION
Added the following fields to the kubernetes.json object (currently inside the aws extension) to provide more valuable information:

- pod_name
- pod_uid
- pod_ip
- pod_namespace
- container
- cluster_uid
- cluster_name
- node_name
- node_ip

Updated the dictionary.json (inside aws ex) with missing attributes:

- pod_name
- pod_uid
- pod_ip
- pod_namespace
- cluster_name
- node_name
- node_ip

Tested on my local ocsf-server instance with no errors or warnings related to those fields. Evidence below.

<img width="1620" alt="Screen Shot 2022-07-13 at 10 04 42 AM" src="https://user-images.githubusercontent.com/1558043/178740821-b10a2ee4-156b-4671-8c63-312193af63ff.png">
