### PR TITLE
[nonbreaking] Add 'Open' activity_id to Network File Activity

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -46,6 +46,9 @@
         },
         "13": {
           "caption": "Unshare"
+        },
+        "14": {
+          "caption": "Open"
         }
       }
     },

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.0.5-alpha"
+  "version": "1.0.6-alpha"
 }


### PR DESCRIPTION
The `Network File Activity` class was missing a common `activity_id`: Open. This PR adds an `Open` enum to this class so that such events may be mapped.

Result:
<img width="329" alt="image" src="https://user-images.githubusercontent.com/91983279/222843323-56aa3bb4-78d4-493b-ad09-c87f5af4ab43.png">
