### PR TITLE
Moves integrity sibling property to integrity_id

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1521,12 +1521,12 @@
     "integrity": {
       "caption": "Integrity",
       "description": "The process integrity level, as defined by the event source. (Windows only).",
-      "sibling": "integrity",
       "type": "string_t"
     },
     "integrity_id": {
       "caption": "Integrity Level",
       "description": "The normalized identifier of the process integrity level (Windows only).",
+      "sibling": "integrity",
       "enum": {},
       "type": "integer_t"
     },


### PR DESCRIPTION
* Moves the sibling property of the `integrity` field to the `integrity_id` property. I think this is correct as the `sibling` property lives alongside the `enum` property in other objects.