### PR TITLE
Email: Remove Duplicate Email UID

### DIFF
--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -58,10 +58,6 @@
       "requirement": "recommended",
       "group": "primary"
     },
-    "email_uid": {
-      "requirement": "recommended",
-      "group": "primary"
-    },
     "src_endpoint": {
       "description": "The initiator (client) sending the email.",
       "requirement": "optional",


### PR DESCRIPTION
The email class contains the email_uid attribute and it is also in the included email trait

Signed-off-by: Andy Blyler <ablyler@barracuda.com>