### PR TITLE
Bringing application category name in sync with other categories

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -29,8 +29,8 @@
       "uid": 5
     },
     "application": {
-      "caption": "Application",
-      "description": "Application Lifecycle events report detailed information about the behavior of applications and services.",
+      "caption": "Application Activity",
+      "description": "Application Activity events report detailed information about the behavior of applications and services.",
       "uid": 6
     }
   }


### PR DESCRIPTION
A simple change. Renaming `Application` category to `Application Activity` to keep all category names consistent.

![Screen Shot 2023-04-04 at 4 56 14 PM](https://user-images.githubusercontent.com/89877409/229918883-28b9548b-f5ee-44aa-9b0c-a2358d142285.png)
