### PR TITLE
Email: Remove Connection UID

### DIFF
--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -37,10 +37,6 @@
       "requirement": "optional",
       "group": "context"
     },
-    "connection_uid": {
-      "requirement": "optional",
-      "group": "context"
-    },
     "dkim_signature": {
       "requirement": "recommended",
       "group": "context"


### PR DESCRIPTION
removing the connection_uid attribute because it doesn’t make much sense for the email activity

Signed-off-by: Andy Blyler <ablyler@barracuda.com>