### PR TITLE
Add quickXorHash & TLSH to fingerprint algorithms

### DIFF
--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -36,6 +36,14 @@
         "5": {
           "caption": "CTPH",
           "description": "The ssdeep generated fuzzy checksum. Also known as Context Triggered Piecewise Hash (CTPH)."
+        },
+        "6": {
+          "caption": "TLSH",
+          "description": "The TLSH fuzzy hashing algorithm."
+        },
+        "7": {
+          "caption": "quickXorHash",
+          "description": "Microsoft simple non-cryptographic hash algorithm that works by XORing the bytes in a circular-shifting fashion."
         }
       },
       "requirement": "required"


### PR DESCRIPTION
- Add `quickXorHash`, a Microsoft algorithm used primarily in OneDrive and Sharepoint. This algo is the only one reported by several Microsoft APIs
- Add `TLSH`, a fuzzy hashing algorithm used for similarity comparisons, used by various standards and services including Virustotal, MISP, and STIX

References:
https://learn.microsoft.com/en-us/onedrive/developer/code-snippets/quickxorhash?view=odsp-graph-online
https://learn.microsoft.com/en-us/graph/api/resources/hashes?view=graph-rest-1.0
https://tlsh.org/