### PR TITLE
Product, Metadata, the origin of an event.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2997,9 +2997,9 @@
       "description": "The CVSS vector string is a text representation of a set of CVSS metrics. It is commonly used to record or transfer CVSS metric information in a concise form.",
       "type": "string_t"
     },
-    "vendor": {
-      "caption": "Vendor",
-      "description": "The vendor that pertains to the object. See specific usage.",
+    "vendor_name": {
+      "caption": "Vendor name",
+      "description": "The name of the vendor. See specific usage.",
       "type": "string_t"
     },
     "version": {

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -29,10 +29,6 @@
       "group": "primary",
       "requirement": "optional"
     },
-    "product": {
-      "group": "context",
-      "requirement": "recommended"
-    },
     "ref_event_code": {
       "group": "context"
     },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -16,6 +16,7 @@
       "description": "The time when the event was last modified or enriched."
     },
     "processed_time": {},
+    "product":{},
     "sequence": {},
     "version": {
       "default": "1.0.0",

--- a/objects/peripheral_device.json
+++ b/objects/peripheral_device.json
@@ -23,7 +23,7 @@
       "description": "The unique identifier of the peripheral device.",
       "requirement": "recommended"
     },
-    "vendor": {
+    "vendor_name": {
       "description": "The peripheral device vendor.",
       "requirement": "recommended"
     }

--- a/objects/product.json
+++ b/objects/product.json
@@ -4,6 +4,7 @@
   "description": "The product object describes a software product.",
   "extends": "object",
   "attributes": {
+    "feature":{},
     "lang": {
       "requirement": "recommended"
     },

--- a/objects/product.json
+++ b/objects/product.json
@@ -4,7 +4,6 @@
   "description": "The product object describes a software product.",
   "extends": "object",
   "attributes": {
-    "feature": {},
     "lang": {
       "requirement": "recommended"
     },
@@ -21,6 +20,11 @@
       "caption": "Product ID",
       "description": "The unique identifier of the product.",
       "requirement": "recommended"
+    },
+    "vendor_name": {
+      "caption": "Vendor Name",
+      "description": "The name of the vendor of the product.",
+      "requirement": "required"
     },
     "version": {
       "caption": "Product Version",

--- a/objects/vulernability.json
+++ b/objects/vulernability.json
@@ -34,7 +34,7 @@
       "description": "The vulnerability unique identifier.",
       "requirement": "required"
     },
-    "vendor": {
+    "vendor_name": {
       "description": "The vendor who identified the vulnerability.",
       "requirement": "optional"
     }


### PR DESCRIPTION
PR to implement results of the following proposals - 

1. https://github.com/ocsf/ocsf-schema/discussions/190
2. https://github.com/ocsf/ocsf-schema/discussions/191
3. https://github.com/ocsf/ocsf-schema/discussions/192

Changelog:
1. Moving `product` under `metadata` from base_event
2. Renaming `vendor` to `vendor_name` >> correcting consequent side-effects in vulnerability and peripheral_device objects.
3. Adding `vendor_name` to product
4. Removing `feature` from product, leaving the rest as is, as the attributes represent the robust proposal
----
![Screen Shot 2022-09-19 at 1 52 53 PM](https://user-images.githubusercontent.com/89877409/191081841-2be4981f-3457-4434-9062-2bbcda177794.png)
![Screen Shot 2022-09-19 at 1 52 44 PM](https://user-images.githubusercontent.com/89877409/191081909-73942c2b-41c9-48aa-a9ca-218406b3484a.png)

