### PR TITLE
Add logged value to activity_id

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -108,8 +108,8 @@
           "description": "The event activity is unknown."
         },
         "1": {
-          "caption": "Mapped",
-          "description": "The event activity is mapped to the schema."
+          "caption": "Logged",
+          "description": "The event activity is logged."
         }
       },
       "sibling": "activity_name",

--- a/dictionary.json
+++ b/dictionary.json
@@ -106,6 +106,10 @@
         "0": {
           "caption": "Unknown",
           "description": "The event activity is unknown."
+        },
+        "1": {
+          "caption": "Mapped",
+          "description": "The event activity is mapped to the schema."
         }
       },
       "sibling": "activity_name",


### PR DESCRIPTION
This value will help indicate "logged" data. The data state has been captured and normalized. This generic value is for non-event, such as inventory stateful data, and doesn't fall under a typical activity as defined by activity_id. 

Signed-off-by: jason.reimer <jason.reimer@tanium.com>