### PR TITLE
Updated the Discovery inventory_info and config_state classes to make device required.

### DIFF
--- a/events/discovery/config_state.json
+++ b/events/discovery/config_state.json
@@ -1,10 +1,22 @@
 {
   "caption": "Device Config State",
-  "description": "Device Config State events report device inventory data.",
+  "description": "Device Config State events report device configuration data.",
   "extends": "discovery",
   "name": "config_state",
   "uid": 2,
+  "profiles": [
+    "host"
+  ],
   "attributes": {
+    "actor": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "device": {
+      "group": "primary",
+      "requirement": "required",
+      "description": "The device that is being discovered by an inventory process."
+    },
     "cis_benchmark_result": {
       "group": "primary"
     }

--- a/events/discovery/discovery.json
+++ b/events/discovery/discovery.json
@@ -4,23 +4,26 @@
   "description": "The Discovery event is a generic event that defines a set of attributes available in Discvoery category events. As a generic event, it could be used to log events that are not otherwise defined by the Discovery specific event classes.",
   "extends": "base_event",
   "name": "discovery",
-  "profiles": [
-    "host"
-  ],
   "attributes": {
-    "$include": [
-      "profiles/host.json"
-    ],
     "activity_id": {
       "enum": {
         "1": {
-          "caption": "Log"
+          "caption": "Log",
+          "description": "The discovered information is via a log."
+        },
+        "2": {
+          "caption": "Collect",
+          "description": "The discovered information is via a collection process."
         }
       }
     },
-    "device": {
-      "group": "primary",
-      "requirement": "required"
+    "org_name": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "org_unit": {
+      "group": "context",
+      "requirement": "optional"
     }
   }
 }

--- a/events/discovery/inventory_info.json
+++ b/events/discovery/inventory_info.json
@@ -4,10 +4,18 @@
   "extends": "discovery",
   "name": "inventory_info",
   "uid": 1,
+  "profiles": [
+    "host"
+  ],
   "attributes": {
+    "actor": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "device": {
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "required",
+      "description": "The device that is being discovered by an inventory process."
     }
   }
 }


### PR DESCRIPTION
The previous classes used the `Host` profile to bring in the `device` attribute, but the `device` attribute needs to be a built-in required attribute of the two classes since without it there are not targets for the inventory or config state.

An additional `activity_id`, `Collect`, added to the existing `Log` `activity_id` as discovery in many cases is done without intermediary persistence (per @jasonbreimer ).  `org_name` and `org_unit` added as optional context if reported or added by the discovery process.