### PR TITLE
Adding cloud profile to the base event

### DIFF
--- a/events/base_event.json
+++ b/events/base_event.json
@@ -2,10 +2,14 @@
   "caption": "Base Event",
   "name": "base_event",
   "description": "The base event is a generic concrete event and it also defines a set of attributes available in most event classes. As a generic event that does not belong to any event category, it could be used to log events that are not otherwise defined by the schema.",
+  "profiles": [
+    "cloud"
+  ],
   "attributes": {
     "$include": [
       "includes/occurrence.json",
-      "includes/classification.json"
+      "includes/classification.json",
+      "profiles/cloud.json"
     ],
     "_raw_data": {
       "group": "context"

--- a/events/cloud/cloud.json
+++ b/events/cloud/cloud.json
@@ -3,13 +3,7 @@
   "category": "cloud",
   "name": "cloud",
   "extends": "base_event",
-  "profiles": [
-    "cloud"
-  ],
   "attributes": {
-    "$include": [
-      "profiles/cloud.json"
-    ],
     "activity_id": {
       "$include": "enums/cloud_activity.json"
     }


### PR DESCRIPTION
Adding the cloud profile to the base_event, every event class can now be overlayed with cloud object.

![Screen Shot 2022-08-25 at 11 56 36 AM](https://user-images.githubusercontent.com/89877409/186713023-7b10828b-ab51-4c4a-9255-771a7e13caad.png)
