### PR TITLE
Add an optional data attribute to the base event

### DIFF
--- a/events/base_event.json
+++ b/events/base_event.json
@@ -1,9 +1,10 @@
 {
   "caption": "Base Event",
-  "name": "base_event",
   "description": "The base event is a generic concrete event and it also defines a set of attributes available in most event classes. As a generic event that does not belong to any event category, it could be used to log events that are not otherwise defined by the schema.",
+  "name": "base_event",
   "profiles": [
-    "cloud", "datetime"
+    "cloud",
+    "datetime"
   ],
   "attributes": {
     "$include": [
@@ -12,8 +13,9 @@
       "profiles/datetime.json",
       "profiles/cloud.json"
     ],
-    "raw_data": {
-      "group": "context"
+    "data": {
+      "description": "Additional data that is associated with the event.",
+      "requirement": "optional"
     },
     "enrichments": {
       "group": "context"
@@ -29,6 +31,9 @@
     "observables": {
       "group": "primary",
       "requirement": "optional"
+    },
+    "raw_data": {
+      "group": "context"
     },
     "ref_event_code": {
       "group": "context"

--- a/extensions/dev/events/incidents/incident_create.json
+++ b/extensions/dev/events/incidents/incident_create.json
@@ -25,7 +25,7 @@
       "requirement": "optional"
     },
     "data": {
-      "description": "The additional data that is associated with the incident",
+      "description": "The additional data that is associated with the incident.",
       "group": "primary",
       "requirement": "optional"
     },

--- a/extensions/dev/events/incidents/incident_update.json
+++ b/extensions/dev/events/incidents/incident_update.json
@@ -17,7 +17,7 @@
       "requirement": "optional"
     },
     "data": {
-      "description": "The additional data that is associated with the incident",
+      "description": "The additional data that is associated with the incident.",
       "group": "primary",
       "requirement": "optional"
     },

--- a/objects/registry_value.json
+++ b/objects/registry_value.json
@@ -1,12 +1,30 @@
 {
   "caption": "Registry Value",
-  "observable": 29,
-  "name": "registry_value",
   "description": "The registry value object describes a Windows registry value.",
   "extends": "object",
+  "name": "registry_value",
+  "observable": 29,
   "attributes": {
+    "data": {
+      "description": "The data of the registry value.",
+      "requirement": "optional"
+    },
+    "is_default": {
+      "requirement": "optional"
+    },
+    "is_system": {
+      "requirement": "optional"
+    },
+    "modified_time": {
+      "description": "The time when the registry value was last modified.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The name of the registry value.",
+      "requirement": "required"
+    },
+    "path": {
+      "description": "The full path to the registry key, where the value is located.",
       "requirement": "required"
     },
     "type": {
@@ -18,6 +36,9 @@
       "enum": {
         "1": {
           "caption": "REG_BINARY"
+        },
+        "10": {
+          "caption": "REG_SZ"
         },
         "2": {
           "caption": "REG_DWORD"
@@ -42,30 +63,9 @@
         },
         "9": {
           "caption": "REG_QWORD_LITTLE_ENDIAN"
-        },
-        "10": {
-          "caption": "REG_SZ"
         }
       },
       "requirement": "recommended"
-    },
-    "data": {
-      "description": "The data of the registry value.",
-      "requirement": "optional"
-    },
-    "is_default": {
-      "requirement": "optional"
-    },
-    "is_system": {
-      "requirement": "optional"
-    },
-    "modified_time": {
-      "description": "The time when the registry value was last modified.",
-      "requirement": "optional"
-    },
-    "path": {
-      "description": "The full path to the registry key, where the value is located.",
-      "requirement": "required"
     }
   }
 }


### PR DESCRIPTION
This is useful for cases when the evnt has additional information. For example script text or data packet.

Signed-off-by: Roumen Roupski <rroupski@splunk.com>