### PR TITLE
#425 add 'Open' enum to File System Activity activity_id

### DIFF
--- a/enums/file_activity.json
+++ b/enums/file_activity.json
@@ -38,6 +38,9 @@
     },
     "13": {
       "caption": "Unmount"
+    },
+    "14": {
+      "caption": "Open"
     }
   }
 }


### PR DESCRIPTION
Resolves Issue #425 

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/91983279/213519425-da26a813-763b-4829-ae60-e3695214bdee.png">


Signed-off-by: Mike Radka (Splunk) <mradka@splunk.com>