### PR TITLE
Changed the Device uuid attribute to the uid_alt attribute and update User uid description.

### DIFF
--- a/objects/entity/endpoint/device.json
+++ b/objects/entity/endpoint/device.json
@@ -122,10 +122,10 @@
       "requirement": "required"
     },
     "uid": {
-      "description": "The unique identifier of the device."
+      "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN."
     },
-    "uuid": {
-      "description": "The universally unique identifier of the device. For example, AWS EC2 instance UUID."
+    "uid_alt": {
+      "description": "An alternate unique identifier of the device if any. For example the ActiveDirectory DN."
     }
   }
 }

--- a/objects/entity/endpoint/device.json
+++ b/objects/entity/endpoint/device.json
@@ -1,7 +1,7 @@
 {
   "caption": "Device",
   "name": "device",
-  "description": "Addressable device where events occurred. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Host/'>d3f:Host</a>.",
+  "description": "Addressable device, computer system or host where events occurred. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Host/'>d3f:Host</a>.",
   "extends": "endpoint",
   "attributes": {
     "autoscale_uid": {

--- a/objects/entity/user.json
+++ b/objects/entity/user.json
@@ -61,7 +61,7 @@
       "name": "integer_t"
     },
     "uid": {
-      "description": "The unique user identifier. For example, the Windows user SID, ActiveDirectory DN or AWS user ARN, or ."
+      "description": "The unique user identifier. For example, the Windows user SID, ActiveDirectory DN or AWS user ARN."
     },
     "uid_alt": {
       "description": "The alternate user identifier. For example, the Active Directory user GUID or AWS user Principal ID.",


### PR DESCRIPTION
Device and User now both use the same two `uid` attributes.  Note that Macs also have a GUID as a device identifier.
Updated the User description to fix the trailing 'or'.
Updated the Device caption to call out computer system or host as synonyms.