### PR TITLE
Change process run_as attribute to user

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3112,11 +3112,6 @@
       "description": "The request header that identifies the operating system and web browser.",
       "type": "string_t"
     },
-    "user_context": {
-      "description": "The user context under which the process is running.",
-      "caption": "Process user context",
-      "type": "user"
-    },
     "user_interaction_id": {
       "caption": "User Interaction",
       "description": "The requirement for a user, other than the attacker, to participate in the successful compromise of the vulnerable component.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2587,11 +2587,6 @@
       "description": "The rules that reported the events.",
       "type": "rule"
     },
-    "run_as": {
-      "caption": "Run-As User",
-      "description": "The user account the process is running as, for when a user is impersonating another user.",
-      "type": "user"
-    },
     "run_state": {
       "caption": "Run State",
       "description": "The state of the job or service, as defined by the event source. See specific usage.",
@@ -3116,6 +3111,11 @@
       "caption": "HTTP User-Agent",
       "description": "The request header that identifies the operating system and web browser.",
       "type": "string_t"
+    },
+    "user_context": {
+      "description": "The user context under which the process is running.",
+      "caption": "Process user context",
+      "type": "user"
     },
     "user_interaction_id": {
       "caption": "User Interaction",

--- a/objects/process.json
+++ b/objects/process.json
@@ -84,8 +84,9 @@
       "caption": "Process UID",
       "requirement": "recommended"
     },
-    "user_context": {
+    "user": {
       "description": "The user context under which this process is running.",
+      "caption": "Process user context",
       "requirement": "recommended"
     },
     "xattributes": {

--- a/objects/process.json
+++ b/objects/process.json
@@ -69,9 +69,6 @@
     "pid": {
       "requirement": "required"
     },
-    "run_as": {
-      "requirement": "optional"
-    },
     "sandbox": {
       "requirement": "optional"
     },
@@ -85,6 +82,10 @@
     "uid": {
       "description": "The process unique identifier, as reported by the event source, such as a UUID. Allows correlation of a process event with other events for that process.",
       "caption": "Process UID",
+      "requirement": "recommended"
+    },
+    "user_context": {
+      "description": "The user context under which this process is running.",
       "requirement": "recommended"
     },
     "xattributes": {


### PR DESCRIPTION
As per https://github.com/ocsf/ocsf-schema/discussions/238 the goal of this PR is to disambiguate the use of the user context in the process object. Based on the feedback on that discussion the field name has been changed, made recommended, and the description updated. 

Note that the `user` profile has not been updated as proposed, after looking at the description of the `user` profile there probably does not need to be any additional clarity around that being the `session` user rather than the user context of the process.