### PR TITLE
Added org_name and adjusted the descriptions of org_unit and org_uid, and os

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2098,14 +2098,19 @@
       "description": "An operation number used to identify a specific remote procedure call (RPC) method or a method in an interface.",
       "type": "integer_t"
     },
+    "org_name": {
+      "caption": "Org Name",
+      "description": "The name of the organization. For example, Widget, Inc",
+      "type": "string_t"
+    },
     "org_uid": {
       "caption": "Org ID",
-      "description": "The unique identifier of the organization to which the user belongs. For example, Active Directory or AWS Org ID.",
+      "description": "The unique identifier of the organization. For example, its Active Directory or AWS Org ID.",
       "type": "string_t"
     },
     "org_unit": {
       "caption": "Org Unit",
-      "description": "The name of the organization to which the user belongs.",
+      "description": "The name of the organizational unit, withiin an organization.  For example, Finance, IT, R&D",
       "type": "string_t"
     },
     "original_time": {
@@ -2115,7 +2120,7 @@
     },
     "os": {
       "caption": "OS",
-      "description": "The device operation system.",
+      "description": "The device operating system.",
       "type": "os"
     },
     "overall_score": {


### PR DESCRIPTION
This is not a breaking change structurally - but `org_unit` is a division within `org_name/org_uid`.  We have used the org_unit in place of organization within the `Device` object based on its description.  Refer to Issue #566 .  The descriptions have scoped the use of `org_uid` and `org_unit` to users.  The description is more general now (e.g. AWS OUs are groups of `Accounts` within an `Organization` - but in AD, devices can also be part of an OU, which in turn is part of an `Organization`.

We'll need a separate PR to make use of `org_name` as it would be paired with `org_uid`. 

The description for `os` was incorrect.

