### PR TITLE
Add d3fend link to the file object

### DIFF
--- a/objects/file.json
+++ b/objects/file.json
@@ -2,7 +2,7 @@
   "caption": "File",
   "observable": 24,
   "name": "file",
-  "description": "The file object describes files, folders, links and mounts, including the reputation information, if applicable.",
+  "description": "A file is a collection of data stored in one unit, identified by a filename. It can be a document, picture, audio or video stream, folder, link, mount point, or other collection of data. Defined by D3FEND <a target='_blank' href='https://next.d3fend.mitre.org/dao/artifact/d3f:File/'>df3:File</a>.",
   "extends": "object",
   "attributes": {
     "accessed_time": {


### PR DESCRIPTION
This is an example of how to add a reference to the D3FEND objects. For for information, see discussion #496.