### PR TITLE
Fix typo in the date/time profile description

### DIFF
--- a/profiles/datetime.json
+++ b/profiles/datetime.json
@@ -1,5 +1,5 @@
 {
-  "description": "Thi profiles defines date/time attributes as defined in RFC-3339. For example 1985-04-12T23:20:50.52Z.",
+  "description": "This profile defines date/time attributes as defined in RFC-3339. For example 1985-04-12T23:20:50.52Z.",
   "meta": "profile",
   "caption": "Date/Time",
   "name": "datetime",


### PR DESCRIPTION
Signed-off-by: Roumen Roupski <rroupski@splunk.com>