### PR TITLE
Issue 689: Add type/type_id to endpoint object

### DIFF
--- a/objects/_endpoint.json
+++ b/objects/_endpoint.json
@@ -39,6 +39,42 @@
     "subnet_uid": {
       "requirement": "optional"
     },
+    "type": {
+      "caption": "Type",
+      "description": "The endpoint type. For example: <code>unknown</code>, <code>server</code>, <code>desktop</code>, <code>laptop</code>, <code>tablet</code>, <code>mobile</code>, <code>virtual</code>, <code>browser</code>, or <code>other</code>.",
+      "requirement": "optional"
+    },
+    "type_id": {
+      "caption": "Type ID",
+      "description": "The endpoint type ID.",
+      "enum": {
+        "1": {
+          "caption": "Server"
+        },
+        "2": {
+          "caption": "Desktop"
+        },
+        "3": {
+          "caption": "Laptop"
+        },
+        "4": {
+          "caption": "Tablet"
+        },
+        "5": {
+          "caption": "Mobile"
+        },
+        "6": {
+          "caption": "Virtual"
+        },
+        "7": {
+          "caption": "IOT"
+        },
+        "8": {
+          "caption": "Browser"
+        }
+      },
+      "requirement": "recommended"
+    },
     "uid": {
       "description": "The unique identifier of the endpoint."
     },

--- a/objects/device.json
+++ b/objects/device.json
@@ -102,39 +102,10 @@
       "requirement": "optional"
     },
     "type": {
-      "caption": "Type",
-      "description": "The device type. For example: <code>unknown</code>, <code>server</code>, <code>desktop</code>, <code>laptop</code>, <code>tablet</code>, <code>mobile</code>, <code>virtual</code>, <code>browser</code>, or <code>other</code>.",
-      "requirement": "optional"
+      "description": "The device type. For example: <code>unknown</code>, <code>server</code>, <code>desktop</code>, <code>laptop</code>, <code>tablet</code>, <code>mobile</code>, <code>virtual</code>, <code>browser</code>, or <code>other</code>."
     },
     "type_id": {
-      "caption": "Type ID",
       "description": "The device type ID.",
-      "enum": {
-        "1": {
-          "caption": "Server"
-        },
-        "2": {
-          "caption": "Desktop"
-        },
-        "3": {
-          "caption": "Laptop"
-        },
-        "4": {
-          "caption": "Tablet"
-        },
-        "5": {
-          "caption": "Mobile"
-        },
-        "6": {
-          "caption": "Virtual"
-        },
-        "7": {
-          "caption": "IOT"
-        },
-        "8": {
-          "caption": "Browser"
-        }
-      },
       "requirement": "required"
     },
     "uid": {

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -2,7 +2,7 @@
   "caption": "Endpoint",
   "observable": 20,
   "name": "endpoint",
-  "description": "The endpoint object describes an entity that has name, uid, and IP address.",
+  "description": "The endpoint object describes an entity that has a name, uid, and IP address.",
   "extends": "_entity",
   "attributes": {
     "domain": {

--- a/objects/network_endpoint.json
+++ b/objects/network_endpoint.json
@@ -13,6 +13,12 @@
     },
     "svc_name": {
       "requirement": "recommended"
+    },
+    "type": {
+      "description": "The network endpoint type. For example: <code>unknown</code>, <code>server</code>, <code>desktop</code>, <code>laptop</code>, <code>tablet</code>, <code>mobile</code>, <code>virtual</code>, <code>browser</code>, or <code>other</code>."
+    },
+    "type_id": {
+      "description": "The network endpoint type ID."
     }
   },
   "constraints": {


### PR DESCRIPTION
#### Related Issue: 689

#### Description of changes:

- Moved device type enums to endpoint object 
- Updates device/network_endpoint objects to have specific type requirements/descriptions

<img width="1359" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/3b6528f4-78ad-4c3a-9b80-902b133135da">
