### PR TITLE
Session Object refinement

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1589,6 +1589,11 @@
       "description": "The name of the Internet Service Provider (ISP).",
       "type": "string_t"
     },
+    "issuer": {
+      "caption": "Issuer Details",
+      "description": "The identifier of the session issuer.",
+      "type": "string_t"
+    },
     "issuer_dn": {
       "caption": "Issuer Distinguished Name",
       "description": "The certificate issuer distinguished name.",

--- a/objects/session.json
+++ b/objects/session.json
@@ -8,9 +8,9 @@
       "description": "The session creation time.",
       "requirement": "recommended"
     },
-    "creator": {
-      "description": "The session creator/source identity information.",
-      "requirement": "optional"
+    "issuer": {
+      "description": "The identifier of the session issuer.",
+      "requirement": "recommended"
     },
     "credential_uid": {
       "requirement": "optional"
@@ -24,7 +24,7 @@
     },
     "uid": {
       "description": "Unique identifier of the session",
-      "requirement": "required"
+      "requirement": "recommended"
     }
   }
 }


### PR DESCRIPTION
1. Adding `'issuer` field in the session object in favor of creator, to more accurately represent the issuer information.
2. Updating the dictionary accordingly.

![Screen Shot 2022-08-19 at 11 04 12 AM](https://user-images.githubusercontent.com/89877409/185648878-cac15001-2776-4fdb-b65d-78b949fc8eb9.png)
