### PR TITLE
Add cpe attribute to product object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -949,9 +949,9 @@
       "description": "The ISO 3166-1 Alpha-2 country code. For the complete list of country codes see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en' >ISO 3166-1 alpha-2 codes</a>.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
       "type": "string_t"
     },
-    "cpe": {
+    "cpe_name": {
       "caption": "The product CPE identifier",
-      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>).",
+      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>) For example: <code>cpe:/a:apple:safari:16.2</code>.",
       "type": "string_t"
     },
     "cpu_bits": {

--- a/objects/product.json
+++ b/objects/product.json
@@ -5,8 +5,8 @@
   "name": "product",
   "attributes": {
     "feature": {},
-    "cpe": {
-      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>).",
+    "cpe_name": {
+      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>) For example: <code>cpe:/a:apple:safari:16.2</code>.",
       "requirement": "optional"
     },
     "lang": {

--- a/objects/product.json
+++ b/objects/product.json
@@ -6,7 +6,7 @@
   "attributes": {
     "feature": {},
     "cpe_name": {
-      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>) For example: <code>cpe:/a:apple:safari:16.2</code>.",
+      "description": "The Common Platform Enumeration (CPE) name for the product.",
       "requirement": "optional"
     },
     "lang": {

--- a/objects/product.json
+++ b/objects/product.json
@@ -6,7 +6,6 @@
   "attributes": {
     "feature": {},
     "cpe_name": {
-      "description": "The Common Platform Enumeration (CPE) name for the product.",
       "requirement": "optional"
     },
     "lang": {

--- a/objects/product.json
+++ b/objects/product.json
@@ -5,6 +5,10 @@
   "name": "product",
   "attributes": {
     "feature": {},
+    "cpe": {
+      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>).",
+      "requirement": "optional"
+    },
     "lang": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/discussions/684

#### Related PR:
https://github.com/ocsf/ocsf-schema/pull/698

####Objective:
This includes addition of `cpe` attribute to the `product` object. This change will allow `vulnerability` object to include `cpe` from `product` object to better describe a software product.

####Change Details:
Edit the product object to include optional `cpe` attribute