### PR TITLE
Set file.path to recommended

### DIFF
--- a/objects/file.json
+++ b/objects/file.json
@@ -69,7 +69,7 @@
     },
     "path": {
       "description": "The full path to the file. For example: <code>c:\\windows\\system32\\svchost.exe</code>.",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "product": {
       "description": "The product that created or installed the file.",


### PR DESCRIPTION
Improve visibility of important file-related field by setting to recommended instead of optional.