### PR TITLE
TLS certificate and sni attributes to recommended

### DIFF
--- a/objects/tls.json
+++ b/objects/tls.json
@@ -12,7 +12,7 @@
       "requirement": "optional"
     },
     "certificate": {
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "certificate_chain": {
       "requirement": "recommended"
@@ -51,7 +51,7 @@
       "requirement": "optional"
     },
     "sni": {
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "version": {
       "description": "The TLS protocol version.",


### PR DESCRIPTION
Certificates are encrypted in TLS 1.3, so this attribute should only be recommended. SNI is an optional extension and there are some efforts to also encrypt it, so it should also only be recommended. 

Signed-off-by: Dale Bowie <dalbowie@au1.ibm.com>