### PR TITLE
Adding attack object in the security findings event class

### DIFF
--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -12,6 +12,11 @@
     "$include": [
       "profiles/cloud.json"
     ],
+    "attacks": {
+      "group": "context",
+      "requirement": "optional",
+      "description": "The attack object describes the technique and associated tactics as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>."
+    },
     "compliance": {
       "group": "context",
       "requirement": "optional"


### PR DESCRIPTION
Adding the already defined MITRE ATT&CK object in the security_findings event class.

![Screen Shot 2022-09-14 at 4 42 46 PM](https://user-images.githubusercontent.com/89877409/190258382-4b723346-6adf-4e1d-a7f6-10ec1786baf2.png)

Signed-off-by: Rajas <rajaspa@amazon.com>