### PR TITLE
Removing resource_type_id from Resource object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2524,64 +2524,8 @@
     },
     "resource_type": {
       "caption": "Resource Type",
-      "description": "The type of the resource.",
+      "description": "The resource type as defined by the event source.",
       "type": "string_t"
-    },
-    "resource_type_id": {
-      "caption": "Resource Type ID",
-      "description": "The normalized type identifier of the resource.",
-      "enum": {
-        "0": {
-          "caption": "Unknown"
-        },
-        "1": {
-          "caption": "Audit Log"
-        },
-        "2": {
-          "caption": "Cloud Resource"
-        },
-        "3": {
-          "caption": "Configuration"
-        },
-        "4": {
-          "caption": "Device"
-        },
-        "5": {
-          "caption": "Document"
-        },
-        "6": {
-          "caption": "File"
-        },
-        "7": {
-          "caption": "Folder"
-        },
-        "8": {
-          "caption": "Group"
-        },
-        "9": {
-          "caption": "OS"
-        },
-        "10": {
-          "caption": "Security Policy"
-        },
-        "11": {
-          "caption": "Service"
-        },
-        "12": {
-          "caption": "System"
-        },
-        "13": {
-          "caption": "User"
-        },
-        "14": {
-          "caption": "Webpage"
-        },
-        "99": {
-          "caption": "Other"
-        }
-      },
-      "sibling": "resource_type",
-      "type": "integer_t"
     },
     "resource_uid": {
       "caption": "Resource ID",

--- a/objects/resource.json
+++ b/objects/resource.json
@@ -35,12 +35,8 @@
       "profile": "cloud"
     },
     "resource_type": {
-      "description": "The resource type, normalized to the caption of the resource_type_id value. In the case of 'Other', it is defined by the event source.",
+      "description": "The resource type as defined by the event source.",
       "requirement": "optional"
-    },
-    "resource_type_id": {
-      "description": "The normalized type identifier of the Resource.",
-      "requirement": "recommended"
     },
     "uid": {
       "description": "The unique identifier of the resource."


### PR DESCRIPTION
Based on discussion in May 2nd OCSF weekly meeting. Removing resource_type_id field from resource object and dictionary.

![Screen Shot 2023-05-02 at 1 36 09 PM](https://user-images.githubusercontent.com/89877409/235741902-dfbed427-4f81-483a-90dd-fb60f41bff04.png)
