### PR TITLE
Removing constraints from http_request object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1474,7 +1474,7 @@
     },
     "http_request": {
       "caption": "HTTP Request",
-      "description": "The HTTP Request made to a web server.",
+      "description": "The HTTP Request Object documents attributes of a request made to a web server.",
       "type": "http_request"
     },
     "http_response": {

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -75,12 +75,5 @@
       "description": "The URL object that pertains to the request.",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "user_agent",
-      "url",
-      "hostname"
-    ]
   }
 }

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -1,7 +1,7 @@
 {
   "caption": "HTTP Request",
   "name": "http_request",
-  "description": "The HTTP Request Object details a request made to a web server.",
+  "description": "The HTTP Request Object documents attributes of a request made to a web server.",
   "extends": "object",
   "attributes": {
     "args": {


### PR DESCRIPTION
Based on discussion on May 2nd OCSF weekly call, removing constraints from the http_request object, updating object description.