### PR TITLE
Changed category name from Access Control to Identity & Access Management

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -13,9 +13,9 @@
       "description": "Findings events report findings, detections, and possible resolutions of malware, anomalies, or other actions performed by security products.",
       "uid": 2
     },
-    "access_control": {
-      "caption": "Access Control",
-      "description": "Access Control events relate to the supervision of the system's access control model. Examples of such events are the success or failure of authentication, granting of authority, password change, entity change, privileged use, system state change, and resource access.",
+    "iam": {
+      "caption": "Identity & Access Management",
+      "description": "Identity & Access Management (IAM) events relate to the supervision of the system's authentication and access control model. Examples of such events are the success or failure of authentication, granting of authority, password change, entity change, privileged use etc.",
       "uid": 3
     },
     "network": {

--- a/events/access_control/access_control.json
+++ b/events/access_control/access_control.json
@@ -1,9 +1,9 @@
 {
-  "caption": "Access Control Activity",
-  "category": "access_control",
-  "description": "The Access Control Activity event is a generic event that defines a set of attributes available in the access control events. As a generic event, it could be used to log events that are not otherwise defined by the Access Control category.",
+  "caption": "Identity & Access Management",
+  "category": "iam",
+  "description": "The Identity & Access Management event is a generic event that defines a set of attributes available in the access control events. As a generic event, it could be used to log events that are not otherwise defined by the IAM category.",
   "extends": "base_event",
-  "name": "access_control",
+  "name": "iam",
   "profiles": [
     "host"
   ],

--- a/events/access_control/account.json
+++ b/events/access_control/account.json
@@ -1,7 +1,7 @@
 {
   "caption": "Account Change",
   "description": "Account Change events report when specific user account management tasks are performed, such as a user/role being created, changed, deleted, renamed, disabled, enabled, locked out or unlocked.",
-  "extends": "access_control",
+  "extends": "iam",
   "name": "account_change",
   "uid": 1,
   "attributes": {

--- a/events/access_control/authentication.json
+++ b/events/access_control/authentication.json
@@ -1,7 +1,7 @@
 {
   "caption": "Authentication",
   "description": "Authentication events report authentication session activities such as user attempts a logon or logoff, successfully or otherwise.",
-  "extends": "access_control",
+  "extends": "iam",
   "name": "authentication",
   "uid": 2,
   "attributes": {

--- a/events/access_control/authorization.json
+++ b/events/access_control/authorization.json
@@ -1,7 +1,7 @@
 {
   "caption": "Authorize Session",
   "description": "Authorize Session events report privileges or groups assigned to a new user session, usually at login time.",
-  "extends": "access_control",
+  "extends": "iam",
   "name": "authorize_session",
   "uid": 3,
   "associations": {

--- a/events/access_control/entity.json
+++ b/events/access_control/entity.json
@@ -2,7 +2,7 @@
   "caption": "Entity Management",
   "uid": 4,
   "name": "entity_management",
-  "extends": "access_control",
+  "extends": "iam",
   "description": "Entity Management events report activity by a managed client, a micro service, or a user at a management console. The activity can be a create, read, update, and delete operation on a managed entity.",
   "attributes": {
     "activity_id": {

--- a/events/access_control/group_management.json
+++ b/events/access_control/group_management.json
@@ -1,7 +1,7 @@
 {
   "caption": "Group Management",
   "description": "Group Management events report management updates to a group, including updates to membership and permissions.",
-  "extends": "access_control",
+  "extends": "iam",
   "name": "group_management",
   "uid": 8,
   "attributes": {

--- a/events/access_control/user_access.json
+++ b/events/access_control/user_access.json
@@ -1,7 +1,7 @@
 {
   "caption": "User Access Management",
   "description": "User Access Management events report management updates to a user's privileges.",
-  "extends": "access_control",
+  "extends": "iam",
   "name": "user_access",
   "uid": 7,
   "attributes": {

--- a/extensions/dev/events/audit/policy_audit.json
+++ b/extensions/dev/events/audit/policy_audit.json
@@ -2,7 +2,7 @@
   "caption": "Policy Override",
   "uid": 1,
   "name": "policy_override",
-  "extends": "access_control",
+  "extends": "iam",
   "description": "Reports user policy override activity at a management console or a managed client.",
   "attributes": {
     "app_name": {


### PR DESCRIPTION
Per weekly meeting discussion.  Non-breaking in that the category ID doesn't change, but it's name does.