### PR TITLE
Issue 710: Update Network Interface Object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2052,7 +2052,7 @@
     },
     "network_interfaces": {
       "caption": "Network Interfaces",
-      "description": "The network interfaces that are associated with the device, one for each MAC address/IP address combination.<p><b>Note:</b> The first element of the array is the network information that pertains to the event.</p>",
+      "description": "The network interfaces that are associated with the device, one for each unique MAC address/IP address/hostname/name combination.<p><b>Note:</b> The first element of the array is the network information that pertains to the event.</p>",
       "is_array": true,
       "type": "network_interface"
     },
@@ -2987,6 +2987,11 @@
       "caption": "Subnet",
       "description": "The subnet mask.",
       "type": "subnet_t"
+    },
+    "subnet_prefix": {
+      "caption": "Subnet Prefix Length",
+      "description": "The subnet prefix length determines the number of bits used to represent the network part of the IP address. The remaining bits are reserved for identifying individual hosts within that subnet.",
+      "type": "integer_t"
     },
     "subnet_uid": {
       "caption": "Subnet UID",

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -1,6 +1,6 @@
 {
   "caption": "Network Interface",
-  "description": "The Network Interface object describes the type and associated addresses of a network interface.",
+  "description": "The Network Interface object describes the type and associated attributes of a network interface.",
   "extends": "_entity",
   "name": "network_interface",
   "attributes": {
@@ -22,6 +22,9 @@
     "namespace": {
       "requirement": "optional"
     },
+    "subnet_prefix": {
+      "requirement": "optional"
+    },
     "type": {
       "description": "The type of network interface.",
       "requirement": "optional"
@@ -40,6 +43,9 @@
         },
         "3": {
           "caption": "Mobile"
+        },
+        "4": {
+          "caption": "VPN"
         },
         "99": {
           "caption": "Other"

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -45,7 +45,7 @@
           "caption": "Mobile"
         },
         "4": {
-          "caption": "VPN"
+          "caption": "Tunnel"
         },
         "99": {
           "caption": "Other"


### PR DESCRIPTION
#### Related Issue: #710 

#### Description of changes:

- Update network interfaces description to make it clear that each interface in the array is a unique ip/mac/hostname/name value
- Update network interface description to make it clear that we do not have multiple addresses in the object
- Add VPN type to network interface
- Add subnet_prefix attribute to network interface object 

<img width="1364" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/68113ec1-ced2-47ee-afa3-55a0444d462f">



<img width="1375" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/97c87077-d924-4566-80ae-cb0285847b21">
