### PR TITLE
Add user_inventory event class and associated person profile

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1757,7 +1757,6 @@
       "caption": "Job Title",
       "group": "context",
       "description": "The user's job title.",
-      "requirement": "optional",
       "type": "string_t"
     },
     "kb_articles": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -907,6 +907,11 @@
       "description": "The unique identifier used to correlate events.",
       "type": "string_t"
     },
+    "cost_center": {
+      "caption": "Cost Center",
+      "description": "The cost center associated with the user.",
+      "type": "string_t"
+    },
     "count": {
       "caption": "Count",
       "default": 1,
@@ -1019,6 +1024,11 @@
       "caption": "Authorization Decision/Outcome",
       "description": "Decision/outcome of the authorization mechanism (e.g. Approved, Denied)",
       "type": "string_t"
+    },
+    "deleted_time": {
+      "caption": "Deleted Time",
+      "description": "The timestamp when the user was deleted",
+      "type": "timestamp_t"
     },
     "delivered_to": {
       "caption": "Delivered To",
@@ -1258,8 +1268,14 @@
     },
     "email_addr": {
       "caption": "Email Address",
-      "description": "The user's email address.",
+      "description": "The user's primary email address.",
       "type": "email_t"
+    },
+    "email_addresses": {
+      "caption": "Email Addresses",
+      "description": "A list of additional email addresses for the user.",
+      "type": "email_t",
+      "is_array": true
     },
     "email_auth": {
       "caption": "Email Authentication",
@@ -1269,6 +1285,11 @@
     "email_uid": {
       "caption": "Email UID",
       "description": "The unique identifier of the email, used to correlate related email alert and activity events.",
+      "type": "string_t"
+    },
+    "employee_id": {
+      "caption": "Employee ID",
+      "description": "The employee identifier assigned to the user by the organization.",
       "type": "string_t"
     },
     "end_time": {
@@ -1423,6 +1444,11 @@
       "description": "The entry-point function of the module. The system calls the entry-point function whenever a process or thread loads or unloads the module.",
       "type": "string_t"
     },
+    "given_name": {
+      "caption": "Given Name",
+      "description": "The given or first name of the user.",
+      "type": "string_t"
+    },
     "group": {
       "caption": "Group",
       "description": "The group object associated with an entity such as user, policy, or rule.",
@@ -1454,6 +1480,11 @@
       "description": "An array of hash attributes.",
       "is_array": true,
       "type": "fingerprint"
+    },
+    "hire_datetime": {
+      "caption": "Hire Date",
+      "description": "The datetime when the user was/will be hired",
+      "type": "datetime_t"
     },
     "hostname": {
       "caption": "Hostname",
@@ -1722,6 +1753,13 @@
       "description": "The job object that pertains to the event.",
       "type": "job"
     },
+    "job_title": {
+      "caption": "Job Title",
+      "group": "context",
+      "description": "The user's job title.",
+      "requirement": "optional",
+      "type": "string_t"
+    },
     "kb_articles": {
       "caption": "Knowledgebase Articles",
       "description": "The KB article/s related to the entity",
@@ -1775,6 +1813,11 @@
       "description": "The two letter lower case language codes, as defined by <a target='_blank' href='https://en.wikipedia.org/wiki/ISO_639-1'>ISO 639-1</a>. For example: <code>en</code> (English), <code>de</code> (German), or <code>fr</code> (French).",
       "type": "string_t"
     },
+    "last_login_time": {
+      "caption": "Last Login",
+      "description": "The last time when the user logged in. This is usually populated by <code>user_inventory</code> events where a collection method provides this account information. It may not be populated in other event types and doesn't need populated in those cases.",
+      "type": "timestamp_t"
+    },
     "last_run_time": {
       "caption": "Last Run",
       "description": "The last run time of application or service. See specific usage.",
@@ -1794,6 +1837,11 @@
       "caption": "Lease Duration",
       "description": "This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events. (activity_id = 1)",
       "type": "integer_t"
+    },
+    "leave_datetime": {
+      "caption": "Leave Date",
+      "description": "The datetime when the user left/will be leaving the organization",
+      "type": "datetime_t"
     },
     "length": {
       "caption": "Response Length",
@@ -1935,6 +1983,11 @@
       "is_array": true,
       "type": "malware"
     },
+    "manager": {
+      "caption": "Manager",
+      "description": "The user's manager. This helps in understanding an org hierarchy. This should only ever be populated once in an event. I.e. there should not be a manager's manager in an event.",
+      "type": "user"
+    },
     "message": {
       "caption": "Message",
       "description": "The description of the event, as defined by the event source.",
@@ -2018,6 +2071,11 @@
       "description": "The observables associated with the event.",
       "is_array": true,
       "type": "observable"
+    },
+    "office_location": {
+      "caption": "Office Location",
+      "description": "The primary office location associated with the user. This could be any string and isn't a specific address. For example, <code>South East Virtual</code>.",
+      "type": "string_t"
     },
     "opcode": {
       "caption": "DNS Opcode",
@@ -2215,6 +2273,12 @@
       },
       "type": "integer_t",
       "sibling": "phase"
+    },
+    "phones": {
+      "caption": "Phones",
+      "description": "The phone numbers associated with the user",
+      "type": "string_t",
+      "is_array": true
     },
     "physical_height": {
       "caption": "Physical Height",
@@ -2918,6 +2982,11 @@
       "caption": "Supporting Data",
       "description": "Additional data supporting a finding as provided by security tool",
       "type": "json_t"
+    },
+    "surname": {
+      "caption": "Surname",
+      "description": "The last or family name for the user.",
+      "type": "string_t"
     },
     "svc_name": {
       "caption": "Service Name",

--- a/events/discovery/user_inventory.json
+++ b/events/discovery/user_inventory.json
@@ -1,6 +1,6 @@
 {
     "caption": "User Inventory Info",
-    "description": "User Inventory Info events report user inventory data. For example, this can be used to collect information about users by dumping Active Directory data.",
+    "description": "User Inventory Info events report user inventory data. For example, this can be used to collect information about users by dumping Active Directory data. This event class is meant to be used in conjunction with the <code>person</code> profile to allow capturing extended information about the user.",
     "extends": "discovery",
     "name": "user_inventory",
     "uid": 3,

--- a/events/discovery/user_inventory.json
+++ b/events/discovery/user_inventory.json
@@ -1,0 +1,18 @@
+{
+    "caption": "User Inventory Info",
+    "description": "User Inventory Info events report user inventory data. For example, this can be used to collect information about users by dumping Active Directory data.",
+    "extends": "discovery",
+    "name": "user_inventory",
+    "uid": 3,
+    "attributes": {
+        "actor": {
+            "group": "context",
+            "requirement": "optional"
+        },
+        "user": {
+            "group": "primary",
+            "requirement": "required",
+            "description": "The user that is being discovered by an inventory process."
+        }
+    }
+}

--- a/objects/location.json
+++ b/objects/location.json
@@ -12,7 +12,7 @@
       "requirement": "recommended"
     },
     "coordinates": {
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "country": {
       "requirement": "recommended"
@@ -38,5 +38,14 @@
       "requirement": "optional",
       "description": "The alphanumeric code that identifies the principal subdivision (e.g. province or state) of the country. Region codes are defined at <a target='_blank' href='https://www.iso.org/iso-3166-country-codes.html'>ISO 3166-2</a> and have a limit of three characters. For example, see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:code:3166:US'>the region codes for the US</a>."
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "coordinates",
+      "city",
+      "country",
+      "postal_code",
+      "region"
+    ]
   }
 }

--- a/objects/user.json
+++ b/objects/user.json
@@ -5,6 +5,7 @@
   "description": "The user object represents the identity of a person or security principal. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:UserAccount/'>d3f:UserAccount</a>.",
   "extends": "_entity",
   "attributes": {
+    "$include": "profiles/person.json",
     "account": {
       "description": "The user's account or the account associated with the user.",
       "requirement": "optional"

--- a/profiles/person.json
+++ b/profiles/person.json
@@ -1,0 +1,65 @@
+{
+  "description": "The additonal attributes that describe a person or user beyond those required for a user. These are expected to be used primarily to add additional context for the <code>user_inventory</code> event class.",
+  "meta": "profile",
+  "caption": "Person",
+  "name": "person",
+  "annotations": {
+    "group": "primary"
+  },
+  "attributes": {
+    "cost_center": {
+      "requirement": "optional"
+    },
+    "created_time": {
+      "description": "The timestamp when the user was created.",
+      "requirement": "optional"
+    },
+    "deleted_time": {
+      "requirement": "optional"
+    },
+    "employee_id": {
+      "requirement": "optional"
+    },
+    "given_name": {
+      "requirement": "optional"
+    },
+    "hire_datetime": {
+      "requirement": "optional"
+    },
+    "job_title": {
+      "requirement": "optional"
+    },
+    "labels": {
+      "description": "The labels associated with the user. For example in AD this could be the <code>userType</code>, <code>employeeType</code>. For example: <code>Member, Employee</code>",  
+      "requirement": "optional"
+    },
+    "last_login_time": {
+      "requirement": "optional"
+    },
+    "leave_datetime": {
+      "requirement": "optional"
+    },
+    "location": {
+      "description": "The detailed geographical location associated with a user. When used with the <code>user_inventory</code> event class, this typically documents the users usual work location.",
+      "requirement": "optional"
+    },
+    "manager": {
+      "requirement": "optional"
+    },
+    "modified_time": {
+      "description":"The timestamp when the user entry was last modified",
+      "requirement": "optional"
+    },
+    "office_location": {
+      "requirement": "optional"
+    },
+    "email_addresses": {
+      "caption": "Email Addresses",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "surname": {
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
In an effort to get collected AD type data into OCSF, we are adding a new event class called `user_inventory`. It would collect a lot more attributes associated with a user (person). So, in addition to the new class there is a new person profile that allows us to dynamically add the extended attributes to the user for the user_inventory class (or anywhere else that someone may want to add these attributes to the `user` object. In order to allow the user location to be specified without the coordinates in a location, we make the coordinates recommended and add constraints to the `location` object. Finally, the new attributes are added to the dictionary.