### PR TITLE
Updating description of the rcode field

### DIFF
--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -1,9 +1,9 @@
 {
+  "uid": 3,
   "caption": "DNS Activity",
   "description": "DNS Activity events report DNS queries and answers as seen on the network.",
   "extends": "network_activity",
   "name": "dns_activity",
-  "uid": 3,
   "attributes": {
     "activity_id": {
       "$include": "enums/dns_activity.json"
@@ -29,18 +29,16 @@
       "requirement": "recommended"
     },
     "rcode": {
-      "description": "The DNS server response code, as defined by the event source.",
+      "description": "The DNS server response code, normalized to the caption of the rcode_id value. In the case of 'Other', it is defined by the event source.",
       "group": "primary",
       "requirement": "optional"
     },
     "rcode_id": {
       "caption": "Response Code ID",
       "description": "The normalized identifier of the DNS server response code. See <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc6895'>RFC-6895</a>.",
+      "group": "primary",
+      "requirement": "optional",
       "enum": {
-        "99": {
-          "caption": "Other",
-          "description": "The dns response code is not defined by the RFC."
-        },
         "0": {
           "caption": "NoError",
           "description": "No Error."
@@ -49,57 +47,9 @@
           "caption": "FormError",
           "description": "Format Error."
         },
-        "10": {
-          "caption": "NotZone",
-          "description": "Name not contained in zone."
-        },
-        "11": {
-          "caption": "DSOTYPENI",
-          "description": "DSO-TYPE Not Implemented."
-        },
-        "16": {
-          "caption": "BADSIG_VERS",
-          "description": "TSIG Signature Failure or Bad OPT Version."
-        },
-        "17": {
-          "caption": "BADKEY",
-          "description": "Key not recognized."
-        },
-        "18": {
-          "caption": "BADTIME",
-          "description": "Signature out of time window."
-        },
-        "19": {
-          "caption": "BADMODE",
-          "description": "Bad TKEY Mode."
-        },
         "2": {
           "caption": "ServError",
           "description": "Server Failure."
-        },
-        "20": {
-          "caption": "BADNAME",
-          "description": "Duplicate key name."
-        },
-        "21": {
-          "caption": "BADALG",
-          "description": "Algorithm not supported."
-        },
-        "22": {
-          "caption": "BADTRUNC",
-          "description": "Bad Truncation."
-        },
-        "23": {
-          "caption": "BADCOOKIE",
-          "description": "Bad/missing Server Cookie."
-        },
-        "24": {
-          "caption": "Unassigned",
-          "description": "The codes deemed to be unassigned by the RFC (unassigned codes: 12-15, 24-3840, 4096-65534)."
-        },
-        "25": {
-          "caption": "Reserved",
-          "description": "The codes deemed to be reserved by the RFC (codes: 3841-4095, 65535)."
         },
         "3": {
           "caption": "NXDomain",
@@ -128,10 +78,60 @@
         "9": {
           "caption": "NotAuth",
           "description": "Not Authorized or Server Not Authoritative for zone."
+        },
+        "10": {
+          "caption": "NotZone",
+          "description": "Name not contained in zone."
+        },
+        "11": {
+          "caption": "DSOTYPENI",
+          "description": "DSO-TYPE Not Implemented."
+        },
+        "16": {
+          "caption": "BADSIG_VERS",
+          "description": "TSIG Signature Failure or Bad OPT Version."
+        },
+        "17": {
+          "caption": "BADKEY",
+          "description": "Key not recognized."
+        },
+        "18": {
+          "caption": "BADTIME",
+          "description": "Signature out of time window."
+        },
+        "19": {
+          "caption": "BADMODE",
+          "description": "Bad TKEY Mode."
+        },
+        "20": {
+          "caption": "BADNAME",
+          "description": "Duplicate key name."
+        },
+        "21": {
+          "caption": "BADALG",
+          "description": "Algorithm not supported."
+        },
+        "22": {
+          "caption": "BADTRUNC",
+          "description": "Bad Truncation."
+        },
+        "23": {
+          "caption": "BADCOOKIE",
+          "description": "Bad/missing Server Cookie."
+        },
+        "24": {
+          "caption": "Unassigned",
+          "description": "The codes deemed to be unassigned by the RFC (unassigned codes: 12-15, 24-3840, 4096-65534)."
+        },
+        "25": {
+          "caption": "Reserved",
+          "description": "The codes deemed to be reserved by the RFC (codes: 3841-4095, 65535)."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The dns response code is not defined by the RFC."
         }
-      },
-      "group": "primary",
-      "requirement": "optional"
+      }
     },
     "response_time": {
       "group": "occurrence",

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.0.2-alpha"
+  "version": "1.0.3-alpha"
 }


### PR DESCRIPTION
A non-breaking update to the description of `rcode` field to bring it sync with other sibling fields throughout OCSF.

Related Proposal - https://github.com/ocsf/ocsf-schema/discussions/480

![Screen Shot 2023-02-24 at 2 50 15 PM](https://user-images.githubusercontent.com/89877409/221277191-e8a5c34a-3c9f-4fcc-b00b-5b28339656c0.png)
