### PR TITLE
Producer object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2190,6 +2190,11 @@
       "description": "Unique Identifier of a product.",
       "type": "string_t"
     },
+    "producer": {
+      "caption": "Producer",
+      "description": "Describes the product, service, appliance or similar that an event originated from.",
+      "type": "producer"
+    },
     "profiles": {
       "caption": "Profiles",
       "description": "The list of profiles used to create the event.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2192,7 +2192,7 @@
     },
     "producer": {
       "caption": "Producer",
-      "description": "Describes the product, service, appliance or similar that an event originated from.",
+      "description": "The product, service, appliance or similar that an event originated from.",
       "type": "producer"
     },
     "profiles": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -11,6 +11,9 @@
     "log_time": {
       "requirement": "reserved"
     },
+    "producer": {
+      "requirement": "required"
+    },
     "modified_time": {
       "description": "The time when the event was last modified or enriched."
     },

--- a/objects/producer.json
+++ b/objects/producer.json
@@ -1,0 +1,27 @@
+{
+    "caption": "Producer",
+    "name": "producer",
+    "description": "The producer object describes the product, service, appliance or similar that an event originated from",
+    "extends": "object",
+    "attributes": {
+      "name": {
+        "description": "Name of the product, service, appliance or similar that an event originated from. Should omit name of the vendor if the vendor name is independent of the producer name.",
+        "notes": "For example: <i>VPC Flow</i>, <i>Windows</i>, <i>ASA</i>",
+        "requirement": "required"
+      },
+      "vendor": {
+        "description": "The name of the organization or entity responsible for the event originator.",
+        "notes": "For example: <i>AWS</i>, <i>Microsoft</i>, <i>Cisco</i>, <i></i>.",
+        "requirement": "required"
+      },
+      "uid": {
+        "description": "A unique identifier of the originating product, service, or appliance of an event.",
+        "requirement": "optional"
+      },
+      "version": {
+        "description": "The version of the originating product, service, appliance etc of an event.",
+        "requirement": "optional"
+      }
+    }
+  }
+  


### PR DESCRIPTION
Adds new producer object to metadata object. This is to describe an event origin such as Vendor and Product.

Signed-off-by: Julian Crowley jcrowley@sumologic.com