### PR TITLE
Fix #306: Add the severity/score confidence level as determined by the event source

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -898,7 +898,7 @@
     },
     "confidence": {
       "caption": "Confidence",
-      "description": "The confidence of the reported finding as a percentage: 0%-100%.",
+      "description": "The confidence of the reported event severity as a percentage: 0%-100%.",
       "type": "integer_t"
     },
     "confidentiality": {

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -13,6 +13,10 @@
       "profiles/datetime.json",
       "profiles/cloud.json"
     ],
+    "confidence": {
+      "group": "classification",
+      "requirement": "optional"
+    },
     "data": {
       "description": "Additional data that is associated with the event.",
       "requirement": "optional"

--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -1,15 +1,18 @@
 {
+  "caption": "Security Finding",
   "category": "findings",
   "description": "Security Finding events describe findings, detections, anomalies, alerts and/or actions performed by security products",
   "extends": "findings",
-  "caption": "Security Finding",
   "name": "security_finding",
+  "profiles": [
+    "malware"
+  ],
   "uid": 1,
   "attributes": {
     "attacks": {
+      "description": "The attack object describes the technique and associated tactics as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",
       "group": "context",
-      "requirement": "optional",
-      "description": "The attack object describes the technique and associated tactics as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>."
+      "requirement": "optional"
     },
     "compliance": {
       "group": "context",
@@ -31,14 +34,12 @@
       "group": "primary",
       "requirement": "recommended"
     },
-    "state":{
+    "state": {
       "description": "The normalized state of a security finding.",
       "group": "context",
       "requirement": "optional"
     },
     "state_id": {
-      "group": "context",
-      "requirement": "required",
       "description": "The normalized state identifier of a security finding.",
       "enum": {
         "1": {
@@ -57,7 +58,9 @@
           "caption": "Resolved",
           "description": "The finding was reviewed and remediated and is now considered resolved."
         }
-      }
+      },
+      "group": "context",
+      "requirement": "required"
     },
     "vulnerabilities": {
       "group": "context",

--- a/objects/finding.json
+++ b/objects/finding.json
@@ -4,9 +4,6 @@
   "name": "finding",
   "extends": "object",
   "attributes": {
-    "confidence": {
-      "requirement": "optional"
-    },
     "created_time": {
       "description": "The time when the finding was created.",
       "requirement": "optional"


### PR DESCRIPTION
Move the confidence from the finding details object to the base event