### PR TITLE
Adding device object in the resource object

### DIFF
--- a/objects/resource.json
+++ b/objects/resource.json
@@ -16,7 +16,11 @@
       "requirement": "optional"
     },
     "details": {
-      "description": "The details pertaining to the resource.",
+      "description": "Additional details describing the resource.",
+      "requirement": "optional"
+    },
+    "device":{
+      "description": "The device specific details, if the resource is a host/device.",
       "requirement": "optional"
     },
     "group_name": {


### PR DESCRIPTION
Adding `device` object in the `resources` object, to account for device/host specific details of a resource.

Signed-off-by: Rajas <rajaspa@amazon.com>
![Screen Shot 2023-01-06 at 3 26 52 PM](https://user-images.githubusercontent.com/89877409/211094036-393299d8-a25a-4742-9cff-f30556d33344.png)
