### PR TITLE
Rectifying duplication of `uid` field

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -13,11 +13,6 @@
       "description": "The normalized event occurrence time.",
       "type": "timestamp_t"
     },
-    "uid": {
-      "caption": "Event UID",
-      "description": "The logging system-assigned unique identifier of an event instance.",
-      "type": "string_t"
-    },
     "access_complexity_id": {
       "caption": "Access Complexity (AC)",
       "description": "The Access Complexity Common Vulnerability Scoring System (CVSS) metric.",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -5,6 +5,7 @@
   "extends": "object",
   "attributes": {
     "uid": {
+      "caption": "Event UID",
       "description": "The logging system-assigned unique identifier of an event instance.",
       "requirement": "optional"
     },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -5,6 +5,7 @@
   "extends": "object",
   "attributes": {
     "uid": {
+      "description": "The logging system-assigned unique identifier of an event instance.",
       "requirement": "optional"
     },
     "correlation_uid": {},


### PR DESCRIPTION
Noticed `uid` was defined twice in the dictionary, de-duping. Adding specific definition in the `metadata` object



