### PR TITLE
Issue-672: Extend network event in network file activity

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -1,8 +1,8 @@
 {
   "caption": "Network File Activity",
-  "description": "Network File Activity events report activities on a cloud file storage service such as Box, MS OneDrive, or Google Drive.",
+  "description": "Network File Activity events report file activities traversing the network, including file storage services such as Box, MS OneDrive, or Google Drive.",
   "category": "network",
-  "extends": "base_event",
+  "extends": "network_activity",
   "name": "network_file_activity",
   "uid": 10,
   "attributes": {
@@ -56,6 +56,15 @@
       "description": "The actor that performed the activity on the target file.",
       "group": "primary",
       "requirement": "required"
+    },
+    "connection_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "dst_endpoint": {
+      "description": "The endpoint that received the activity on the target file.",
+      "requirement": "recommended",
+      "group": "primary"
     },
     "expiration_time": {
       "description": "The share expiration time.",

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -58,13 +58,11 @@
       "requirement": "required"
     },
     "connection_info": {
-      "group": "primary",
       "requirement": "optional"
     },
     "dst_endpoint": {
       "description": "The endpoint that received the activity on the target file.",
-      "requirement": "recommended",
-      "group": "primary"
+      "requirement": "recommended"
     },
     "expiration_time": {
       "description": "The share expiration time.",


### PR DESCRIPTION
- Make network file activity more generic and extend network event class. This will add `dst_endpoint`, `connection_info` and `traffic` to the event class. 
- Change the requirement options on the `connection_info` and `dst_endpoint`.

#672 
<img width="866" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/4d9c3827-83d6-4fa7-869c-07d423ea5222">

<img width="1391" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/ef02e707-e865-4908-a363-a0dd80b2f9f4">
