### PR TITLE
Issue-703: Remove url_string, path and hostname requirements

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3135,7 +3135,7 @@
     },
     "url_string": {
       "caption": "URL String",
-      "description": "The URL string.  See RFC 1738. For example: <code>http://www.example.com/download/trouble.exe</code>.",
+      "description": "The URL string. See RFC 1738. For example: <code>http://www.example.com/download/trouble.exe</code>.",
       "type": "url_t"
     },
     "user": {

--- a/objects/url.json
+++ b/objects/url.json
@@ -11,11 +11,11 @@
     },
     "hostname": {
       "description": "The URL host as extracted from the URL. For example: <code>www.example.com</code> from <code>www.example.com/download/trouble</code>.",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "path": {
       "description": "The URL path as extracted from the URL. For example: <code>/download/trouble</code> from <code>www.example.com/download/trouble</code>.",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "port": {
       "description": "The URL port. For example: <code>80</code>.",
@@ -34,7 +34,14 @@
       "requirement": "optional"
     },
     "url_string": {
-      "requirement": "required"
+      "description": "The URL string. See RFC 1738. For example: <code>http://www.example.com/download/trouble.exe</code>. Note: The URL path should not populate the URL string.",
+      "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "url_string",
+      "path"
+    ]
   }
 }


### PR DESCRIPTION
#### Related Issue: #703 

#### Description of changes:
- Changed `path, hostname, url_string` attribute requirements from required to recommended
- Added a constraint that requires either `path` or `url_string` to be available
- Added a note to the end of `url_string` in the url object indicating not to use this attribute for the path.

<img width="1384" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/b16f41ab-63cc-4ce6-8091-780a4e5a9439">



