### PR TITLE
Change inheritance order in Inventory

### DIFF
--- a/events/inventory/inventory_info.json
+++ b/events/inventory/inventory_info.json
@@ -5,7 +5,7 @@
   "name": "inventory_info",
   "uid": 1,
   "attributes": {
-    "hw_info": {
+    "device": {
       "group": "primary",
       "requirement": "recommended"
     }


### PR DESCRIPTION
The primary group should be Device for Inventory event class. The device hardware info object inherits from Device. Therefor having device as primary group allows usage of both device and device hardware info attributes.


Signed-off-by: jason.reimer <jason.reimer@tanium.com>