### PR TITLE
Change group object constraints to mirror user object constraint of name or ID

### DIFF
--- a/objects/group.json
+++ b/objects/group.json
@@ -10,7 +10,7 @@
     },
     "name": {
       "description": "The group name.",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "privileges": {
       "description": "The group privileges.",
@@ -26,5 +26,11 @@
       "caption": "Unique ID",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "name",
+      "uid"
+    ]
   }
 }


### PR DESCRIPTION
Existing group had `name` as required, which does not work for many Linux log sources that only provide the ID.