### PR TITLE
Add Linux platform extension to add support for linux_users profile

### DIFF
--- a/extensions/linux/dictionary.json
+++ b/extensions/linux/dictionary.json
@@ -6,17 +6,17 @@
     "auid": {
       "caption": "Audit User ID",
       "description": "The audit user assigned at login by the audit subsystem.",
-      "type": "user"
+      "type": "integer_t"
     },
     "euid": {
       "caption": "Effective User ID",
       "description": "The effective user under which this process is running.",
-      "type": "user"
+      "type": "integer_t"
     },
     "egid": {
       "caption": "Effective Group ID",
       "description": "The effective group under which this process is running.",
-      "type": "group"
+      "type": "integer_t"
     }
   }
 }

--- a/extensions/linux/dictionary.json
+++ b/extensions/linux/dictionary.json
@@ -1,0 +1,22 @@
+{
+  "caption": "Attribute Dictionary",
+  "description": "The Attribute Dictionary defines schema attributes and includes references to the events and objects in which they are used.",
+  "name": "dictionary",
+  "attributes": {
+    "auid": {
+      "caption": "Audit User ID",
+      "description": "The audit user assigned at login by the audit subsystem.",
+      "type": "user"
+    },
+    "euid": {
+      "caption": "Effective User ID",
+      "description": "The effective user under which this process is running.",
+      "type": "user"
+    },
+    "egid": {
+      "caption": "Effective Group ID",
+      "description": "The effective group under which this process is running.",
+      "type": "group"
+    }
+  }
+}

--- a/extensions/linux/extension.json
+++ b/extensions/linux/extension.json
@@ -1,0 +1,6 @@
+{
+  "caption": "Linux Extension",
+  "name": "linux",
+  "version": "0.0.0",
+  "uid": 998
+}

--- a/extensions/linux/objects/linux_process.json
+++ b/extensions/linux/objects/linux_process.json
@@ -1,0 +1,21 @@
+{
+    "caption": "Linux Process",
+    "description": "Extends the process object to add Linux specific fields",
+    "extends": "process",
+    "attributes": {
+      "auid": {
+        "requirement": "optional"
+      },
+      "euid": {
+          "requirement": "optional"
+      },
+      "egid": {
+          "requirement": "optional"
+      },
+      "group": {
+          "description": "The group under which this process is running",
+          "requirement": "recommended"
+      }
+    }
+}
+  

--- a/extensions/linux/objects/process.json
+++ b/extensions/linux/objects/process.json
@@ -1,0 +1,14 @@
+{
+    "caption": "Linux Process",
+    "description": "Extends the process object to add Linux specific fields",
+    "extends": "process",
+    "profiles": [
+      "linux_users"
+    ],
+    "attributes": {
+      "$include": [
+        "profiles/linux_users.json"
+      ]
+    }
+}
+  

--- a/extensions/linux/profiles/linux_users.json
+++ b/extensions/linux/profiles/linux_users.json
@@ -1,11 +1,8 @@
 {
-    "description": "The attributes that Linux uses to identify user information",
+    "description": "The attributes that Linux uses to identify user information.",
     "meta": "profile",
     "caption": "Linux Users",
     "name": "linux_users",
-    "annotations": {
-      "group": "primary"
-    },
     "attributes": {
       "auid": {
           "requirement": "optional"
@@ -17,7 +14,7 @@
           "requirement": "optional"
       },
       "group": {
-          "description": "The group under which this process is running",
+          "description": "The group under which this process is running.",
           "requirement": "recommended"
       }
     }

--- a/extensions/linux/profiles/linux_users.json
+++ b/extensions/linux/profiles/linux_users.json
@@ -1,10 +1,14 @@
 {
-    "caption": "Linux Process",
-    "description": "Extends the process object to add Linux specific fields",
-    "extends": "process",
+    "description": "The attributes that Linux uses to identify user information",
+    "meta": "profile",
+    "caption": "Linux Users",
+    "name": "linux_users",
+    "annotations": {
+      "group": "primary"
+    },
     "attributes": {
       "auid": {
-        "requirement": "optional"
+          "requirement": "optional"
       },
       "euid": {
           "requirement": "optional"
@@ -17,5 +21,4 @@
           "requirement": "recommended"
       }
     }
-}
-  
+  }


### PR DESCRIPTION
The linux_users profile adds additional fields to the `process` object to support the various standard user information that is provided, such as `auid`, `euid`, `egid` and `gid`.

This is done via a Linux platform extension to keep the Linux-specific information out of the core schema