### PR TITLE
Downgrade requirement for cmd_line from Required to Recommended

### DIFF
--- a/objects/process.json
+++ b/objects/process.json
@@ -6,7 +6,7 @@
   "extends": "object",
   "attributes": {
     "cmd_line": {
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "created_time": {
       "description": "The time when the process was created/started.",


### PR DESCRIPTION
Downgrade requirement for `cmd_line` attribute in the `process` object from `Required` to `Recommended`

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/91983279/196801991-226d01cf-1ecd-498d-bba1-75440bbd8091.png">

Signed-off-by: Mike Radka (Splunk) <mradka@splunk.com>