### PR TITLE
Cleaning up duplication of groups in Resource Details

### DIFF
--- a/objects/resource.json
+++ b/objects/resource.json
@@ -16,9 +16,6 @@
       "description": "Additional data describing the resource.",
       "requirement": "optional"
     },
-    "group": {
-      "requirement": "recommended"
-    },
     "labels": {
       "requirement": "optional"
     },


### PR DESCRIPTION
Current [Resource](https://schema.ocsf.io/objects/resource) object contains a `group` attribute, with no specific definition.
 
If the intention behind having this attribute is to express resource owner's groups the `owner` object already covers it. Leaving both in leads to a duplicate definition of the `group` object. 

If there's another reason to have `group` object in the `resource` object, please comment on this PR along with the desired description of that object so that it can be updated. If not, then `group` can be removed from `resource` as is the intention of this PR.

After the change - 
<img width="1226" alt="Screen Shot 2023-05-04 at 3 27 19 PM" src="https://user-images.githubusercontent.com/89877409/236309520-678b7558-5734-4eba-944d-37dfc182a3cf.png">
