### PR TITLE
Extensions: update directories in README, fix Treat typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,14 @@ To extend the schema create a new directory in the `schema/extensions` directory
 structure is the same as the top level schema directory, and it may contain the following files
 and subdirectories.
 
+
 | Name              | Description                                                               |
-| ----------------- | ------------------------------------------------------------------------- |
+|-------------------|---------------------------------------------------------------------------|
 | `categories.json` | Create it to define a new event category to reserve a range of class IDs. |
 | `dictionary.json` | Create it to define new attributes.                                       |
+| `enums`           | Create it to define new enumerations.                                     |
 | `events`          | Create it to define new event classes.                                    |
+| `includes`        | Create it to define new shared data.                                      |
 | `objects`         | Create it to define new objects.                                          |
 
 For more information on extending the schema, please refer to the contribution guide,

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -17,9 +17,11 @@ For example:
 
 The directory structure is the same as the top level schema directory and it may contain the following files and subdirectories.
 
-| Name              | Description                                                  |
-| ----------------- | ------------------------------------------------------------ |
+| Name              | Description                                                               |
+|-------------------|---------------------------------------------------------------------------|
 | `categories.json` | Create it to define a new event category to reserve a range of class IDs. |
-| `dictionary.json` | Create it to define new attributes.                          |
-| `events`          | Create it to define new event classes.                       |
-| `objects`         | Create it to define new objects.                             |
+| `dictionary.json` | Create it to define new attributes.                                       |
+| `enums`           | Create it to define new enumerations.                                     |
+| `events`          | Create it to define new event classes.                                    |
+| `includes`        | Create it to define new shared data.                                      |
+| `objects`         | Create it to define new objects.                                          |

--- a/extensions/dev/includes/email.json
+++ b/extensions/dev/includes/email.json
@@ -1,5 +1,5 @@
 {
-  "caption": "Email Treat",
+  "caption": "Email Trait",
   "description": "Email trait defines attributes shared by endpoint and network email events.",
   "attributes": {
     "connection_uid": {

--- a/extensions/dev/includes/email_delivery.json
+++ b/extensions/dev/includes/email_delivery.json
@@ -1,5 +1,5 @@
 {
-  "caption": "Email Delivery Treat",
+  "caption": "Email Delivery Trait",
   "attributes": {
     "attempt": {
       "requirement": "recommended",


### PR DESCRIPTION
Extensions example "dev" includes directories "enums" and "includes" that are not listed in README - add them.

Email example has a typo "Treat" that should be "Trait".