### PR TITLE
Bringing consistency in event class names across Network Activity category

### DIFF
--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -10,7 +10,7 @@
   ],
   "category": "network",
   "description": "DNS Activity events report DNS queries and answers as seen on the network.",
-  "extends": "network",
+  "extends": "network_activity",
   "attributes": {
     "$include": [
       "profiles/cloud.json",

--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -1,7 +1,7 @@
 {
   "caption": "DNS Activity",
   "uid": 3,
-  "name": "network_dns_activity",
+  "name": "dns_activity",
   "profiles": [
     "cloud",
     "domain_security",

--- a/events/network/ftp.json
+++ b/events/network/ftp.json
@@ -1,7 +1,7 @@
 {
   "caption": "FTP Activity",
   "uid": 8,
-  "name": "network_ftp_activity",
+  "name": "ftp_activity",
   "profiles": [
     "user",
     "host"

--- a/events/network/ftp.json
+++ b/events/network/ftp.json
@@ -8,7 +8,7 @@
   ],
   "category": "network",
   "description": "File Transfer Protocol (FTP) Activity events report file transfers between a server and a client as seen on the network.",
-  "extends": "network",
+  "extends": "network_activity",
   "attributes": {
     "codes": {
       "description": "The list of return codes to the FTP command.",

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -2,7 +2,7 @@
   "caption": "HTTP Activity",
   "uid": 2,
   "name": "http_activity",
-  "extends": "network",
+  "extends": "network_activity",
   "description": "HTTP Activity events report HTTP connection and traffic information.",
   "attributes": {
     "$include": "includes/http.json"

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -1,7 +1,7 @@
 {
   "caption": "HTTP Activity",
   "uid": 2,
-  "name": "network_http_activity",
+  "name": "http_activity",
   "extends": "network",
   "description": "HTTP Activity events report HTTP connection and traffic information.",
   "attributes": {

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -3,7 +3,7 @@
   "category": "network",
   "description": "Network Activity events report network connection and traffic activity.",
   "extends": "base_event",
-  "name": "network",
+  "name": "network_activity",
   "profiles": [
     "cloud",
     "domain_security",

--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -8,7 +8,7 @@
   ],
   "category": "network",
   "description": "Remote Desktop Protocol (RDP) Activity events report remote client connections to a server as seen on the network.",
-  "extends": "network",
+  "extends": "network_activity",
   "attributes": {
     "certificate_chain": {
       "description": "The list of observed certificates in an RDP TLS connection.",

--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -1,7 +1,7 @@
 {
   "caption": "RDP Activity",
   "uid": 5,
-  "name": "network_rdp_activity",
+  "name": "rdp_activity",
   "profiles": [
     "user",
     "host"

--- a/events/network/smb.json
+++ b/events/network/smb.json
@@ -1,7 +1,7 @@
 {
   "caption": "SMB Activity",
   "uid": 6,
-  "name": "network_smb_activity",
+  "name": "smb_activity",
   "profiles": [
     "user",
     "host"

--- a/events/network/smb.json
+++ b/events/network/smb.json
@@ -8,7 +8,7 @@
   ],
   "category": "network",
   "description": "Server Message Block (SMB) Protocol Activity events report client/server connections sharing resources within the network.",
-  "extends": "network",
+  "extends": "network_activity",
   "attributes": {
     "activity_id": {
       "enum": {

--- a/events/network/ssh.json
+++ b/events/network/ssh.json
@@ -1,7 +1,7 @@
 {
   "caption": "SSH Activity",
   "uid": 7,
-  "name": "network_ssh_activity",
+  "name": "ssh_activity",
   "profiles": [
     "user",
     "host"

--- a/events/network/ssh.json
+++ b/events/network/ssh.json
@@ -8,7 +8,7 @@
   ],
   "category": "network",
   "description": "SSH Activity events report remote client connections to a server using the Secure Shell (SSH) Protocol.",
-  "extends": "network",
+  "extends": "network_activity",
   "attributes": {
     "client": {
       "description": "The SSH client.",


### PR DESCRIPTION
In the Network Activity category -

1. DHCP Activity was named - dhcp_activity
2. Network Activity was named - network
3. Every other class was named - network_xyz_activity

Changing the names to xyz_activity. Removing the redundant `network_` prefix from all the classes.  

Signed-off-by: Rajas <rajaspa@amazon.com>