### PR TITLE
Correcting capitalization of an attribute caption

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1432,7 +1432,7 @@
       "type": "string_t"
     },
     "identity": {
-      "caption": "identity",
+      "caption": "Identity",
       "description": "Identity Object details AuthN, AuthZ information pertaining to the event",
       "type": "identity"
     },


### PR DESCRIPTION
identity -> Identity

![Screen Shot 2022-08-09 at 3 25 31 PM](https://user-images.githubusercontent.com/89877409/183744486-75385939-3466-40bb-b112-786381715da3.png)

Signed-off-by: Rajas <rajaspa@amazon.com>