### PR TITLE
Correcting an erroneous definition in the base-event

### DIFF
--- a/events/base_event.json
+++ b/events/base_event.json
@@ -11,9 +11,6 @@
       "group": "context"
     },
     "message": {
-      "customer_uid": {
-        "group": "context"
-      },
       "group": "primary",
       "requirement": "recommended"
     },


### PR DESCRIPTION
Noticed the base_event definition had a `customer_uid` field incorrectly defined, nested inside the `message` field. Correcting the error.

Also, unclear what `customer_uid` represents, it is not currently referenced by any object, event_class. What does a customer mean in the context of a log? Removing from base_event. We can probably remove it from the dictionary as well. 




Signed-off-by: Rajas <rajaspa@amazon.com>