### PR TITLE
Remove first_seen_time from the dev dictionary

### DIFF
--- a/extensions/dev/dictionary.json
+++ b/extensions/dev/dictionary.json
@@ -169,11 +169,6 @@
       "description": "The unique identifier of the facility.",
       "type": "string_t"
     },
-    "first_seen_time": {
-      "caption": "First Seen",
-      "description": "The initial detection time of the malware.",
-      "type": "timestamp_t"
-    },
     "from": {
       "caption": "From",
       "description": "The email header From values, as defined by RFC 5322.",


### PR DESCRIPTION
Signed-off-by: Roumen Roupski <rroupski@splunk.com>