### PR TITLE
url_string to Product and Web Resource

### DIFF
--- a/objects/product.json
+++ b/objects/product.json
@@ -14,6 +14,9 @@
     "path": {
       "description": "The installation path of the product."
     },
+    "url_string": {
+      "description": "The URL pointing towards the product."
+    },
     "uid": {
       "description": "The unique identifier of the product."
     },

--- a/objects/web_resource.json
+++ b/objects/web_resource.json
@@ -15,8 +15,8 @@
         "description": "Description of the web resource.",
         "requirement": "optional"
       },
-      "url": {
-        "description": "The URL pointing towards the source of the resource.",
+      "url_string": {
+        "description": "The URL pointing towards the source of the web resource.",
         "requirement": "recommended"
       },
       "type": {


### PR DESCRIPTION
Adding `url_string` to `Product` and changing `URL` to `url_string` in `web resource`. 

![product-w-url_string](https://github.com/ocsf/ocsf-schema/assets/120660286/2005a1e3-c51f-46ac-a6cd-2c8ff7b72877)

![web-resource-w-url_string](https://github.com/ocsf/ocsf-schema/assets/120660286/04a9f16d-0986-4b13-ab4a-069f2a907c10)
