### PR TITLE
Removed the org attribute from Account object and Discovery classes (#Issue 629)

### DIFF
--- a/events/discovery/discovery.json
+++ b/events/discovery/discovery.json
@@ -16,10 +16,6 @@
           "description": "The discovered information is via a collection process."
         }
       }
-    },
-    "org": {
-      "group": "context",
-      "requirement": "optional"
     }
   }
 }

--- a/objects/entity/account.json
+++ b/objects/entity/account.json
@@ -7,10 +7,6 @@
     "name": {
       "description": "The name of the account (e.g. GCP Account Name)."
     },
-    "org": {
-      "description": "Organization and org unit related to the account.",
-      "requirement": "optional"
-    },
     "type": {
       "caption": "Type",
       "description": "The account type, normalized to the caption of 'account_type_id'. In the case of 'Other', it is defined by the event source.",


### PR DESCRIPTION
Account and User both have org and is redundant as User has an Account.  Device has `org` and so is not necessary in the class due to redundancy (Device has an org attribute and is the primary required attribute).

Issue #629