### PR TITLE
Adding CWE object to the framework & in the vulnerability object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -994,10 +994,10 @@
       "description": "The CVSS object details Common Vulnerability Scoring System (<a target='_blank' href='https://www.first.org/cvss/'>CVSS</a>) scores from the advisory that are related to the vulnerability.",
       "type": "cvss"
     },
-    "cwe_uid": {
-      "caption": "CWE UID",
-      "description": "The <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> unique identifier. For example: <code>CWE-787</code>.",
-      "type": "string_t"
+    "cwe": {
+      "caption": "CWE",
+      "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
+      "type": "cwe"
     },
     "cwe_url": {
       "caption": "CWE URL",

--- a/dictionary.json
+++ b/dictionary.json
@@ -999,11 +999,6 @@
       "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
       "type": "cwe"
     },
-    "cwe_url": {
-      "caption": "CWE URL",
-      "description": "Common Weakness Enumeration (CWE) definition URL. For example: <code>https://cwe.mitre.org/data/definitions/787.html</code>.",
-      "type": "url_t"
-    },
     "data": {
       "caption": "Data",
       "description": "The additional data that is associated with the event or object. See specific usage.",

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -8,8 +8,7 @@
       "requirement": "recommended"
     },
     "cwe":{
-      "requirement": "optional",
-      "description": "The Common Weakness Enumeration (CWE) is a community-developed list of software and hardware weakness types. The CWE Specification provides a common language of discourse for discussing, finding and dealing with the causes of software security vulnerabilities as they are found in code, design, or system architecture. For more information see <a target='_blank' href='https://cwe.mitre.org/'>CWE</a>"
+      "requirement": "optional"
     },
     "modified_time": {
       "description": "The Record Modified Date identifies when the CVE record was last updated.",

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -7,6 +7,10 @@
     "cvss": {
       "requirement": "recommended"
     },
+    "cwe":{
+      "requirement": "optional",
+      "description": "The Common Weakness Enumeration (CWE) is a community-developed list of software and hardware weakness types. The CWE Specification provides a common language of discourse for discussing, finding and dealing with the causes of software security vulnerabilities as they are found in code, design, or system architecture. For more information see <a target='_blank' href='https://cwe.mitre.org/'>CWE</a>"
+    },
     "modified_time": {
       "description": "The Record Modified Date identifies when the CVE record was last updated.",
       "requirement": "optional"

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -7,19 +7,11 @@
     "cvss": {
       "requirement": "recommended"
     },
-    "cwe_uid": {
-      "requirement": "optional"
-    },
-    "cwe_url": {
-      "requirement": "optional"
-    },
     "modified_time": {
-			"caption": "Record Modified Date",
       "description": "The Record Modified Date identifies when the CVE record was last updated.",
       "requirement": "optional"
     },
     "created_time": {
-			"caption": "Record Creation Date",
       "description": "The Record Creation Date identifies when the CVE ID was issued to a CVE Numbering Authority (CNA) or the CVE Record was published on the CVE List. Note that the Record Creation Date does not necessarily indicate when this vulnerability was discovered, shared with the affected vendor, publicly disclosed, or updated in CVE.",
       "requirement": "recommended"
     },

--- a/objects/cwe.json
+++ b/objects/cwe.json
@@ -1,0 +1,16 @@
+{
+  "caption": "CWE",
+  "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
+  "extends": "object",
+  "name": "cwe",
+  "attributes": {
+    "uid": {
+      "caption": "CWE ID",
+      "description": "The Common Weakness Enumeration unique number assigned to a specific weakness. A CWE Identifier begins \"CWE\" followed by a sequence of digits that acts as a unique identifier. For example: <code>CWE-123</code>.",
+      "requirement": "required"
+    },
+    "cwe_url": {
+      "requirement": "optional"
+    }
+  }
+}

--- a/objects/cwe.json
+++ b/objects/cwe.json
@@ -4,13 +4,18 @@
   "extends": "object",
   "name": "cwe",
   "attributes": {
+    "caption":{
+      "description": "The caption assigned to the Common Weakness Enumeration unique identifier.",
+      "requirement": "optional"
+    },
+    "src_url": {
+      "description": "URL pointing to the CWE Specification. For more information see <a target='_blank' href='https://cwe.mitre.org/'>CWE.</a>",
+      "requirement": "optional"
+    },
     "uid": {
       "caption": "CWE ID",
       "description": "The Common Weakness Enumeration unique number assigned to a specific weakness. A CWE Identifier begins \"CWE\" followed by a sequence of digits that acts as a unique identifier. For example: <code>CWE-123</code>.",
       "requirement": "required"
-    },
-    "cwe_url": {
-      "requirement": "optional"
     }
   }
 }

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -5,7 +5,10 @@
   "extends": "object",
   "attributes": {
     "cve": {
-      "requirement": "required"
+      "requirement": "recommended"
+    },
+    "cwe": {
+      "requirement": "recommended"
     },
     "desc": {
       "description": "The description of the vulnerability.",
@@ -37,5 +40,11 @@
       "description": "The vendor who identified the vulnerability.",
       "requirement": "optional"
     }
+  },
+  "constraints":{
+    "at_least_one": [
+      "cve",
+      "cwe"
+    ]
   }
 }

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -21,7 +21,7 @@
       "requirement": "optional"
     },
     "packages": {
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "references": {
       "requirement": "recommended"
@@ -34,7 +34,7 @@
     },
     "title": {
       "description": "The title of the vulnerability.",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "vendor_name": {
       "description": "The vendor who identified the vulnerability.",


### PR DESCRIPTION
Picking up changes proposed in https://github.com/ocsf/ocsf-schema/pull/558.
Related issue: https://github.com/ocsf/ocsf-schema/issues/676

* Keeping in all the changes from the original PR. (new cwe object, replacing individual cwe fields with cwe object)
* Additionally, added a constraint of at_least_one(cve, cwe) in the vulnerability object.

This is a backwards incompatible change since, cwe_uid, cwe_url has been removed from the dictionary. (in favor of the new cwe object)

