### PR TITLE
[Nonbreaking] Add Optional attribute 'expiration_time' to the Network File Activity class.

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -57,6 +57,11 @@
       "group": "primary",
       "requirement": "required"
     },
+    "expiration_time": {
+      "description": "The share expiration time.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "file": {
       "description": "The file that is the target of the activity.",
       "group": "primary",

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.0.7-alpha"
+  "version": "1.0.8-alpha"
 }


### PR DESCRIPTION
`Network File Activity` events often have an expiration time for the file/folder shared. This PR adds an `Optional` attribute, `expiration_time` to this class in order to enhance data mappings.

<img width="997" alt="image" src="https://user-images.githubusercontent.com/91983279/223767061-c918e6c2-403a-49a3-9033-166c3e94447d.png">
