### PR TITLE
reorganize email fields

### DIFF
--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -30,16 +30,42 @@
       }
     },
     "attempt": {
-      "requirement": "recommended",
+      "requirement": "optional",
+      "description": "The attempt number for attempting to deliver the email.",
       "group": "context"
     },
     "banner": {
       "requirement": "optional",
       "group": "context"
     },
-    "dkim_signature": {
-      "requirement": "recommended",
-      "group": "context"
+    "direction": {
+      "description": "The direction of the email, as defined by the <code>direction_id</code> value.",
+      "requirement": "optional"
+    },
+    "direction_id": {
+      "description": "The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The email direction is unknown."
+        },
+        "1": {
+          "caption": "Inbound",
+          "description": "Email Inbound, from the Internet or outside network destined for an entity inside network."
+        },
+        "2": {
+          "caption": "Outbound",
+          "description": "Email Outbound, from inside the network destined for an entity outside network."
+        },
+        "3": {
+          "caption": "Internal",
+          "description": "Email Internal, from inside the network destined for an entity inside network."
+        },
+        "99": {
+          "caption": "Other"
+        }
+      },
+      "requirement": "required"
     },
     "dst_endpoint": {
       "description": "The responder (server) receiving the email.",
@@ -58,6 +84,10 @@
       "description": "The initiator (client) sending the email.",
       "requirement": "optional",
       "group": "primary"
+    },
+    "src_smtp_hello": {
+      "description": "The initiator (client) SMTP hello banner.",
+      "requirement": "recommended"
     }
   }
 }

--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -16,6 +16,7 @@
       "profiles/security_control.json"
     ],
     "activity_id": {
+      "requirement": "optional",
       "enum": {
         "1": {
           "caption": "Send"
@@ -27,7 +28,8 @@
           "caption": "Scan",
           "description": "Email being scanned (example: security scanning)"
         }
-      }
+      },
+      "group": "context"
     },
     "attempt": {
       "requirement": "optional",
@@ -40,6 +42,7 @@
     },
     "direction": {
       "description": "The direction of the email, as defined by the <code>direction_id</code> value.",
+      "group": "context",
       "requirement": "optional"
     },
     "direction_id": {
@@ -65,6 +68,7 @@
           "caption": "Other"
         }
       },
+      "group": "context",
       "requirement": "required"
     },
     "dst_endpoint": {
@@ -88,6 +92,7 @@
     "src_smtp_hello": {
       "description": "The initiator (client) SMTP hello banner.",
       "requirement": "recommended"
+      "group": "primary"
     }
   }
 }

--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -89,9 +89,9 @@
       "requirement": "optional",
       "group": "primary"
     },
-    "src_smtp_hello": {
-      "description": "The initiator (client) SMTP hello banner.",
-      "requirement": "recommended"
+    "smtp_hello": {
+      "description": "The value of the SMTP HELO or EHLO command sent by the initiator (client).",
+      "requirement": "recommended",
       "group": "primary"
     }
   }

--- a/extensions/dev/events/network/email/email.json
+++ b/extensions/dev/events/network/email/email.json
@@ -46,7 +46,7 @@
       "requirement": "optional"
     },
     "direction_id": {
-      "description": "The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.",
+      "description": "<p>The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.",
       "enum": {
         "0": {
           "caption": "Unknown",

--- a/extensions/dev/objects/email_auth.json
+++ b/extensions/dev/objects/email_auth.json
@@ -9,6 +9,9 @@
     "dkim": {
       "requirement": "recommended"
     },
+    "dkim_signature": {
+      "requirement": "recommended"
+    },
     "dmarc": {
       "requirement": "recommended"
     },
@@ -16,9 +19,6 @@
       "requirement": "recommended"
     },
     "dmarc_policy": {
-      "requirement": "recommended"
-    },
-    "raw_header": {
       "requirement": "recommended"
     },
     "spf": {

--- a/objects/email.json
+++ b/objects/email.json
@@ -10,40 +10,14 @@
     "delivered_to": {
       "requirement": "optional"
     },
-    "direction": {
-      "description": "The direction of the email, as defined by the <code>direction_id</code> value.",
-      "requirement": "optional"
-    },
-    "direction_id": {
-      "description": "The direction of the email relative to the scanning host or organization.</p>Email scanned at an internet gateway might be characterized as inbound to the organization from the Internet, outbound from the organization to the Internet, or internal within the organization. Email scanned at a workstation might be characterized as inbound to, or outbound from the workstation.",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The email direction is unknown."
-        },
-        "1": {
-          "caption": "Inbound",
-          "description": "Email Inbound, from the Internet or outside network destined for an entity inside network."
-        },
-        "2": {
-          "caption": "Outbound",
-          "description": "Email Outbound, from inside the network destined for an entity outside network."
-        },
-        "3": {
-          "caption": "Internal",
-          "description": "Email Internal, from inside the network destined for an entity inside network."
-        },
-        "99": {
-          "caption": "Other"
-        }
-      },
-      "requirement": "required"
-    },
     "from": {
       "requirement": "required"
     },
     "message_uid": {
       "requirement": "recommended"
+    },
+    "raw_header": {
+      "requirement": "optional"
     },
     "reply_to": {
       "requirement": "recommended"
@@ -53,9 +27,6 @@
       "requirement": "recommended"
     },
     "smtp_from": {
-      "requirement": "recommended"
-    },
-    "smtp_hello": {
       "requirement": "recommended"
     },
     "smtp_to": {


### PR DESCRIPTION
- make attempt optional
- move direction, direction_id, and smtp_hello from email object to email activity class
- rename smtp_hello to src_smtp_hello to ensure it is clear it is the hello banner from the client that is sending the email to the server
- move dkim_signature from email activity class to email auth object
- move raw_header from email auth object to email object

Signed-off-by: Andy Blyler <ablyler@barracuda.com>