### PR TITLE
#427 Add descriptions to activity_id enums (nonbreaking)

### DIFF
--- a/enums/file_activity.json
+++ b/enums/file_activity.json
@@ -1,46 +1,60 @@
 {
   "enum": {
     "1": {
-      "caption": "Create"
+      "caption": "Create",
+      "description": "A request to create a new file on a file system."
     },
     "2": {
-      "caption": "Read"
+      "caption": "Read",
+      "description": "A request to read data from a file on a file system."
     },
     "3": {
-      "caption": "Update"
+      "caption": "Update",
+      "description": "A request to write data to a file on a file system."
     },
     "4": {
-      "caption": "Delete"
+      "caption": "Delete",
+      "description": "A request to delete a file on a file system."
     },
     "5": {
-      "caption": "Rename"
+      "caption": "Rename",
+      "description": "A request to rename a file on a file system."
     },
     "6": {
-      "caption": "Set Attributes"
+      "caption": "Set Attributes",
+      "description": "A request to set attributes for a file on a file system."
     },
     "7": {
-      "caption": "Set Security"
+      "caption": "Set Security",
+      "description": "A request to set security for a file on a file system."
     },
     "8": {
-      "caption": "Get Attributes"
+      "caption": "Get Attributes",
+      "description": "A request to get attributes for a file on a file system."
     },
     "9": {
-      "caption": "Get Security"
+      "caption": "Get Security",
+      "description": "A request to get security for a file on a file system."
     },
     "10": {
-      "caption": "Encrypt"
+      "caption": "Encrypt",
+      "description": "A request to encrypt a file on a file system."
     },
     "11": {
-      "caption": "Decrypt"
+      "caption": "Decrypt",
+      "description": "A request to decrypt a file on a file system."
     },
     "12": {
-      "caption": "Mount"
+      "caption": "Mount",
+      "description": "A request to mount a file on a file system."
     },
     "13": {
-      "caption": "Unmount"
+      "caption": "Unmount",
+      "description": "A request to unmount a file from a file system."
     },
     "14": {
-      "caption": "Open"
+      "caption": "Open",
+      "description": "A request to create a file handle."
     }
   }
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.0.1"
+  "version": "1.0.2-alpha"
 }


### PR DESCRIPTION
(Non-Breaking, costmetic) - Add descriptions to `activity_id` enum in the `File System Activity` class.

How it looks:
<img width="1060" alt="image" src="https://user-images.githubusercontent.com/91983279/219439418-8671d36f-01c7-490f-9ed8-e6bbad884818.png">
