### PR TITLE
Entity Class Refinements

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1227,11 +1227,6 @@
       "description": "The updated managed entity.",
       "type": "managed_entity"
     },
-    "actor_entity": {
-      "caption": "Actor Entity",
-      "description": "The entity that performed the operation or action on the target entity. For example, the entity that could have created a configuration or modified a policy.",
-      "type": "managed_entity"
-    },
     "error": {
       "caption": "Error Code",
       "description": "Error Code",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1227,6 +1227,11 @@
       "description": "The updated managed entity.",
       "type": "managed_entity"
     },
+    "actor_entity": {
+      "caption": "Actor Entity",
+      "description": "The entity that performed the operation or action on the target entity. For example, the entity that could have created a configuration or modified a policy.",
+      "type": "managed_entity"
+    },
     "error": {
       "caption": "Error Code",
       "description": "Error Code",

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -3,7 +3,7 @@
   "uid": 3,
   "name": "entity_management_audit",
   "extends": "audit",
-  "description": "Entity Audit events report activity by a managed client, a micro service, or a user at a management console. The activity can be a create, update, and delete operation on a managed entity.",
+  "description": "Entity Audit events report activity by a managed client, a micro service, or a user at a management console. The activity can be a create, read, update, and delete operation on a managed entity.",
   "attributes": {
     "comment": {
       "description": "The user provided comment about why the entity was changed.",
@@ -16,16 +16,13 @@
           "caption": "Created"
         },
         "2": {
-          "caption": "Updated"
+          "caption": "Read"
         },
         "3": {
-          "caption": "Deleted"
+          "caption": "Updated"
         },
         "4": {
-          "caption": "Moved"
-        },
-        "5": {
-          "caption": "Accessed"
+          "caption": "Deleted"
         }
       }
     },
@@ -37,13 +34,13 @@
       "requirement": "optional",
       "group": "primary"
     },
+    "actor_entity": {
+      "requirement": "optional",
+      "group": "primary"
+    },
     "src_user": {
       "requirement": "recommended",
       "group": "context"
     }
-  },
-  "associations": {
-    "origin.device": ["src_user"],
-    "src_user": ["origin.device"]
   }
 }

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -36,10 +36,16 @@
     },
     "actor_entity": {
       "requirement": "optional",
+      "notes": "Use for when the entity acting upon another entity is not a user",
       "group": "primary"
     },
     "src_user": {
       "requirement": "recommended",
+      "notes": "Use for when the entity acting upon another entity is a user",
+      "group": "context"
+    },
+    "actor_process": {
+      "description": "Use for when the entity acting upon another entity is a process",
       "group": "context"
     }
   }

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -1,7 +1,7 @@
 {
-  "caption": "Entity Audit",
+  "caption": "Entity Management Audit",
   "uid": 3,
-  "name": "entity_audit",
+  "name": "entity_management_audit",
   "extends": "audit",
   "description": "Entity Audit events report activity by a managed client, a micro service, or a user at a management console. The activity can be a create, update, and delete operation on a managed entity.",
   "attributes": {

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -34,14 +34,9 @@
       "requirement": "optional",
       "group": "primary"
     },
-    "actor_entity": {
-      "requirement": "optional",
-      "notes": "Use for when the entity acting upon another entity is not a user",
-      "group": "primary"
-    },
     "src_user": {
       "requirement": "recommended",
-      "notes": "Use for when the entity acting upon another entity is a user",
+      "description": "Use for when the entity acting upon another entity is a user",
       "group": "context"
     },
     "actor_process": {


### PR DESCRIPTION
Clarified name of entity_audit to be clear it is for capturing managed entity activity vs inventory of managed entities.

Refined activity enum to be slightly more relatable to a myriad of general mgmt ops.

Signed-off-by: Julian Crowley jcrowley@sumologic.com