### PR TITLE
[nonbreaking] Add 'is_new_logon' optional context attribute

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1622,6 +1622,11 @@
       "description": "The event occurred on a managed device.",
       "type": "boolean_t"
     },
+    "is_new_logon": {
+      "caption": "New Logon",
+      "description": "Indicates logon is from a device not seen before or a first time account logon.",
+      "type": "boolean_t"
+    },
     "is_on_premises": {
       "caption": "On Premises",
       "description": "The indication of whether the location is on premises.",

--- a/events/audit/authentication.json
+++ b/events/audit/authentication.json
@@ -49,7 +49,11 @@
       "requirement": "optional"
     },
     "is_cleartext": {
-      "group": "primary",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "is_new_logon": {
+      "group": "context",
       "requirement": "optional"
     },
     "is_remote": {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.0.4-alpha"
+  "version": "1.0.5-alpha"
 }


### PR DESCRIPTION
Some authentication events (such as the case with Box events) indicate whether the logon is brand new. This PR adds an optional context attribute, `is_new_logon` (type boolean_t) to the `Authentication` class.

End result:

<img width="871" alt="image" src="https://user-images.githubusercontent.com/91983279/222825677-0ca77d44-bb61-48b4-8ff1-6f489ed6924d.png">
