### PR TITLE
File Object username -> User objects

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -27,7 +27,7 @@
     "accessor": {
       "caption": "Accessor",
       "description": "The name of the user who last accessed the object.",
-      "type": "string_t"
+      "type": "user"
     },
     "account_type": {
       "caption": "Account Type",
@@ -973,7 +973,7 @@
     "creator": {
       "caption": "Creator",
       "description": "The user that created the object associated with event. See specific usage.",
-      "type": "string_t"
+      "type": "user"
     },
     "credential_uid": {
       "caption": "User Credential ID",
@@ -1882,7 +1882,7 @@
     "modifier": {
       "caption": "Modifier",
       "description": "The user that last modified the object associated with the event. See specific usage.",
-      "type": "string_t"
+      "type": "user"
     },
     "module": {
       "caption": "Module",
@@ -2019,7 +2019,7 @@
     "owner": {
       "caption": "Owner",
       "description": "The user that owns the file/object.",
-      "type": "string_t"
+      "type": "user"
     },
     "packages": {
       "caption": "Software Packages",


### PR DESCRIPTION
These were strings containing usernames but this makes it possible to store additional user metadata while making it more OCSF compliant

Closes #391

Signed-off-by: Christopher Schmitt <christopher.schmitt@crowdstrike.com>