### PR TITLE
Rename the target of the Application Lifecyle event to app for consistency in naming with the event class and description

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -105,6 +105,11 @@
       "description": "API object details information pertaining to the API calls",
       "type": "api"
     },
+    "app": {
+      "caption": "Application",
+      "description": "The application that reported the event.",
+      "type": "product"
+    },
     "app_name": {
       "caption": "Application Name",
       "description": "The name of the application that is associated with the event or object.",

--- a/events/application/application_lifecycle.json
+++ b/events/application/application_lifecycle.json
@@ -28,7 +28,7 @@
         }
       }
     },
-    "product": {
+    "app": {
       "description": "The application that was affected by the lifecycle event.  This also applies to self-updating application systems.",
       "group": "primary",
       "requirement": "required"


### PR DESCRIPTION
Rename the target of the Application Lifecyle event to app for consistency in naming with the event class and description