### PR TITLE
Resolve #220 (fix activity_id enums)

### DIFF
--- a/events/system/process.json
+++ b/events/system/process.json
@@ -6,20 +6,22 @@
   "uid": 7,
   "attributes": {
     "activity_id": {
-      "1": {
-        "caption": "Launch"
-      },
-      "2": {
-        "caption": "Terminate"
-      },
-      "3": {
-        "caption": "Open"
-      },
-      "4": {
-        "caption": "Inject"
-      },
-      "5": {
-        "caption": "Set User ID"
+      "enum": {
+        "1": {
+          "caption": "Launch"
+        },
+        "2": {
+          "caption": "Terminate"
+        },
+        "3": {
+          "caption": "Open"
+        },
+        "4": {
+          "caption": "Inject"
+        },
+        "5": {
+          "caption": "Set User ID"
+        }
       }
     },
     "actor_process": {


### PR DESCRIPTION
Big Fix: nest `activity_id` enums under `enum` in the json file. Tested & validated:

<img width="858" alt="image" src="https://user-images.githubusercontent.com/91983279/190706001-d0542d8d-3416-4142-bc58-62b2e76f6a85.png">

Signed-off-by: Mike Radka (Splunk) <mradka@splunk.com>