### PR TITLE
Updated the URL object to better conform to RFC 1738.  

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2251,11 +2251,6 @@
       "description": "The postal code of the location.",
       "type": "string_t"
     },
-    "prefix": {
-      "caption": "Prefix",
-      "description": "The domain prefix.",
-      "type": "string_t"
-    },
     "priority": {
       "caption": "Priority",
       "description": "The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source. See specific usage.",
@@ -2914,6 +2909,11 @@
       "sibling": "status",
       "type": "integer_t"
     },
+    "subdomain": {
+      "caption": "Subdomain",
+      "description": "The subdomain portion of the URL. For example: <code>sub</code> in <code>https://sub.example.com</code> or <code>sub2.sub1</code> in <code>https://sub2.sub1.example.com</code>.",
+      "type": "string_t"
+    },
     "subject": {
       "caption": "Subject Details",
       "description": "The identifier of the subject. See specific usage.",
@@ -2970,11 +2970,6 @@
       "caption": "Terminated Time",
       "description": "The time when the entity was terminated. See specific usage.",
       "type": "timestamp_t"
-    },
-    "text": {
-      "caption": "URL Text",
-      "description": "The URL. For example: <code>http://www.example.com/download/trouble.exe</code>.",
-      "type": "url_t"
     },
     "tid": {
       "caption": "Thread ID",
@@ -3085,6 +3080,11 @@
       "caption": "URL",
       "description": "The URL object that pertains to the event or object. See specific usage.",
       "type": "url"
+    },
+    "url_string": {
+      "caption": "URL String",
+      "description": "The URL string.  See RFC 1738. For example: <code>http://www.example.com/download/trouble.exe</code>.",
+      "type": "url_t"
     },
     "user": {
       "caption": "User",

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -54,10 +54,6 @@
       "description": "The Hypertext Transfer Protocol (HTTP) version.",
       "requirement": "recommended"
     },
-    "prefix": {
-      "description": "Domain prefix.",
-      "requirement": "optional"
-    },
     "referrer": {
       "requirement": "optional"
     },

--- a/objects/url.json
+++ b/objects/url.json
@@ -2,7 +2,7 @@
   "caption": "Uniform Resource Locator",
   "observable": 23,
   "name": "url",
-  "description": "The Uniform Resource Locator (URL) object describes the path and reputation of a URL. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:URL/'>d3f:URL</a>.",
+  "description": "The Uniform Resource Locator (URL) object describes the path and category of a URL. See RFC 1738.  Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:URL/'>d3f:URL</a>.",
   "extends": "object",
   "attributes": {
     "categories": {
@@ -11,11 +11,11 @@
       "requirement": "recommended"
     },
     "hostname": {
-      "description": "The URL host as extracted from the URL. For example: www.example.com.",
+      "description": "The URL host as extracted from the URL. For example: <code>www.example.com</code> from <code>www.example.com/download/trouble</code>.",
       "requirement": "required"
     },
     "path": {
-      "description": "The URL path as extracted from the URL. For example: <code>/download/trouble</code>.",
+      "description": "The URL path as extracted from the URL. For example: <code>/download/trouble</code> from <code>www.example.com/download/trouble</code>.",
       "requirement": "required"
     },
     "port": {
@@ -31,7 +31,10 @@
     "scheme": {
       "requirement": "recommended"
     },
-    "text": {
+    "subdomain": {
+      "requirement": "optional"
+    },
+    "url_string": {
       "requirement": "required"
     }
   }


### PR DESCRIPTION
See Issue #565.

More consistent with RFC 1738 (URL).  Moved `prefix` from `http_request` to `URL` and changed dictionary names from `prefix` to `subdomain`, `text` to `url_string`.