### PR TITLE
Changing metrics from required to optional.

### DIFF
--- a/objects/cvss.json
+++ b/objects/cvss.json
@@ -13,7 +13,7 @@
     },
     "metrics": {
       "description": "The Common Vulnerability Scoring System metrics.This attribute contains information on the CVE's impact. If the CVE has been analyzed, this attribute will contain any CVSSv2 or CVSSv3 information associated with the vulnerability. For example: <code> {{\"Access Vector\", \"Network\"}, {\"Access Complexity\", \"Low\"}, ...}</code>.",
-      "requirement": "required"
+      "requirement": "optional"
     },
     "overall_score": {
       "description": "The CVSS overall score, impacted by base, temporal, and environmental metrics. For example: <code>9.1</code>.",


### PR DESCRIPTION
Changing metrics from required to optional. Most of the time logs would not contain cvss metrics associated with  a score.