### PR TITLE
Add Process object to Memory Activity

### DIFF
--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -1,6 +1,6 @@
 {
   "caption": "Memory Activity",
-  "description": "Memory Activity events report when a process performs internal memory allocation, modification, or other manipulation activities - such as a buffer overflow or turning off data execution protection (DEP) - that are not typical for a process.",
+  "description": "Memory Activity events report when a process has memory allocated, read/modified, or other manipulation activities - such as a buffer overflow or turning off data execution protection (DEP).",
   "extends": "system",
   "name": "memory_activity",
   "uid": 4,
@@ -24,6 +24,11 @@
     "size": {
       "description": "The memory size that was access or requested.",
       "group": "primary"
+    },
+    "process": {
+      "description": "The process that had memory allocated, read/written, or had other manipulation activities performed on it.",
+      "group": "primary",
+      "requirement": "required"
     }
   }
 }


### PR DESCRIPTION
Adds Process to Memory Activity to track the process that had it's memory read, written to, manipulated, etc.

Also changed the Description to move it from Internal to both Internal and External activities

Signed-off-by: Christopher Schmitt <christopher.schmitt@crowdstrike.com>