### PR TITLE
#537 Fix HTTP Activity IDs and HTTP Method

### DIFF
--- a/enums/http_activity.json
+++ b/enums/http_activity.json
@@ -1,0 +1,36 @@
+{
+  "enum": {
+    "1": {
+      "caption": "Connect",
+      "description": "The CONNECT method establishes a tunnel to the server identified by the target resource."
+    },
+    "2": {
+      "caption": "Delete",
+      "description": "The DELETE method deletes the specified resource."
+    },
+    "3": {
+      "caption": "Get",
+      "description": "The GET method requests a representation of the specified resource. Requests using GET should only retrieve data."
+    },
+    "4": {
+      "caption": "Head",
+      "description": "The HEAD method asks for a response identical to a GET request, but without the response body."
+    },
+    "5": {
+      "caption": "Options",
+      "description": "The OPTIONS method describes the communication options for the target resource."
+    },
+    "6": {
+      "caption": "Post",
+      "description": "The POST method submits an entity to the specified resource, often causing a change in state or side effects on the server."
+    },
+    "7": {
+      "caption": "Put",
+      "description": "The PUT method replaces all current representations of the target resource with the request payload."
+    },
+    "8": {
+      "caption": "Trace",
+      "description": "The TRACE method performs a message loop-back test along the path to the target resource."
+    }
+  }
+}

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -5,6 +5,9 @@
   "extends": "network_activity",
   "description": "HTTP Activity events report HTTP connection and traffic information.",
   "attributes": {
+    "activity_id": {
+      "$include": "enums/http_activity.json"
+    },
     "http_status": {
       "group": "primary"
     },

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -11,7 +11,43 @@
       "requirement": "recommended"
     },
     "http_method": {
-      "requirement": "recommended"
+      "caption": "HTTP Method",
+      "description": "The <a target='_blank' href='https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods'>HTTP request method</a> indicates the desired action to be performed for a given resource.",
+      "enum": {
+        "CONNECT": {
+          "caption": "Connect",
+          "description": "The CONNECT method establishes a tunnel to the server identified by the target resource."
+        },
+        "DELETE": {
+          "caption": "Delete",
+          "description": "The DELETE method deletes the specified resource."
+        },
+        "GET": {
+          "caption": "Get",
+          "description": "The GET method requests a representation of the specified resource. Requests using GET should only retrieve data."
+        },
+        "HEAD": {
+          "caption": "Head",
+          "description": "The HEAD method asks for a response identical to a GET request, but without the response body."
+        },
+        "OPTIONS": {
+          "caption": "Options",
+          "description": "The OPTIONS method describes the communication options for the target resource."
+        },
+        "POST": {
+          "caption": "Post",
+          "description": "The POST method submits an entity to the specified resource, often causing a change in state or side effects on the server."
+        },
+        "PUT": {
+          "caption": "Put",
+          "description": "The PUT method replaces all current representations of the target resource with the request payload."
+        },
+        "TRACE": {
+          "caption": "Trace",
+          "description": "The TRACE method performs a message loop-back test along the path to the target resource."
+        }
+      },
+      "type": "string_t"
     },
     "version": {
       "caption": "HTTP Version",


### PR DESCRIPTION
Addresses Issue #537 
----

`http_method` before:

<img width="1163" alt="image" src="https://user-images.githubusercontent.com/91983279/227068631-ba7f7ce1-8c53-4c75-a7e3-0859ade3d74c.png">

`http_method` after:

<img width="1155" alt="image" src="https://user-images.githubusercontent.com/91983279/227068672-05f0bbee-9a25-4726-b18a-2fa8ae1ef3b2.png">

----

`HTTP Activity` `activity_id` before:

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/91983279/227068801-090f030c-47a4-404a-b78a-9dc7b41cba40.png">

`HTTP Activity` `activity_id` after:

<img width="1151" alt="image" src="https://user-images.githubusercontent.com/91983279/227068886-15d4fab3-db67-4244-9475-68e54a038aa4.png">
