### PR TITLE
Merge Changes: New attributes and object for patch metadata (kb_article)

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -319,6 +319,11 @@
       "description": "The operating system build number.",
       "type": "string_t"
     },
+    "bulletin": {
+      "caption": "Patch Bulletin",
+      "description": "The vendor bulletin identfier.",
+      "type": "string_t"
+    },
     "bytes": {
       "caption": "Total Bytes",
       "default": 0,
@@ -711,6 +716,11 @@
       "sibling": "classifications",
       "type": "integer_t"
     },
+    "classification": {
+      "caption": "Classification",
+      "description": "The classification as defined by the vendor.",
+      "type": "string_t"
+    },
     "classifications": {
       "caption": "Classifications",
       "description": "The list of malware classifications, normalized to the captions of the classification_id values. In the case of 'Other', they are defined by the event source.",
@@ -921,6 +931,11 @@
     "country": {
       "caption": "Country",
       "description": "The ISO 3166-1 Alpha-2 country code. For the complete list of country codes see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en' >ISO 3166-1 alpha-2 codes</a>.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
+      "type": "string_t"
+    },
+    "cpe": {
+      "caption": "The product CPE identifier",
+      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>).",
       "type": "string_t"
     },
     "cpu_bits": {
@@ -1753,6 +1768,11 @@
       "group": "context",
       "description": "The user's job title.",
       "type": "string_t"
+    },
+    "kb_article": {
+      "caption": "The KB Article object contains metadata that describes the patch or update.",
+      "description": "The KB article data related to the entity",
+      "type": "kb_article"
     },
     "kb_articles": {
       "caption": "Knowledgebase Articles",
@@ -2976,6 +2996,11 @@
       "caption": "Subnet UID",
       "description": "The unique identifier of a virtual subnet.",
       "type": "string_t"
+    },
+    "superseded": {
+      "caption": "The patch is superseded.",
+      "description": "The vendor patch has been replaced by another.",
+      "type": "boolean_t"
     },
     "supporting_data": {
       "caption": "Supporting Data",

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -40,10 +40,6 @@
       "description": "The size in bytes for the kb article.",
       "requirement": "optional"
     },
-    "related_vulnerabilities": {
-      "description": "A list of related vulnerabilities to the kb article.",
-      "requirement": "optional"
-    },
     "src_url": {
       "description": "The kb article link from the source vendor.",
       "requirement": "optional"

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -1,0 +1,56 @@
+{
+  "caption": "KB Article",
+  "description": "The KB Article object contains metadata that describes the patch or update.",
+  "extends": "object",
+  "name": "kb_article",
+  "attributes": {
+    "title": {
+      "description": "The title of the kb article.",
+      "requirement": "recommended"
+    },
+    "uid": {
+      "description": "The unique identifier for the kb article.",
+      "requirement": "required"
+    },
+    "os": {
+      "description": "The operating system the kb article applies.",
+      "requirement": "recommended"
+    },
+    "severity": {
+      "description": "The severity of the kb article.",
+      "requirement": "recommended"
+    },
+    "bulletin": {
+      "description": "The kb article bulletin identifier.",
+      "requirement": "optional"
+    },
+    "product": {
+      "description": "The product details the kb article applies.",
+      "requirement": "optional"
+    },
+    "superseded": {
+      "description": "The kb article has been replaced by another.",
+      "requirement": "optional"
+    },
+    "created_time": {
+      "description": "The date the kb article was released by the vendor.",
+      "requirement": "optional"
+    },
+    "size": {
+      "description": "The size in bytes for the kb article.",
+      "requirement": "optional"
+    },
+    "related_vulnerabilities": {
+      "description": "A list of related vulnerabilities to the kb article.",
+      "requirement": "optional"
+    },
+    "src_url": {
+      "description": "The kb article link from the source vendor.",
+      "requirement": "optional"
+    },
+    "classification": {
+      "description": "The vendors classification of the kb article.",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/discussions/684

#### Related PR:
https://github.com/ocsf/ocsf-schema/pull/698

#### Objective:
This includes attribute and object changes to allow optional enrichment of vulnerability class with patch/update meta data. The new object kb_article replaces an attribute kb_articles and contains additional details regarding the specific patch. This change will allow allow direct mapping of patch "findings" (forthcoming).

#### Change Details:
1. New attributes: bulletin, classification, cpe, superseded, 
2. New Class: kb_article