### PR TITLE
Replace separate org_name, org_uid, org_unit attributes with the org object attribute

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2084,21 +2084,6 @@
       "description": "The orchestrator managing the container, such as ECS, EKS, K8s, or OpenShift.",
       "type": "string_t"
     },
-    "org_name": {
-      "caption": "Org Name",
-      "description": "The name of the organization. For example, Widget, Inc",
-      "type": "string_t"
-    },
-    "org_uid": {
-      "caption": "Org Unit ID",
-      "description": "The unique identifier of the organizational unit. For example, its Active Directory OU DN or AWS OU ID.",
-      "type": "string_t"
-    },
-    "org_unit": {
-      "caption": "Org Unit Name",
-      "description": "The name of the organizational unit, within an organization.  For example, Finance, IT, R&D",
-      "type": "string_t"
-    },
     "ou_name": {
       "caption": "Org Unit Name",
       "description": "The name of the organizational unit, within an organization.  For example, Finance, IT, R&D",

--- a/events/discovery/discovery.json
+++ b/events/discovery/discovery.json
@@ -17,11 +17,7 @@
         }
       }
     },
-    "org_name": {
-      "group": "context",
-      "requirement": "optional"
-    },
-    "org_unit": {
+    "org": {
       "group": "context",
       "requirement": "optional"
     }

--- a/objects/cloud.json
+++ b/objects/cloud.json
@@ -7,7 +7,7 @@
     "account": {
       "requirement": "optional"
     },
-    "org_uid": {
+    "org": {
       "requirement": "optional"
     },
     "project_uid": {


### PR DESCRIPTION
Removed from dictionary; replaced in `discovery.json` and `cloud.json` to keep consistent use of `org`