### PR TITLE
Adding a software packages object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -161,6 +161,11 @@
       "description": "The name of the application that is associated with the event or object.",
       "type": "string_t"
     },
+    "architecture": {
+      "caption": "Architecture",
+      "description": "Architecture is a shorthand name describing the type of computer hardware the packaged software is meant to run on.",
+      "type": "string_t"
+    },
     "args": {
       "caption": "HTTP Arguments",
       "description": "The arguments sent along with the HTTP request.",
@@ -1254,6 +1259,11 @@
       "description": "The updated managed entity.",
       "type": "managed_entity"
     },
+    "epoch": {
+      "caption": "Epoch",
+      "description": "The software package epoch. Epoch is a way to define weighted dependencies based on version numbers.",
+      "type": "integer_t"
+    },
     "error": {
       "caption": "Error Code",
       "description": "Error Code",
@@ -2002,10 +2012,10 @@
       "type": "string_t"
     },
     "packages": {
-      "caption": "Related Packages",
+      "caption": "Software Packages",
       "description": "List of vulnerable packages as identified by the security product",
       "is_array": true,
-      "type": "string_t"
+      "type": "package"
     },
     "packet_uid": {
       "caption": "Packet UID",
@@ -2378,6 +2388,11 @@
       "caption": "Relay",
       "description": "The network relay that is associated with the event.",
       "type": "network_interface"
+    },
+    "release": {
+      "caption": "Software Release Details",
+      "description": "Release is the number of times a version of the software has been packaged.",
+      "type": "string_t"
     },
     "remediation": {
       "caption": "Remediation",

--- a/objects/package.json
+++ b/objects/package.json
@@ -1,0 +1,25 @@
+{
+  "caption": "Software Package",
+  "name": "package",
+  "description": "The package object describes details about a software package.",
+  "extends": "object",
+  "attributes": {
+    "architecture": {
+      "requirement": "recommended"
+    },
+    "epoch": {
+      "requirement": "optional"
+    },
+    "name": {
+      "description":"The software package name.",
+      "requirement": "required"
+    },
+    "release": {
+      "requirement": "optional"
+    },
+    "version": {
+      "description":"The software package version.",
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
Adding software packages object. To be used, not limited to, for representing details about a packages affected by vulnerabilities in a security finding event.

Signed-off-by: Rajas <rajaspa@amazon.com>
<img width="1228" alt="Screen Shot 2022-11-21 at 2 28 23 PM" src="https://user-images.githubusercontent.com/89877409/203142265-e2b9bf34-d606-49fa-9547-841bda0d1b96.png">
