### PR TITLE
Add process_activity to enums

### DIFF
--- a/enums/process_activity.json
+++ b/enums/process_activity.json
@@ -1,0 +1,19 @@
+{
+  "enum": {
+    "1": {
+      "caption": "Launch"
+    },
+    "2": {
+      "caption": "Terminate"
+    },
+    "3": {
+      "caption": "Open"
+    },
+    "4": {
+      "caption": "Inject"
+    },
+    "5": {
+      "caption": "Set User ID"
+    }
+  }
+}

--- a/events/system/process.json
+++ b/events/system/process.json
@@ -6,23 +6,7 @@
   "uid": 7,
   "attributes": {
     "activity_id": {
-      "enum": {
-        "1": {
-          "caption": "Launch"
-        },
-        "2": {
-          "caption": "Terminate"
-        },
-        "3": {
-          "caption": "Open"
-        },
-        "4": {
-          "caption": "Inject"
-        },
-        "5": {
-          "caption": "Set User ID"
-        }
-      }
+      "$include": "enums/process_activity.json"
     },
     "actor_process": {
       "description": "The process that performed the operation or action on the target <code>process</code>. For example, the process that could have started a new process or injected code into another process."


### PR DESCRIPTION
Following the pattern of [cloud_activity](https://github.com/ocsf/ocsf-schema/commit/911aa4352b2540ff159412865f721a43c09910a8), place process_activity enum in the enums directory and reference it with #include.  Similar updates should be made to other events, collecting all enum definitions into a single location.

See #221.