### PR TITLE
Split IP address field into ipv4 and ipv6

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1627,9 +1627,14 @@
       "description": "The name of the service that invoked the activity as described in the event.",
       "type": "string_t"
     },
-    "ip": {
-      "caption": "IP Address",
-      "description": "The IP address, in either IPv4 or IPv6 format.",
+    "ipv4": {
+      "caption": "IPv4 Address",
+      "description": "The IPv4 address.",
+      "type": "ip_t"
+    },
+    "ipv6": {
+      "caption": "IPv6 Address",
+      "description": "The IPv6 address.",
       "type": "ip_t"
     },
     "is_cleartext": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -35,9 +35,6 @@
     "imei": {
       "requirement": "optional"
     },
-    "ip": {
-      "description": "The device IP address, in either IPv4 or IPv6 format."
-    },
     "is_compliant": {
       "requirement": "optional"
     },

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -21,8 +21,12 @@
     "interface_uid": {
       "requirement": "recommended"
     },
-    "ip": {
-      "description": "The IP address of the endpoint, in either IPv4 or IPv6 format.",
+    "ipv4": {
+      "description": "The IPv4 address of the endpoint.",
+      "requirement": "recommended"
+    },
+    "ipv6": {
+      "description": "The IPv6 address of the endpoint.",
       "requirement": "recommended"
     },
     "location": {
@@ -51,7 +55,8 @@
   },
   "constraints": {
     "at_least_one": [
-      "ip",
+      "ipv4",
+      "ipv6",
       "uid",
       "name",
       "hostname",

--- a/objects/network_endpoint.json
+++ b/objects/network_endpoint.json
@@ -17,7 +17,8 @@
   },
   "constraints": {
     "at_least_one": [
-      "ip",
+      "ipv4",
+      "ipv6",
       "uid",
       "name",
       "hostname",

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -8,8 +8,12 @@
       "description": "The hostname associated with the network interface.",
       "requirement": "recommended"
     },
-    "ip": {
-      "description": "The IP address associated with the network interface.",
+    "ipv4": {
+      "description": "The IPv4 address associated with the network interface.",
+      "requirement": "recommended"
+    },
+    "ipv6": {
+      "description": "The IPv6 address associated with the network interface.",
       "requirement": "recommended"
     },
     "mac": {
@@ -54,7 +58,8 @@
   },
   "constraints": {
     "at_least_one": [
-      "ip",
+      "ipv4",
+      "ipv6",
       "mac",
       "name",
       "hostname"

--- a/objects/network_proxy.json
+++ b/objects/network_proxy.json
@@ -8,9 +8,13 @@
       "description": "The proxy hostname.",
       "requirement": "optional"
     },
-    "ip": {
-      "description": "The proxy IP address.",
-      "requirement": "required"
+    "ipv4": {
+      "description": "The proxy IPv4 address.",
+      "requirement": "recommended"
+    },
+    "ipv6": {
+      "description": "The proxy IPv6 address.",
+      "requirement": "recommended"
     },
     "port": {
       "description": "The proxy IP port.",
@@ -24,5 +28,11 @@
       "description": "The unique identifier of the proxy.",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "ipv4",
+      "ipv6"
+    ]
   }
 }


### PR DESCRIPTION
The world is very much still transitioning from IPv4 to IPv6. According to [Google](https://www.google.com/intl/en/ipv6/statistics.html#tab=per-country-ipv6-adoption), IPv6 adoption in the US is around 48.49%, whereas Canada, Australia, Spain, and other developed nations have <35% adoption (also see: [APNIC](https://stats.labs.apnic.net/ipv6), [Akamai](https://www.akamai.com/internet-station/cyber-attacks/state-of-the-internet-report/ipv6-adoption-visualization)). My sense is this transition will last for many, many years, and thus both public interfaces (e.g. google[.]com) and private endpoints (e.g. on corporate networks) will have a mix of IPv4 and/or IPv6 IP addresses. This also means that systems collecting security-related telemetry will record a mix of IPv4 and IPv6 IP addresses for a given NIC depending on the configuration and implementation. Consequently, it's imperative that responders have full IP information to correlate security events across providers of security telemetry, and not to force providers to choose logging either IPv4 or IPv6.

This commit replaces the `ip` field with `ipv4` and `ipv6` in the following objects:

1. `Device`
2. `Endpoint`
3. `NetworkEndpoint`
4. `NetworkInterface`
5. `NetworkProxy`

The `constraints` are also updated such that either `ipv4` or `ipv6` must be provided when `ip` was originally required.

I validated the changes using ocsf-server, but please let me know if I missed any required updates to the schema. Happy to amend as needed.

Signed-off-by: Noah Rubin [narubin@amazon.com](mailto:narubin@amazon.com)