### PR TITLE
Correcting the uids to bring consistency across categories

### DIFF
--- a/events/audit/account.json
+++ b/events/audit/account.json
@@ -1,6 +1,6 @@
 {
   "caption": "Account Change Audit",
-  "uid": 0,
+  "uid": 1,
   "name": "account_change_audit",
   "extends": "audit",
   "description": "Account Audit events report when specific user account management tasks are performed, such as a user account is created, changed, deleted, renamed, disabled, enabled, locked out or unlocked.",

--- a/events/audit/authentication.json
+++ b/events/audit/authentication.json
@@ -1,6 +1,6 @@
 {
   "caption": "Authentication Audit",
-  "uid": 1,
+  "uid": 2,
   "name": "authentication_audit",
   "extends": "audit",
   "description": "Authentication Audit events report authentication session activities such as user attempts a logon or logoff, successfully or otherwise.",

--- a/events/audit/authorization.json
+++ b/events/audit/authorization.json
@@ -1,6 +1,6 @@
 {
   "caption": "Authorization Audit",
-  "uid": 2,
+  "uid": 3,
   "name": "authorization_audit",
   "extends": "audit",
   "description": "Authorization Audit events report special privileges or groups assigned to a session.",

--- a/events/audit/entity.json
+++ b/events/audit/entity.json
@@ -1,6 +1,6 @@
 {
   "caption": "Entity Management Audit",
-  "uid": 3,
+  "uid": 4,
   "name": "entity_management_audit",
   "extends": "audit",
   "description": "Entity Audit events report activity by a managed client, a micro service, or a user at a management console. The activity can be a create, read, update, and delete operation on a managed entity.",


### PR DESCRIPTION
Event classes began with 0 in the Audit category, however for every other category classes began with 1.

After correction - 

![Screen Shot 2022-08-10 at 9 32 05 AM](https://user-images.githubusercontent.com/89877409/183914168-5404a747-aa64-49cc-8455-898e8fde59b3.png)

Signed-off-by: Rajas <rajaspa@amazon.com>