### PR TITLE
Refining http_request

### DIFF
--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -15,7 +15,6 @@
       "requirement": "recommended"
     },
     "http_method": {
-      "description": "",
       "requirement": "recommended"
     },
     "version": {
@@ -35,8 +34,7 @@
       "requirement": "optional"
     },
     "user_agent": {
-      "description": "",
-      "requirement": "recommended"
+      "requirement": "required"
     },
     "x_forwarded_for": {
       "requirement": "optional"
@@ -46,5 +44,12 @@
       "requirement": "required",
       "group": "primary"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "user_agent",
+      "url",
+      "hostname"
+    ]
   }
 }


### PR DESCRIPTION
1. Descriptions were overridden with a blank "" in the http_request object, cleaning up.
2. Adding a constraint of at least one to satisfy the requirements, for sources where all the required fields are not available.

![Screen Shot 2022-08-16 at 11 54 08 AM](https://user-images.githubusercontent.com/89877409/184924226-ff7153f8-b988-43b9-afe5-b47ea3ed3ef8.png)



Signed-off-by: Rajas <rajaspa@amazon.com>