### PR TITLE
Issue 500: Update JA3 Attributes in TLS Object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1694,7 +1694,7 @@
     },
     "ja3s_hash": {
       "caption": "JA3S Hash",
-      "description": "The MD5 hash of JAS3 string.",
+      "description": "The MD5 hash of a JA3S string.",
       "type": "fingerprint"
     },
     "job": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1687,25 +1687,15 @@
       "description": "The certificate issuer name.",
       "type": "string_t"
     },
-    "ja3_fingerprint": {
-      "caption": "JA3 Fingerprint",
-      "description": "The fingerprint of JA3 string.",
+    "ja3_hash": {
+      "caption": "JA3 Hash",
+      "description": "The MD5 hash of a JA3 string.",
       "type": "fingerprint"
     },
-    "ja3_string": {
-      "caption": "JA3 String",
-      "description": "The JA3 string.",
-      "type": "string_t"
-    },
-    "ja3s_fingerprint": {
-      "caption": "JAS3 Fingerprint",
-      "description": "The fingerprint of JAS3 string.",
+    "ja3s_hash": {
+      "caption": "JA3S Hash",
+      "description": "The MD5 hash of JAS3 string.",
       "type": "fingerprint"
-    },
-    "ja3s_string": {
-      "caption": "JAS3 String",
-      "description": "The JAS3 string.",
-      "type": "string_t"
     },
     "job": {
       "caption": "Job",

--- a/objects/tls.json
+++ b/objects/tls.json
@@ -25,16 +25,10 @@
     "handshake_dur": {
       "requirement": "optional"
     },
-    "ja3_fingerprint": {
+    "ja3_hash": {
       "requirement": "recommended"
     },
-    "ja3_string": {
-      "requirement": "recommended"
-    },
-    "ja3s_fingerprint": {
-      "requirement": "recommended"
-    },
-    "ja3s_string": {
+    "ja3s_hash": {
       "requirement": "recommended"
     },
     "key_length": {


### PR DESCRIPTION
-  Remove `ja3_string`/`ja3s_string`
- Rename `ja3_fingerprint`/`ja3s_fingerprint` to `ja3_hash`/`ja3s_hash` and update description to relay that this is an md5 hash

#500 
<img width="1027" alt="image" src="https://user-images.githubusercontent.com/6465263/224068913-b1f0cce7-82ce-4625-8778-6b68d8582fd0.png">



