### PR TITLE
Update recommended and required fields on process object and their descriptions

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -682,7 +682,7 @@
     },
     "cmd_line": {
       "caption": "Command Line",
-      "description": "The full command line used to launch an application, service, process, or job. For example: <code>ssh user@10.0.0.10</code>",
+      "description": "The full command line used to launch an application, service, process, or job. For example: <code>ssh user@10.0.0.10</code>. If the command line is unavailable or missing, the empty string <code>''</code> is to be used",
       "type": "string_t"
     },
     "code": {
@@ -1758,7 +1758,7 @@
     },
     "lineage": {
       "caption": "Lineage",
-      "description": "The lineage of the process, represented by a list of paths for each ancestor process. Eg ['/usr/sbin/sshd', '/usr/bin/bash', '/usr/bin/whoami']",
+      "description": "The lineage of the process, represented by a list of paths for each ancestor process. For example: <code>['/usr/sbin/sshd', '/usr/bin/bash', '/usr/bin/whoami']</code>",
       "is_array": true,
       "type": "string_t"
     },
@@ -2100,7 +2100,7 @@
     },
     "parent_process": {
       "caption": "Parent Process",
-      "description": "The parent process of the <code>actor</code> process. It is recommended to only populate this field for the first process object.",
+      "description": "The parent process of this process object. It is recommended to only populate this field for the first process object, to prevent deep nesting.",
       "type": "process"
     },
     "path": {
@@ -3108,11 +3108,6 @@
     "user": {
       "caption": "User",
       "description": "The user that pertains to the event or object.",
-      "type": "user"
-    },
-    "username": {
-      "caption": "Username",
-      "description": "The user account the process is running as.",
       "type": "user"
     },
     "user_agent": {

--- a/objects/process.json
+++ b/objects/process.json
@@ -87,9 +87,6 @@
       "caption": "Process UID",
       "requirement": "recommended"
     },
-    "username": {
-      "requirement": "required"
-    },
     "xattributes": {
       "description": "An unordered collection of zero or more name/value pairs that represent a process extended attribute.",
       "requirement": "optional"


### PR DESCRIPTION
- Set fields `cmd_line` and `path` to `required`, as these are the most important data points for a process.
- Bump some important optional fields to recommended to increase visibility and promote their inclusion.
- Remove the `at least one` constraint, as two of these fields were made required
- Updating descriptions to improve clarity around field content 
- Postponing `user` related changes until profiles can be made required for particular event classes