### PR TITLE
Removing redundant enum definition

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1129,20 +1129,24 @@
       "caption": "Direction ID",
       "description": "The normalized identifier of the direction of the initiated connection, traffic, or email.",
       "enum": {
-        "99": {
-          "caption": "Other"
-        },
         "0": {
-          "caption": "Unknown",
-          "description": "The direction is unknown."
+          "description": "Connection direction is unknown.",
+          "caption": "Unknown"
         },
         "1": {
-          "caption": "Inbound",
-          "description": "Inbound, from the Internet or outside network destined for services on the inside network."
+          "description": "Inbound network connection. The connection was originated from the Internet or outside network, destined for services on the inside network.",
+          "caption": "Inbound"
         },
         "2": {
-          "caption": "Outbound",
-          "description": "Outbound, from inside the network destined for services on the Internet or outside network."
+          "description": "Outbound network connection. The connection was originated from inside the network, destined for services on the Internet or outside network.",
+          "caption": "Outbound"
+        },
+        "3": {
+          "description": "Lateral network connection. The connection was originated from inside the network, destined for services on the inside network.",
+          "caption": "Lateral"
+        },
+        "99": {
+          "caption": "Other"
         }
       },
       "sibling": "direction",

--- a/objects/network_connection.json
+++ b/objects/network_connection.json
@@ -7,32 +7,9 @@
     "boundary": {},
     "boundary_id": {},
     "direction": {
-      "description": "The direction of the initiated connection.",
       "requirement": "optional"
     },
     "direction_id": {
-      "description": "The direction of the initiated connection.",
-      "enum": {
-        "0": {
-          "description": "Connection direction is unknown.",
-          "caption": "Unknown"
-        },
-        "1": {
-          "description": "Inbound network connection. The connection was originated from the Internet or outside network, destined for services on the inside network.",
-          "caption": "Inbound"
-        },
-        "2": {
-          "description": "Outbound network connection. The connection was originated from inside the network, destined for services on the Internet or outside network.",
-          "caption": "Outbound"
-        },
-        "3": {
-          "description": "Lateral network connection. The connection was originated from inside the network, destined for services on the inside network.",
-          "caption": "Lateral"
-        },
-        "99": {
-          "caption": "Other"
-        }
-      },
       "requirement": "required"
     },
     "protocol_name": {},


### PR DESCRIPTION
No breaking changes involved.

1. direction_id & direction fields were being overridden in the connection_info object with older descriptions, removing this redundancy and letting it use the dictionary definitions with the updated description.
2. Updating the enum in dictionary to match the one in connection_info object. 

![Screen Shot 2023-02-01 at 12 56 50 PM](https://user-images.githubusercontent.com/89877409/216124357-f2e265ee-c480-4231-bcd9-98bf68b33902.png)

Signed-off-by: Rajas [rajaspa@amazon.com](mailto:rajaspa@amazon.com)