### PR TITLE
Update Audit category description

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -15,7 +15,7 @@
     },
     "audit": {
       "caption": "Audit Activity",
-      "description": "Audit events are any security-relevant activity in the system. A security-relevant activity can be a change to the security state of the system, an attempted or actual system access. Audit events can include, for example, password changes, user changes, failed logons, or failed accesses related to information systems, administrative privilege usage, or third-party credential usage.",
+      "description": "Audit events relate to the supervision of the system's access control model. Examples of such records are the success or failure of authentication, granting of authority, password change, entity change, privileged use, system state change, and resource access.",
       "uid": 3
     },
     "network": {

--- a/categories.json
+++ b/categories.json
@@ -15,7 +15,7 @@
     },
     "audit": {
       "caption": "Audit Activity",
-      "description": "Audit events relate to the supervision of the system's access control model. Examples of such records are the success or failure of authentication, granting of authority, password change, entity change, privileged use, system state change, and resource access.",
+      "description": "Audit events relate to the supervision of the system's access control model. Examples of such events are the success or failure of authentication, granting of authority, password change, entity change, privileged use, system state change, and resource access.",
       "uid": 3
     },
     "network": {


### PR DESCRIPTION
Following discussion in the weekly calls, an attempt is being made to update the description of the Audit category to more specifically reflect the types of records for which the category has been intended. Additional discussion on https://github.com/ocsf/ocsf-schema/discussions/423.

The goal of the update is to highlight that the Audit category should not be "any security-relevant activity in the system", but instead a place where supervisory events both _about_ the system and resource events _within_ the system can be logged in order to create an audit trail.