### PR TITLE
Added "caption" to the new attributes for the Windows Log profile.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1332,6 +1332,7 @@
       "type": "string_t"
     },
     "event_code": {
+      "caption": "Event Code",
       "description": "The Event ID or Code that the product uses to describe the event. See specific usage.",
       "type": "string_t"
     },
@@ -1858,10 +1859,12 @@
       "type": "location"
     },
     "log_name": {
+      "caption": "Log Name",
       "description": "The logging subsystem the product uses for the event. See specific usage.",
       "type": "string_t"
     },
     "log_version": {
+      "caption": "Log Version",
       "description": "The version of the event log template which the product uses for the event. See specific usage.",
       "type": "string_t"
     },


### PR DESCRIPTION
`event_code` `log_name` and `log_version` didn't have captions, also causing them to sort incorrectly.