### PR TITLE
Removing containers from the cloud profile

### DIFF
--- a/profiles/cloud.json
+++ b/profiles/cloud.json
@@ -7,9 +7,6 @@
     "group": "primary"
   },
   "attributes": {
-    "container": {
-      "requirement": "recommended"
-    },
     "cloud": {
       "requirement": "required"
     }


### PR DESCRIPTION
Removing `containers` object from the definition of `cloud` profile. 

Signed-off-by: Rajas <rajaspa@amazon.com>