### PR TITLE
Firewall Profile Implementation

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3257,7 +3257,7 @@
     "rate_limit": {
       "caption": "Rate Limit",
       "description": "The rate limit for a rate-based rule.",
-      "type": "string_t"
+      "type": "integer_t"
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1196,12 +1196,6 @@
         "18": {
           "caption": "Tagged",
           "description": "Marked with extended attributes."
-        },
-        "19": {
-          "caption": "Captcha"
-        },
-        "20": {
-          "caption": "Challenge"
         }
       },
       "sibling": "disposition",
@@ -2611,6 +2605,11 @@
       "description": "The rules that reported the events.",
       "type": "rule"
     },
+    "firewall_rule": {
+      "caption": "Firewall Rule",
+      "description": "The firewall rules that triggered the events.",
+      "type": "firewall_rule"
+    },
     "run_state": {
       "caption": "Run State",
       "description": "The state of the job or service, normalized to the caption of the run_state_id value. In the case of 'Other', it is defined by the event source. See specific usage.",
@@ -3232,32 +3231,6 @@
     "zone": {
       "caption": "Network Zone",
       "description": "The network zone or LAN segment.",
-      "type": "string_t"
-    },
-    "condition": {
-      "caption": "Condition",
-      "description": "The rule trigger condition for the rule. For example: SQL_INJECTION.",
-      "type": "string_t"
-    },
-    "sensitivity": {
-      "caption": "Sensitivity",
-      "description": "The location in the request where the rule matched. For example: HIGH.",
-      "type": "string_t"
-    },
-    "rule_location": {
-      "caption": "Rule Location",
-      "description": "The location in the request where the rule matched. For example: HEADER.",
-      "type": "string_t"
-    },
-    "match_details": {
-      "caption": "Match Details",
-      "description": "The data in a request that rule matched. For example: '[\"10\",\"and\",\"1\"]'.",
-      "is_array": true,
-      "type": "string_t"
-    },
-    "rate_limit": {
-      "caption": "Rate Limit",
-      "description": "The rate limit for a rate-based rule.",
       "type": "string_t"
     }
   },

--- a/dictionary.json
+++ b/dictionary.json
@@ -1196,6 +1196,12 @@
         "18": {
           "caption": "Tagged",
           "description": "Marked with extended attributes."
+        },
+        "19": {
+          "caption": "Captcha"
+        },
+        "20": {
+          "caption": "Challenge"
         }
       },
       "sibling": "disposition",
@@ -3226,6 +3232,32 @@
     "zone": {
       "caption": "Network Zone",
       "description": "The network zone or LAN segment.",
+      "type": "string_t"
+    },
+    "condition": {
+      "caption": "Condition",
+      "description": "The rule trigger condition for the rule. For example: SQL_INJECTION.",
+      "type": "string_t"
+    },
+    "sensitivity": {
+      "caption": "Sensitivity",
+      "description": "The location in the request where the rule matched. For example: HIGH.",
+      "type": "string_t"
+    },
+    "rule_location": {
+      "caption": "Rule Location",
+      "description": "The location in the request where the rule matched. For example: HEADER.",
+      "type": "string_t"
+    },
+    "match_details": {
+      "caption": "Match Details",
+      "description": "The data in a request that rule matched. For example: '[\"10\",\"and\",\"1\"]'.",
+      "is_array": true,
+      "type": "string_t"
+    },
+    "rate_limit": {
+      "caption": "Rate Limit",
+      "description": "The rate limit for a rate-based rule.",
       "type": "string_t"
     }
   },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3244,7 +3244,7 @@
       "type": "string_t"
     },
     "match_location": {
-      "caption": "Rule Location",
+      "caption": "Match Location",
       "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
       "type": "string_t"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3232,6 +3232,32 @@
       "caption": "Network Zone",
       "description": "The network zone or LAN segment.",
       "type": "string_t"
+    },
+    "condition": {
+      "caption": "Condition",
+      "description": "The rule trigger condition for the rule. For example: SQL_INJECTION.",
+      "type": "string_t"
+    },
+    "sensitivity": {
+      "caption": "Sensitivity",
+      "description": "The sensitivity of the firewall rule in the matched event. For example: HIGH.",
+      "type": "string_t"
+    },
+    "match_location": {
+      "caption": "Rule Location",
+      "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
+      "type": "string_t"
+    },
+    "match_details": {
+      "caption": "Match Details",
+      "description": "The data in a request that rule matched. For example: '[\"10\",\"and\",\"1\"]'.",
+      "is_array": true,
+      "type": "string_t"
+    },
+    "rate_limit": {
+      "caption": "Rate Limit",
+      "description": "The rate limit for a rate-based rule.",
+      "type": "string_t"
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3245,7 +3245,7 @@
     },
     "match_location": {
       "caption": "Match Location",
-      "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
+      "description": "The location of the matched data in the source which resulted in the triggered firewall rule. For example: HEADER.",
       "type": "string_t"
     },
     "match_details": {

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -1,10 +1,17 @@
 {
-  "caption": "HTTP Activity",
-  "uid": 2,
-  "name": "http_activity",
-  "extends": "network_activity",
   "description": "HTTP Activity events report HTTP connection and traffic information.",
+  "extends": "network_activity",
+  "caption": "HTTP Activity",
+  "name": "http_activity",
+  "category": "network",
+  "uid": 2,
+  "profiles": [
+    "firewall"
+  ],
   "attributes": {
+    "$include": [
+      "profiles/firewall.json"
+    ],
     "activity_id": {
       "$include": "enums/http_activity.json"
     },

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -1,0 +1,40 @@
+{
+  "caption": "Firewall Rule",
+  "name": "firewall_rule",
+  "description": "The firewall rule object associated with a policy or event.",
+  "extends": "rule",
+  "attributes": {
+    "condition": {
+      "description": "The rule trigger condition for the rule. For example: SQL_INJECTION.",
+      "requirement": "optional"
+    },
+    "sensitivity": {
+      "description": "The location in the request where the rule matched. For example: HIGH.",
+      "requirement": "optional"
+    },	
+    "rule_location": {
+      "description": "The location in the request where the rule matched. For example: HEADER.",
+      "requirement": "optional"
+    },	
+    "match_details": {
+      "description": "The data in a request that rule matched. For example: '[\"10\",\"and\",\"1\"]'.",
+      "requirement": "optional"
+    },	
+    "rate_limit": {
+      "description": "The rate limit for a rate-based rule.",
+      "requirement": "optional"
+    },	
+    "status_code": {
+      "description": "The firewall event status code, detailing the rule action of the event source.",
+      "requirement": "optional"
+    },	
+    "response_time": {
+      "description": "The rule response time, usually used for challenge completion time.",
+      "requirement": "optional"
+    },	
+    "message": {
+      "description": "The description of the firewall event rule action, as defined by the event source.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -5,11 +5,9 @@
   "extends": "rule",
   "attributes": {
     "condition": {
-      "description": "The rule trigger condition for the rule. For example: SQL_INJECTION.",
       "requirement": "optional"
     },
     "sensitivity": {
-      "description": "The sensitivity of the firewall rule in the matched event. For example: HIGH.",
       "requirement": "optional"
     },	
     "match_location": {
@@ -17,11 +15,9 @@
       "requirement": "optional"
     },	
     "match_details": {
-      "description": "The data in a request that rule matched. For example: '[\"10\",\"and\",\"1\"]'.",
       "requirement": "optional"
     },	
     "rate_limit": {
-      "description": "The rate limit for a rate-based rule.",
       "requirement": "optional"
     },	
     "status_code": {

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -12,7 +12,7 @@
       "description": "The sensitivity of the firewall rule in the matched event. For example: HIGH.",
       "requirement": "optional"
     },	
-    "rule_location": {
+    "match_location": {
       "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
       "requirement": "optional"
     },	

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -9,11 +9,11 @@
       "requirement": "optional"
     },
     "sensitivity": {
-      "description": "The location in the request where the rule matched. For example: HIGH.",
+      "description": "The sensitivity of the firewall rule in the matched event. For example: HIGH.",
       "requirement": "optional"
     },	
     "rule_location": {
-      "description": "The location in the request where the rule matched. For example: HEADER.",
+      "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
       "requirement": "optional"
     },	
     "match_details": {

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -11,7 +11,6 @@
       "requirement": "optional"
     },	
     "match_location": {
-      "description": "The location of the in the matched data in the event as it pertains to the firewall rule. For example: HEADER.",
       "requirement": "optional"
     },	
     "match_details": {

--- a/profiles/firewall.json
+++ b/profiles/firewall.json
@@ -1,0 +1,20 @@
+{
+  "description": "The attributes that identify firewall events such as firewall_rule.",
+  "meta": "profile",
+  "caption": "Firewall",
+  "name": "firewall",
+  "annotations": {
+    "group": "primary"
+  },
+  "attributes": {
+    "firewall_rule": {
+      "requirement": "required"
+    },
+    "disposition": {
+      "requirement": "optional"
+    },
+    "disposition_id": {
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
Firewall Profile Description of Changed:
1. Adding firewall.json in profiles
2. Adding firewall_rule.json in objects which extends the rule object for the firewall profile usecase. 
3. Updating http.json in events/network to include the application of the firewall profile in to accommodate WAF events. 
4. Updating disctionary.json to include new attributes from firewall.json profile and firewall_rule.json object, as well as adding additional disposition_id options to reflect possible firewall actions. 


The following is an example AWS WAF log conforming to the firewall profile as applies to 4002.

    {
        "activity_id": 1,
        "activity_name": "Get",
        "category_name": "Network Activity",
        "category_uid": 4,
        "class_name": "HTTP Activity",
        "class_uid": 4002,
        "type_name": "HTTP Activity: Get",
        "type_uid": 400503,
        "time": 1576280412771,
        "disposition": "Block",
        "disposition_id": "2",
        "time": 1576280412771,
        "metadata": {
            "product": {
	            "name": "AWS WAF",
	            "vendor_name": "AWS"
            },
            "feature": {
	            "uid": "arn:aws:wafv2:ap-southeast-2:111122223333:regional/webacl/STMTest/1EXAMPLE-2ARN-3ARN-4ARN-123456EXAMPLE"
            },
            "log_version": "1",
            "profiles": [firewall],
            "version": "1.0.0-rc.3",
            "labels": [
	            {
		            "name": "value"
	            }
            ]
        },
        "src_endpoint": {
            "ip": "1.1.1.1",
            "location": {
	            "country": "AU"
            }
        },
        "http_request": {
            "args": "",
            "version": "HTTP/1.1",
            "method": "GET",
            "uid": "rid",
            "user_agent": "curl/7.61.1",
            "url": {
	            "hostname": "localhost:1989",
	            "path": "/myUri",
	            "url_string": "localhost:1989/myUri"
            },
            "headers": [
	            {
		            "name": "Accept",
		            "value": "*/*"
	            },
	            {
		            "name": "x-stm-test",
		            "value": "10 AND 1=1"
	            }
            ]
        },
        "rule": {
            "uid": "STMTest_SQLi_XSS",
            "type": "REGULAR",
            "condition": "SQL_INJECTION",
            "sensitivity": "HIGH",
            "location": "HEADER",
            "matched_data": [
	            "10",
	            "AND",
	            "1"
            ]
        },
        "unmapped": {
            "httpSourceName": "APIGW",
            "httpSourcId": "-"
        }
    }