### PR TITLE
Issue 711:  Change Interface Attribute in DCE/RPC Object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1669,6 +1669,11 @@
       "enum": {},
       "type": "integer_t"
     },
+    "interface": {
+      "caption": "Remote Procedure Call Interface",
+      "description": "The RPC Interface object describes the details pertaining to the remote procedure call interface.",
+      "type": "interface"
+    },
     "interface_name": {
       "caption": "Network Interface Name",
       "description": "The name of the network interface (e.g. eth2).",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2649,7 +2649,7 @@
     "rpc_interface": {
       "caption": "Remote Procedure Call Interface",
       "description": "The RPC Interface object describes the details pertaining to the remote procedure call interface.",
-      "type": "interface"
+      "type": "rpc_interface"
     },
     "rule": {
       "caption": "Rule",

--- a/dictionary.json
+++ b/dictionary.json
@@ -34,6 +34,16 @@
       "description": "The account object describes details about the account that was the source or target of the activity.",
       "type": "account"
     },
+    "ack_reason": {
+      "caption": "Acknowledgement Reason",
+      "description": "An integer that provides a reason code or additional information about the acknowledgment result.",
+      "type": "integer_t"
+    },
+    "ack_result": {
+      "caption": "Acknowledgement Result",
+      "description": "An integer that denotes the acknowledgment result of the DCE/RPC call.",
+      "type": "integer_t"
+    },
     "activity_id": {
       "caption": "Activity ID",
       "description": "The normalized identifier of the activity that triggered the event.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1669,11 +1669,6 @@
       "enum": {},
       "type": "integer_t"
     },
-    "interface": {
-      "caption": "Remote Procedure Call Interface",
-      "description": "The RPC Interface object describes the details pertaining to the remote procedure call interface.",
-      "type": "interface"
-    },
     "interface_name": {
       "caption": "Network Interface Name",
       "description": "The name of the network interface (e.g. eth2).",
@@ -2650,6 +2645,11 @@
       "caption": "Risk Score",
       "description": "The risk score as reported by the event source.",
       "type": "integer_t"
+    },
+    "rpc_interface": {
+      "caption": "Remote Procedure Call Interface",
+      "description": "The RPC Interface object describes the details pertaining to the remote procedure call interface.",
+      "type": "interface"
     },
     "rule": {
       "caption": "Rule",

--- a/objects/dce_rpc.json
+++ b/objects/dce_rpc.json
@@ -16,7 +16,7 @@
       "description": "The list of interface flags.",
       "requirement": "required"
     },
-    "interface": {
+    "rpc_interface": {
       "requirement": "required"
     },
     "opnum": {

--- a/objects/dce_rpc.json
+++ b/objects/dce_rpc.json
@@ -16,8 +16,7 @@
       "description": "The list of interface flags.",
       "requirement": "required"
     },
-    "network_interfaces": {
-      "description": "The list of DCE/RPC interfaces",
+    "interface": {
       "requirement": "required"
     },
     "opnum": {

--- a/objects/interface.json
+++ b/objects/interface.json
@@ -1,0 +1,22 @@
+{
+  "caption": "RPC Interface",
+  "name": "interface",
+  "description": "The RPC Interface represents the remote procedure call interface used in the DCE/RPC session.",
+  "extends": "object",
+  "attributes": {
+    "ack_reason": {
+      "requirement": "recommended"
+    },
+    "ack_result": {
+      "requirement": "recommended"
+    },
+    "uuid": {
+      "description": "The unique identifier of the particular remote procedure or service.",
+      "requirement": "required"
+    },
+    "version": {
+      "description": "The version of the DCE/RPC protocol being used in the session.",
+      "requirement": "required"
+    }
+  }
+}

--- a/objects/rpc_interface.json
+++ b/objects/rpc_interface.json
@@ -1,6 +1,6 @@
 {
   "caption": "RPC Interface",
-  "name": "interface",
+  "name": "rpc_interface",
   "description": "The RPC Interface represents the remote procedure call interface used in the DCE/RPC session.",
   "extends": "object",
   "attributes": {


### PR DESCRIPTION
#### Related Issue: #711 

#### Description of changes:

- Created new rpc interface object and new attributes for it
- Removed `network_interfaces` from DCE/RPC object and replaced with new `interface` object

<img width="1447" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/a30552f9-f0fa-4d34-b425-7cbb163d3b0a">

<img width="1444" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/46493a98-3ad9-45c5-a78c-8687be429071">

