### PR TITLE
Fix [warning] security_finding uses 'security_control' profile...

### DIFF
--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -4,9 +4,6 @@
   "description": "Security Finding events describe findings, detections, anomalies, alerts and/or actions performed by security products",
   "extends": "findings",
   "name": "security_finding",
-  "profiles": [
-    "security_control"
-  ],
   "uid": 1,
   "attributes": {
     "analytic": {

--- a/extensions/linux/extension.json
+++ b/extensions/linux/extension.json
@@ -1,6 +1,7 @@
 {
-  "caption": "Linux Extension",
+  "caption": "Linux",
+  "description": "The Linux extension defines Linux specific attributes.",
   "name": "linux",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "uid": 998
 }

--- a/extensions/linux/profiles/linux_users.json
+++ b/extensions/linux/profiles/linux_users.json
@@ -1,21 +1,21 @@
 {
-    "description": "The attributes that Linux uses to identify user information.",
-    "meta": "profile",
-    "caption": "Linux Users",
-    "name": "linux_users",
-    "attributes": {
-      "auid": {
-          "requirement": "optional"
-      },
-      "euid": {
-          "requirement": "optional"
-      },
-      "egid": {
-          "requirement": "optional"
-      },
-      "group": {
-          "description": "The group under which this process is running.",
-          "requirement": "recommended"
-      }
+  "caption": "Linux",
+  "description": "The attributes that Linux uses to identify user information.",
+  "meta": "profile",
+  "name": "linux_users",
+  "attributes": {
+    "auid": {
+      "requirement": "optional"
+    },
+    "egid": {
+      "requirement": "optional"
+    },
+    "euid": {
+      "requirement": "optional"
+    },
+    "group": {
+      "description": "The group under which this process is running.",
+      "requirement": "recommended"
     }
   }
+}


### PR DESCRIPTION
Remove the `security_control` profile from the `security_finding` class to fix the `security_finding uses 'security_control' profile, but it does not define 'disposition_id' attribute` warning.