### PR TITLE
Move K8s object from AWS extension to core

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1715,6 +1715,11 @@
       "description": "The keyboard type (e.g., xt, ico).",
       "type": "string_t"
     },
+    "kubernetes": {
+      "caption": "kubernetes",
+      "description": "Kubernetes object describes details related to a K8s entity",
+      "type": "kubernetes"
+    },
     "labels": {
       "caption": "Labels",
       "description": "The list of labels attached to an event, object, or attribute.",
@@ -1987,6 +1992,16 @@
       "description": "The next run time. See specific usage.",
       "type": "timestamp_t"
     },
+    "node_ip": {
+      "caption": "Node IP",
+      "description": "The IP of the Node inside the Kubernetes cluster",
+      "type": "string_t"
+    },
+    "node_name": {
+      "caption": "Node Name",
+      "description": "The Name of the Node inside the Kubernetes cluster",
+      "type": "string_t"
+    },
     "observables": {
       "caption": "Observables",
       "description": "The observables associated with the event.",
@@ -2157,6 +2172,26 @@
       "caption": "Pixel Bits",
       "description": "The number of bits per pixel.",
       "type": "integer_t"
+    },
+    "pod_ip": {
+      "caption": "Pod IP",
+      "description": "The IP of the pod inside the Kubernetes cluster",
+      "type": "string_t"
+    },
+    "pod_name": {
+      "caption": "Pod Name",
+      "description": "The name of the pod inside the Kubernetes cluster",
+      "type": "string_t"
+    },
+    "pod_namespace": {
+      "caption": "Pod Name",
+      "description": "The Namespace where the pod is located inside the Kubernetes cluster",
+      "type": "string_t"
+    },
+    "pod_uid": {
+      "caption": "Pod ID",
+      "description": "The unique ID of the pod inside the Kubernetes cluster",
+      "type": "string_t"
     },
     "policy": {
       "caption": "Policy",

--- a/dictionary.json
+++ b/dictionary.json
@@ -820,6 +820,16 @@
       "description": "The canonical cloud partition name to which the region is assigned (e.g. AWS Partitions: aws, aws-cn, aws-us-gov).",
       "type": "string_t"
     },
+    "cluster_name": {
+      "caption": "Cluster Name",
+      "description": "The name for the container cluster",
+      "type": "string_t"
+    },
+    "cluster_uid": {
+      "caption": "Cluster UID",
+      "description": "The unique identifer for the container cluster",
+      "type": "string_t"
+    },
     "cmd_line": {
       "caption": "Command Line",
       "description": "The full command line used to launch an application, service, process, or job. For example: <code>ssh user@10.0.0.10</code>. If the command line is unavailable or missing, the empty string <code>''</code> is to be used",
@@ -952,6 +962,11 @@
       "caption": "Container",
       "description": "The container information.",
       "type": "container"
+    },
+    "container_orchestration_runtime": {
+      "caption": "Container Orchestration Runtime Object",
+      "description": "The object to contain the information that describes the runtime environment of a container",
+      "type": "container_orchestration_runtime"
     },
     "content_type": {
       "caption": "HTTP Content Type",
@@ -1755,6 +1770,11 @@
       "caption": "Response Length",
       "description": "The HTTP response length, in number of bytes.",
       "type": "integer_t"
+    },
+    "level": {
+      "caption": "Level",
+      "description": "AuditLevel at which event was generated",
+      "type": "string_t"
     },
     "lineage": {
       "caption": "Lineage",
@@ -2909,6 +2929,16 @@
       "caption": "Source User",
       "description": "The existing user from which an activity was initiated.",
       "type": "user"
+    },
+    "stage": {
+      "caption": "Stage",
+      "description": "Stage or phase of an entity(e.g. Dev, Test, Stage, Prod et al)",
+      "type": "string_t"
+    },
+    "stage_timestamp": {
+      "caption": "Stage Timestamp",
+      "description": "Time the request reached current audit stage",
+      "type": "timestamp_t"
     },
     "start_address": {
       "caption": "Start Address",

--- a/objects/kubernetes.json
+++ b/objects/kubernetes.json
@@ -1,0 +1,79 @@
+{
+  "description": "Kubernetes Object encompasses various K8 specifc logs fields. is a (Kubernetes is a unique type of container orchestration).",
+  "caption": "kubernetes",
+  "name": "kubernetes",
+  "attributes": {
+    "container_orchestration_runtime": {
+      "description": "The Kubernetes Resources object details resources that were operated on in the request",
+      "requirement": "optional"
+    },
+    "http_request": {
+      "description": "The HTTP Request Object details a request made to a web server",
+      "requirement": "required"
+    },
+    "http_response": {
+      "description": "The HTTP Response Object details a response from a web server to a requester",
+      "requirement": "required"
+    },
+    "level": {
+      "description": "AuditLevel at which event was generated",
+      "requirement": "required"
+    },
+    "operation": {
+      "description": "Kubernetes verb/operation associated with the request",
+      "requirement": "required"
+    },
+    "request": {
+      "description": "Embedded Kubernetes API JSON dict from the request",
+      "requirement": "optional"
+    },
+    "response": {
+      "description": "Embedded Kubernetes API JSON dict from the response",
+      "requirement": "optional"
+    },
+    "stage": {
+      "description": "Stage of the request handling when this event instance was generated.",
+      "requirement": "required"
+    },
+    "stage_timestamp": {
+      "description": "Time the request reached current audit stage",
+      "requirement": "required"
+    },
+    "pod_name": {
+      "description": "The name of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_uid": {
+      "description": "The ID of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_ip": {
+      "description": "The IP of the pod inside the Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "pod_namespace": {
+      "description": "The Namespace where the pod is located inside the Kubernetes cluster",
+      "requirement": ""
+    },
+    "container": {
+      "description": "The Container object inside the pod in a Kubernetes cluster",
+      "requirement": "optional"
+    },
+    "cluster_uid": {
+      "description": "The ID of the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "cluster_name": {
+      "description": "The Name of the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "node_name": {
+      "description": "The Name of the Node inside the Kubernetes cluster",
+      "requirement": "recommended"
+    },
+    "node_ip": {
+      "description": "The IP of the Node inside the Kubernetes cluster",
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
Moving the K8s object from the AWS extension to the core schema. 

As discussed here: https://opencybersecu-lz97379.slack.com/archives/C03C2QJRA73/p1664470650464869

Updated dictionary.json with the required attributes.