### PR TITLE
Cleaning up descriptions of the resource object

### DIFF
--- a/objects/entity/resource.json
+++ b/objects/entity/resource.json
@@ -9,7 +9,7 @@
       "profile": "cloud"
     },
     "criticality": {
-      "description": "The criticality of the resource.",
+      "description": "The criticality of the resource as defined by the event source.",
       "requirement": "optional"
     },
     "data": {
@@ -21,21 +21,22 @@
       "requirement": "optional"
     },
     "labels": {
+      "description": "The list of labels/tags associated to a resource.",
       "requirement": "optional"
     },
     "name": {
-      "description": "The name of the Resource."
+      "description": "The name of the resource."
     },
     "owner": {
-      "description": "The identity of the service or user account that owns the resource",
+      "description": "The identity of the service or user account that owns the resource.",
       "requirement": "recommended"
     },
     "region": {
-      "description": "The region of the resource.",
+      "description": "The cloud region of the resource.",
       "requirement": "optional",
       "profile": "cloud"
     },
-    "resource_type": {
+    "type": {
       "description": "The resource type as defined by the event source.",
       "requirement": "optional"
     },


### PR DESCRIPTION
1. Minor clean up of descriptions
2. Changing `resource_type` to `type`, no need for redundant attribute naming
![Screen Shot 2023-05-30 at 11 33 39 AM](https://github.com/ocsf/ocsf-schema/assets/89877409/4dbbc67e-746d-4457-8bd6-3c60156e6e28)
