### PR TITLE
pii additions to dictionary

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -27,7 +27,8 @@
     "accessor": {
       "caption": "Accessor",
       "description": "The name of the user who last accessed the object.",
-      "type": "user"
+      "type": "user",
+      "pii": "yes"
     },
     "account_type": {
       "caption": "Account Type",
@@ -73,7 +74,8 @@
     "account_name": {
       "caption": "Account Name",
       "description": "The name of the account (e.g. AWS Account Name).",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "yes"
     },
     "activity_id": {
       "caption": "Activity ID",
@@ -99,7 +101,8 @@
     "actor": {
       "caption": "Actor",
       "description": "The actor that performed the operation or the action.",
-      "type": "actor"
+      "type": "actor",
+      "pii": "yes"
     },
     "actual_permissions": {
       "caption": "Actual Permissions",
@@ -108,7 +111,7 @@
     },
     "alert": {
       "caption": "Client TLS Alert",
-      "description": "The integer value of TLS alert if present. The alerts are defined in the TLS specification in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc2246'>RFC-2246</a>.",
+      "description": "The integer value of TLS alert if present. The alerts are defined in the TLS specification in <a target: '_blank' href: 'https://datatracker.ietf.org/doc/html/rfc2246'>RFC-2246</a>.",
       "type": "integer_t"
     },
     "algorithm": {
@@ -154,7 +157,8 @@
       "caption": "DNS Answer",
       "description": "The Domain Name System (DNS) answers.",
       "is_array": true,
-      "type": "dns_answer"
+      "type": "dns_answer",
+      "pii": "maybe"
     },
     "api": {
       "caption": "API details",
@@ -383,7 +387,8 @@
     "caption": {
       "caption": "Caption",
       "description": "A short description or caption of the device. For example: <code>Scanner 1</code> or <code>Database Manager</code>.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "categories": {
       "caption": "Website Categorization",
@@ -684,12 +689,14 @@
       "caption": "Cc",
       "description": "The email header Cc values, as defined by RFC 5322.",
       "is_array": true,
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "certificate": {
       "caption": "Certificate",
       "description": "The certificate object containing information about the digital certificate.",
-      "type": "certificate"
+      "type": "certificate",
+      "pii": "maybe"
     },
     "certificate_chain": {
       "caption": "Certificate Chain",
@@ -709,7 +716,7 @@
     },
     "chassis": {
       "caption": "Chassis",
-      "description": "The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows <a target='_blank' href='https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-systemenclosure'>Windows Chassis Types</a>",
+      "description": "The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows <a target: '_blank' href: 'https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-systemenclosure'>Windows Chassis Types</a>",
       "type": "string_t"
     },
     "cipher": {
@@ -725,7 +732,8 @@
     "city": {
       "caption": "City",
       "description": "The name of the city.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii":"maybe"
     },
     "class": {
       "caption": "Class",
@@ -746,7 +754,7 @@
     },
     "classification_ids": {
       "caption": "Classification IDs",
-      "description": "The list of normalzied identifiers of the malware classifications. Reference: <a target='_blank' href='https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_oxlc4df65spl'>STIX Malware Types</a> ",
+      "description": "The list of normalzied identifiers of the malware classifications. Reference: <a target: '_blank' href: 'https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_oxlc4df65spl'>STIX Malware Types</a> ",
       "enum": {},
       "is_array": true,
       "sibling": "classifications",
@@ -777,7 +785,7 @@
     },
     "cloud": {
       "caption": "Cloud",
-      "description": "Describes details about the Cloud enviroment where the event was originally created or logged.",
+      "description": "Describes details about the Cloud environment where the event was originally created or logged.",
       "type": "cloud"
     },
     "cloud_partition": {
@@ -788,7 +796,8 @@
     "cmd_line": {
       "caption": "Command Line",
       "description": "The full command line used to launch an application, service, process, or job. For example: <code>ssh user@10.0.0.10</code>. If the command line is unavailable or missing, the empty string <code>''</code> is to be used",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "code": {
       "caption": "Response Code",
@@ -835,7 +844,8 @@
     "comment": {
       "caption": "Comment",
       "description": "The user-provided comment.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "company_name": {
       "caption": "Company Name",
@@ -905,7 +915,7 @@
     },
     "content_type": {
       "caption": "HTTP Content Type",
-      "description": "The request header that identifies the original <a target='_blank' href='https://www.iana.org/assignments/media-types/media-types.xhtml'>media type </a> of the resource (prior to any content encoding applied for sending).",
+      "description": "The request header that identifies the original <a target: '_blank' href: 'https://www.iana.org/assignments/media-types/media-types.xhtml'>media type </a> of the resource (prior to any content encoding applied for sending).",
       "type": "string_t"
     },
     "continent": {
@@ -915,7 +925,7 @@
     },
     "coordinates": {
       "caption": "Coordinates",
-      "description": "A two-element array, containing a longitude/latitude pair. The format conforms with <a target='_blank' href='https://geojson.org'>GeoJSON</a>. For example: <code>[-73.983, 40.719]</code>.",
+      "description": "A two-element array, containing a longitude/latitude pair. The format conforms with <a target: '_blank' href: 'https://geojson.org'>GeoJSON</a>. For example: <code>[-73.983, 40.719]</code>.",
       "is_array": true,
       "type": "float_t"
     },
@@ -932,7 +942,7 @@
     },
     "country": {
       "caption": "Country",
-      "description": "The ISO 3166-1 Alpha-2 country code. For the complete list of country codes see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en' >ISO 3166-1 alpha-2 codes</a>.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
+      "description": "The ISO 3166-1 Alpha-2 country code. For the complete list of country codes see <a target: '_blank' href: 'https://www.iso.org/obp/ui/#iso:pub:PUB500001:en' >ISO 3166-1 alpha-2 codes</a>.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
       "type": "string_t"
     },
     "cpu_bits": {
@@ -973,7 +983,8 @@
     "creator": {
       "caption": "Creator",
       "description": "The user that created the object associated with event. See specific usage.",
-      "type": "user"
+      "type": "user",
+	  "pii": "yes"
     },
     "credential_uid": {
       "caption": "User Credential ID",
@@ -992,23 +1003,23 @@
     },
     "cve": {
       "caption": "CVE",
-      "description": "The Common Vulnerabilities and Exposures (<a target='_blank' href='https://cve.mitre.org/'>CVE</a>).",
+      "description": "The Common Vulnerabilities and Exposures (<a target: '_blank' href: 'https://cve.mitre.org/'>CVE</a>).",
       "type": "cve"
     },
     "cves": {
       "caption": "CVE List",
-      "description": "List of Common Vulnerabilities and Exposures (<a target='_blank' href='https://cve.mitre.org/'>CVE</a>).",
+      "description": "List of Common Vulnerabilities and Exposures (<a target: '_blank' href: 'https://cve.mitre.org/'>CVE</a>).",
       "is_array": true,
       "type": "cve"
     },
     "cvss": {
       "caption": "CVSS Score",
-      "description": "The CVSS object details Common Vulnerability Scoring System (<a target='_blank' href='https://www.first.org/cvss/'>CVSS</a>) scores from the advisory that are related to the vulnerability.",
+      "description": "The CVSS object details Common Vulnerability Scoring System (<a target: '_blank' href: 'https://www.first.org/cvss/'>CVSS</a>) scores from the advisory that are related to the vulnerability.",
       "type": "cvss"
     },
     "cwe_uid": {
       "caption": "CWE UID",
-      "description": "The <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> unique identifier. For example: <code>CWE-787</code>.",
+      "description": "The <a target: '_blank' href: 'https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> unique identifier. For example: <code>CWE-787</code>.",
       "type": "string_t"
     },
     "cwe_url": {
@@ -1039,7 +1050,8 @@
     "delivered_to": {
       "caption": "Delivered To",
       "description": "The <strong>Delivered-To</strong> email header field.",
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "depth": {
       "caption": "CVSS Depth",
@@ -1060,7 +1072,8 @@
     "desc": {
       "caption": "Description",
       "description": "The description that pertains to the object or event. See specific usage.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "desktop_display": {
       "caption": "Desktop Display",
@@ -1070,7 +1083,8 @@
     "details": {
       "caption": "Details",
       "description": "Details of an entity. See specific usage",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "detection_uid": {
       "caption": "Detection UID",
@@ -1085,13 +1099,15 @@
     "device": {
       "caption": "Device",
       "description": "The device that reported the event.",
-      "type": "device"
+      "type": "device",
+      "pii": "maybe"
     },
     "devices": {
       "caption": "Devices",
       "description": "The object describes details related to the list of devices.",
       "is_array": true,
-      "type": "device"
+      "type": "device",
+      "pii": "maybe"
     },
     "dialect": {
       "caption": "Dialect",
@@ -1211,7 +1227,8 @@
     "domain_info": {
       "caption": "Domain Information",
       "description": "The registration information pertaining to a domain.",
-      "type": "domain_info"
+      "type": "domain_info",
+      "pii": "maybe"
     },
     "driver": {
       "caption": "Kernel Driver",
@@ -1236,12 +1253,14 @@
     "email": {
       "caption": "Email",
       "description": "The email object.",
-      "type": "email"
+      "type": "email",
+      "pii": "maybe"
     },
     "email_addr": {
       "caption": "Email Address",
       "description": "The user's email address.",
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "end_time": {
       "caption": "End Time",
@@ -1252,12 +1271,14 @@
       "caption": "Enrichments",
       "description": "The additional information from an external data source, which is associated with the event. For example add location information for the IP address in the DNS answers:</p><code>[{\"name\": \"answers.ip\", \"value\": \"92.24.47.250\", \"type\": \"location\", \"data\": {\"city\": \"Socotra\", \"continent\": \"Asia\", \"coordinates\": [-25.4153, 17.0743], \"country\": \"YE\", \"desc\": \"Yemen\"}}]</code>",
       "is_array": true,
-      "type": "enrichment"
+      "type": "enrichment",
+      "pii": "maybe"
     },
     "entity": {
       "caption": "Entity",
       "description": "The managed entity that is being acted upon.",
-      "type": "managed_entity"
+      "type": "managed_entity",
+      "pii": "maybe"
     },
     "entity_result": {
       "caption": "Entity Result",
@@ -1308,7 +1329,8 @@
     "file": {
       "caption": "File",
       "description": "The file that pertains to the event or object. See specific usage.",
-      "type": "file"
+      "type": "file",
+      "pii": "maybe"
     },
     "file_diff": {
       "caption": "File Diff",
@@ -1318,7 +1340,8 @@
     "file_result": {
       "caption": "File Result",
       "description": "The result of the file change. It should contain the new values of the changed attributes.",
-      "type": "file"
+      "type": "file",
+	  "pii": "maybe"
     },
     "finding": {
       "caption": "Finding",
@@ -1358,7 +1381,8 @@
     "folder": {
       "caption": "Folder",
       "description": "The folder that pertains to the event.",
-      "type": "file"
+      "type": "file",
+      "pii": "maybe"
     },
     "frame_buffer": {
       "caption": "Frame Buffer",
@@ -1368,7 +1392,8 @@
     "from": {
       "caption": "From",
       "description": "The email header From values, as defined by RFC 5322.",
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "maybe"
     },
     "function_keys": {
       "caption": "Function Keys",
@@ -1409,7 +1434,8 @@
     "hostname": {
       "caption": "Hostname",
       "description": "The hostname of an endpoint or a device.",
-      "type": "hostname_t"
+      "type": "hostname_t",
+      "pii": "maybe"
     },
     "http_cookies": {
       "caption": "HTTP Cookies",
@@ -1445,7 +1471,7 @@
     },
     "http_status": {
       "caption": "HTTP Status",
-      "description": "The Hypertext Transfer Protocol (HTTP) <a target='_blank' href='https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
+      "description": "The Hypertext Transfer Protocol (HTTP) <a target: '_blank' href: 'https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
       "type": "integer_t"
     },
     "hw_info": {
@@ -1461,12 +1487,15 @@
     "identifier_cookie": {
       "caption": "Identifier Cookie",
       "description": "The client identifier cookie during client/server exchange.",
-      "type": "string_t"
+      "type": "string_t",
+	  "pii": "maybe"
+	  
     },
     "identity": {
       "caption": "Identity",
       "description": "Identity Object details AuthN, AuthZ information pertaining to the event",
-      "type": "identity"
+      "type": "identity",
+      "pii": "yes"
     },
     "idp": {
       "caption": "Identity Provider",
@@ -1486,7 +1515,8 @@
     "imei": {
       "caption": "IMEI",
       "description": "The International Mobile Station Equipment Identifier that is associated with the device.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "injection_type": {
       "caption": "Injection Type",
@@ -1530,11 +1560,6 @@
       "enum": {},
       "type": "integer_t"
     },
-    "interface_name": {
-      "caption": "Network Interface Name",
-      "description": "The name of the network interface (e.g. eth2).",
-      "type": "string_t"
-    },
     "interface_uid": {
       "caption": "Network Interface ID",
       "description": "The unique identifier of the network interface.",
@@ -1544,7 +1569,8 @@
       "caption": "Intermediate IP Addresses",
       "description": "The intermediate IP Addresses. For example, the IP addresses in the HTTP X-Forwarded-For header.",
       "is_array": true,
-      "type": "ip_t"
+      "type": "ip_t",
+      "pii": "maybe"
     },
     "invoked_by": {
       "caption": "Invoked by",
@@ -1554,7 +1580,8 @@
     "ip": {
       "caption": "IP Address",
       "description": "The IP address, in either IPv4 or IPv6 format.",
-      "type": "ip_t"
+      "type": "ip_t",
+      "pii": "maybe"
     },
     "is_cleartext": {
       "caption": "Cleartext Credentials",
@@ -1670,7 +1697,8 @@
     "keyboard_info": {
       "caption": "Keyboard Information",
       "description": "The keyboard detailed information.",
-      "type": "keyboard_info"
+      "type": "keyboard_info",
+	  "pii": "maybe"
     },
     "keyboard_layout": {
       "caption": "Keyboard Layout",
@@ -1695,7 +1723,7 @@
     },
     "lang": {
       "caption": "Language",
-      "description": "The two letter lower case language codes, as defined by <a target='_blank' href='https://en.wikipedia.org/wiki/ISO_639-1'>ISO 639-1</a>. For example: <code>en</code> (English), <code>de</code> (German), or <code>fr</code> (French).",
+      "description": "The two letter lower case language codes, as defined by <a target: '_blank' href: 'https://en.wikipedia.org/wiki/ISO_639-1'>ISO 639-1</a>. For example: <code>en</code> (English), <code>de</code> (German), or <code>fr</code> (French).",
       "type": "string_t"
     },
     "last_run_time": {
@@ -1715,7 +1743,7 @@
     },
     "lease_dur": {
       "caption": "Lease Duration",
-      "description": "This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events. (activity_id = 1)",
+      "description": "This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events. (activity_id :  1)",
       "type": "integer_t"
     },
     "length": {
@@ -1731,7 +1759,7 @@
     },
     "license": {
       "caption": "Software License",
-      "description": "The name or identifier of the license applied on package or software. See <a target='_blank' href='https://spdx.org/licenses/'>SPDX License List</a>.",
+      "description": "The name or identifier of the license applied on package or software. See <a target: '_blank' href: 'https://spdx.org/licenses/'>SPDX License List</a>.",
       "type": "string_t"
     },
     "load_type": {
@@ -1755,7 +1783,8 @@
     "location": {
       "caption": "Detailed Geo Location",
       "description": "The detailed geographical location usually associated with an IP address.",
-      "type": "location"
+      "type": "location",
+	  "pii": "yes"
     },
     "logged_time": {
       "caption": "Logged Time",
@@ -1835,7 +1864,8 @@
     "mac": {
       "caption": "MAC Address",
       "description": "The Media Access Control (MAC) address that is associated with the network interface.",
-      "type": "mac_t"
+      "type": "mac_t",
+      "pii": "maybe"
     },
     "malware": {
       "caption": "Malware",
@@ -1846,7 +1876,8 @@
     "message": {
       "caption": "Message",
       "description": "The description of the event, as defined by the event source.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "message_uid": {
       "caption": "Message UID",
@@ -1856,7 +1887,8 @@
     "metadata": {
       "caption": "Metadata",
       "description": "The metadata associated with the event.",
-      "type": "metadata"
+      "type": "metadata",
+	  "pii": "maybe"
     },
     "metrics": {
       "caption": "Metrics",
@@ -1887,7 +1919,8 @@
     "modifier": {
       "caption": "Modifier",
       "description": "The user that last modified the object associated with the event. See specific usage.",
-      "type": "user"
+      "type": "user",
+      "pii": "yes"
     },
     "module": {
       "caption": "Module",
@@ -1897,7 +1930,8 @@
     "name": {
       "caption": "Name",
       "description": "The name of the entity. See specific usage.",
-      "type": "string_t"
+      "type": "string_t",
+	  "pii": "yes"
     },
     "namespace": {
       "caption": "Namespace",
@@ -1918,7 +1952,8 @@
       "caption": "Network Interfaces",
       "description": "The network interfaces that are associated with the device, one for each MAC address/IP address combination.<p><b>Note:</b> The first element of the array is the network information that pertains to the event.</p>",
       "is_array": true,
-      "type": "network_interface"
+      "type": "network_interface",
+	  "pii": "maybe"
     },
     "next_run_time": {
       "caption": "Next Run",
@@ -1929,7 +1964,8 @@
       "caption": "Observables",
       "description": "The observables associated with the event.",
       "is_array": true,
-      "type": "observable"
+      "type": "observable",
+      "pii": "maybe"
     },
     "opcode": {
       "caption": "DNS Opcode",
@@ -1999,12 +2035,14 @@
     "org_uid": {
       "caption": "Org ID",
       "description": "The unique identifier of the organization to which the user belongs. For example, Active Directory or AWS Org ID.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "org_unit": {
       "caption": "Org Unit",
       "description": "The name of the organization to which the user belongs.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "original_time": {
       "caption": "Original Time",
@@ -2013,7 +2051,7 @@
     },
     "os": {
       "caption": "OS",
-      "description": "The device operation system.",
+      "description": "The device operating system.",
       "type": "os"
     },
     "overall_score": {
@@ -2024,7 +2062,8 @@
     "owner": {
       "caption": "Owner",
       "description": "The user that owns the file/object.",
-      "type": "user"
+      "type": "user",
+      "pii": "yes"
     },
     "packages": {
       "caption": "Software Packages",
@@ -2058,7 +2097,8 @@
     "parent_folder": {
       "caption": "Parent Folder",
       "description": "The parent folder in which the file resides. For example: <code>c:\\windows\\system32</code>",
-      "type": "path_t"
+      "type": "path_t",
+      "pii": "maybe"
     },
     "parent_process": {
       "caption": "Parent Process",
@@ -2068,7 +2108,8 @@
     "path": {
       "caption": "Path",
       "description": "The path that pertains to the event or object. See specific usage.",
-      "type": "path_t"
+      "type": "path_t",
+      "pii": "maybe"
     },
     "peripheral_device": {
       "caption": "Peripheral Device",
@@ -2118,7 +2159,8 @@
     "postal_code": {
       "caption": "Postal Code",
       "description": "The postal code of the location.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "prefix": {
       "caption": "Prefix",
@@ -2176,12 +2218,12 @@
     },
     "protocol_name": {
       "caption": "Protocol Name",
-      "description": "The TCP/IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). See <a target='_blank' href='https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. For example: <code>tcp</code> or <code>udp</code>.",
+      "description": "The TCP/IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). See <a target: '_blank' href: 'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. For example: <code>tcp</code> or <code>udp</code>.",
       "type": "string_t"
     },
     "protocol_num": {
       "caption": "Protocol Number",
-      "description": "The TCP/IP protocol number, as defined by the Internet Assigned Numbers Authority (IANA). Use -1 if the protocol is not defined by IANA. See <a target='_blank' href='https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. For example: <code>6</code> for TCP and <code>17</code> for UDP.",
+      "description": "The TCP/IP protocol number, as defined by the Internet Assigned Numbers Authority (IANA). Use -1 if the protocol is not defined by IANA. See <a target: '_blank' href: 'https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml'>Protocol Numbers</a>. For example: <code>6</code> for TCP and <code>17</code> for UDP.",
       "type": "integer_t"
     },
     "protocol_ver": {
@@ -2213,7 +2255,7 @@
     },
     "query_string": {
       "caption": "HTTP Query String",
-      "description": "The query portion of the URL. For example: the query portion of the URL <code>http://www.example.com/search?q=bad&sort=date</code> is <code>q=bad&sort=date</code>.",
+      "description": "The query portion of the URL. For example: the query portion of the URL <code>http://www.example.com/search?q: bad&sort: date</code> is <code>q: bad&sort: date</code>.",
       "type": "string_t"
     },
     "query_time": {
@@ -2229,7 +2271,8 @@
     "raw_data": {
       "caption": "Raw Data",
       "description": "The event data as received from the event source.",
-      "type": "string_t"
+      "type": "string_t",
+	  "pii": "maybe"
     },
     "rcode": {
       "caption": "Response Code",
@@ -2238,7 +2281,7 @@
     },
     "rcode_id": {
       "caption": "Response Code ID",
-      "description": "The normalized identifier of the DNS server response code. See <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc6895'>RFC-6895</a>.",
+      "description": "The normalized identifier of the DNS server response code. See <a target: '_blank' href: 'https://datatracker.ietf.org/doc/html/rfc6895'>RFC-6895</a>.",
       "enum": {
         "-1": {
           "caption": "Other",
@@ -2422,7 +2465,8 @@
     "reply_to": {
       "caption": "Reply To",
       "description": "The email header Reply-To values, as defined by RFC 5322.",
-      "type": "email_t"
+      "type": "email_t",
+	  "pii": "yes"
     },
     "reputation": {
       "caption": "Reputation Scores",
@@ -2657,11 +2701,12 @@
     "session": {
       "caption": "Session",
       "description": "The session information.",
-      "type": "session"
+      "type": "session",
+      "pii": "maybe"
     },
     "session_uid": {
       "caption": "Session UID",
-      "description": "The unique ID of the user session, as reported by the OS.<br /><br /><u>Examples:</u> <ul><li><i><b>*nix: </b><i>Aug 10 17:31:16 ip-192-168-1-1 systemd[1]: Started Session 222 of User ubuntu.</li><ul><li><b>session_uid</b> == 222</li></ul><li><b>Windows:</b> Logon ID:       0xd22e9734</li><ul><li><b>session_uid</b> == 0xd22e9734</li></ul></ul>",
+      "description": "The unique ID of the user session, as reported by the OS.<br /><br /><u>Examples:</u> <ul><li><i><b>*nix: </b><i>Aug 10 17:31:16 ip-192-168-1-1 systemd[1]: Started Session 222 of User ubuntu.</li><ul><li><b>session_uid</b> : :  222</li></ul><li><b>Windows:</b> Logon ID:       0xd22e9734</li><ul><li><b>session_uid</b> : :  0xd22e9734</li></ul></ul>",
       "type": "string_t"
     },
     "session_uuid": {
@@ -2737,7 +2782,8 @@
     "smtp_from": {
       "caption": "SMTP From",
       "description": "The value of the SMTP MAIL FROM command.",
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "smtp_hello": {
       "caption": "SMTP Hello",
@@ -2748,7 +2794,8 @@
       "caption": "SMTP To",
       "description": "The value of the SMTP envelope RCPT TO command.",
       "is_array": true,
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "sni": {
       "caption": "Server Name Indication",
@@ -2768,12 +2815,14 @@
     "src_endpoint": {
       "caption": "Source Endpoint",
       "description": "The network source endpoint.",
-      "type": "network_endpoint"
+      "type": "network_endpoint",
+      "pii": "maybe"
     },
     "src_url": {
       "caption": "Source URL",
       "description": "The URL pointing towards the source of an entity. See specific usage.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "start_address": {
       "caption": "Start Address",
@@ -2879,14 +2928,15 @@
     },
     "tactics": {
       "caption": "Tactics",
-      "description": "The a list of tactic ID's/names that are associated with the attack technique, as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",
+      "description": "The a list of tactic ID's/names that are associated with the attack technique, as defined by <a target: '_blank' href: 'https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",
       "is_array": true,
       "type": "tactic"
     },
     "tag": {
       "caption": "Image Tag",
       "description": "The image tag. For example: <code>1.11-alpine</code>.",
-      "type": "string_t"
+      "type": "string_t",
+	  "pii": "maybe"
     },
     "tcp_flags": {
       "caption": "TCP Flags",
@@ -2906,7 +2956,8 @@
     "text": {
       "caption": "URL Text",
       "description": "The URL. For example: <code>http://www.example.com/download/trouble.exe</code>.",
-      "type": "url_t"
+      "type": "url_t",
+      "pii": "maybe"
     },
     "tid": {
       "caption": "Thread ID",
@@ -2926,7 +2977,8 @@
     "title": {
       "caption": "Title",
       "description": "The title of an entity. See specific usage.",
-      "type": "string_t"
+      "type": "string_t",
+      "pii": "maybe"
     },
     "tls": {
       "caption": "TLS",
@@ -2937,7 +2989,8 @@
       "caption": "To",
       "description": "The email header To values, as defined by RFC 5322.",
       "is_array": true,
-      "type": "email_t"
+      "type": "email_t",
+      "pii": "yes"
     },
     "traffic": {
       "caption": "Traffic",
@@ -3016,12 +3069,14 @@
     "url": {
       "caption": "URL",
       "description": "The URL object that pertains to the event or object. See specific usage.",
-      "type": "url"
+      "type": "url",
+      "pii": "maybe"
     },
     "user": {
       "caption": "User",
       "description": "The user that pertains to the event or object.",
-      "type": "user"
+      "type": "user",
+      "pii": "yes"
     },
     "user_agent": {
       "caption": "HTTP User-Agent",
@@ -3031,7 +3086,8 @@
     "user_result": {
       "caption": "User Result",
       "description": "The result of the user account change. It should contain the new values of the changed attributes.",
-      "type": "user"
+      "type": "user",
+      "pii": "yes"
     },
     "uuid": {
       "caption": "UUID",
@@ -3066,7 +3122,8 @@
     "vnc_auth": {
       "caption": "VNC Authentication",
       "description": "The Virtual Network Computing (VNC) authentication object describes the VNC authentication values.",
-      "type": "vnc_auth"
+      "type": "vnc_auth",
+      "pii": "maybe"
     },
     "vpc_uid": {
       "caption": "VPC UID",
@@ -3125,7 +3182,8 @@
         "observable": 5,
         "regex": "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "yes"
       },
       "file_hash_t": {
         "caption": "File Hash",
@@ -3140,7 +3198,8 @@
         "observable": 7,
         "regex": "^[a-zA-Z0-9._ -]+$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "maybe"
       },
       "float_t": {
         "caption": "Float",
@@ -3152,7 +3211,8 @@
         "observable": 1,
         "regex": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "maybe"
       },
       "integer_t": {
         "caption": "Integer",
@@ -3165,11 +3225,12 @@
         "observable": 2,
         "regex": "/^(?>(?>([a-f0-9]{1,4})(?>:(?1)){7}|(?!(?:.*[a-f0-9](?>:|$)){8,})((?1)(?>:(?1)){0,6})?::(?2)?)|(?>(?>(?1)(?>:(?1)){5}:|(?!(?:.*[a-f0-9]:){6,})(?3)?::(?>((?1)(?>:(?1)){0,4}):)?)?(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])(?>\\.(?4)){3}))$/iD",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+		"pii": "maybe"
       },
       "json_t": {
         "caption": "JSON",
-        "description": "Embedded JSON value. A value can be a string, or a number, or true or false or null, or an object or an array. These structures can be nested. See <a target='_blank' href='https://www.json.org'>www.json.org</a>."
+        "description": "Embedded JSON value. A value can be a string, or a number, or true or false or null, or an object or an array. These structures can be nested. See <a target: '_blank' href: 'https://www.json.org'>www.json.org</a>."
       },
       "long_t": {
         "caption": "Long",
@@ -3182,18 +3243,21 @@
         "observable": 3,
         "regex": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "maybe"
       },
       "object_t": {
         "caption": "Object",
-        "description": "Object is an unordered set of name/value pairs. For example: <code>{ip: 92.24.47.250, type: IP Address}</code>"
+        "description": "Object is an unordered set of name/value pairs. For example: <code>{ip: 92.24.47.250, type: IP Address}</code>",
+		"pii": "maybe"
       },
       "path_t": {
         "caption": "Path Name",
         "description": "File or folder full path name. For example: <code>/home/user/tmp/text-file.txt</code>.",
         "regex": "^[\\pL0-9_]+[\\pL0-9 ~!@#%&*\\-./_]*$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "maybe"
       },
       "port_t": {
         "caption": "Port",
@@ -3232,7 +3296,7 @@
       },
       "datetime_t": {
         "caption": "Datetime",
-        "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
+        "description": "The Internet Date/Time format as defined in <a target: '_blank' href: 'https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
         "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}%3A\\d{2}(?:.\\d+)?[A-Z]?(?:[.-](?:08:\\d{2}|\\d{2}[A-Z]))?$",
         "type": "string_t",
         "type_name": "String"
@@ -3248,14 +3312,16 @@
         "description": "Uniform Resource Locator (URL) string. For example: <code>http://www.example.com/download/trouble.exe</code>.",
         "observable": 6,
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "maybe"
       },
       "username_t": {
         "caption": "User Name",
         "description": "User name. For example: <code>john_doe</code>.",
         "observable": 4,
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "pii": "yes"
       },
       "bytestring_t": {
         "caption": "Byte String",


### PR DESCRIPTION
OCSF PII Field Readme

Privacy is an important topic and it has various implications across regions, organizations, and other legal and regulatory domains. Our goal with providing an OCSF PII field is to identify which attributes in the schema will likely contain PII (Yes), possibly contain PII (Maybe), or are unlikely to contain PII (No).

The goal of the OCSF PII field is to provide a single place to manage PII identification in our cybersecurity data sets and to keep it updated as the schema evolves. The field is meant as a guideline; data treatment and de-identification procedures are not covered here. 

Our future plan is to provide additional guidance related to PII, such as value, and possible treatments for sensitive data fields.
