### PR TITLE
Update `security_finding` class to extend `findings`

### DIFF
--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -1,7 +1,7 @@
 {
   "category": "findings",
   "description": "Security Finding events describe findings, detections, anomalies, alerts and/or actions performed by security products",
-  "extends": "base_event",
+  "extends": "findings",
   "caption": "Security Finding",
   "name": "security_finding",
   "profiles": [


### PR DESCRIPTION
- Currently `security_finding` was extending base event instead of expected `findings` class.
- This will add the malware profile to the class as it's included in the `findings` class. 

Signed-off-by: Johan Cornelissen <johan1252@gmail.com>