### PR TITLE
A few adjustments to the new Vulnerability findings class

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1417,6 +1417,11 @@
       "description": "The initial detection time of the activity or object. See specific usage",
       "type": "timestamp_t"
     },
+    "fixed_in_version": {
+      "caption": "Fixed In Version",
+      "description": "The software package version in which a reported vulnerability was patched/fixed.",
+      "type": "string_t"
+    },
     "fix_available": {
       "caption": "Fix Availability",
       "description": "Indicates if a fix is available for the reported vulnerability.",
@@ -1776,16 +1781,11 @@
       "description": "The user's job title.",
       "type": "string_t"
     },
-    "kb_article": {
-      "caption": "The KB Article object contains metadata that describes the patch or update.",
-      "description": "The KB article data related to the entity",
-      "type": "kb_article"
-    },
     "kb_articles": {
       "caption": "Knowledgebase Articles",
-      "description": "The KB article/s related to the entity",
+      "description": "The KB article/s related to the entity. A KB Article contains metadata that describes the patch or an update.",
       "is_array": true,
-      "type": "string_t"
+      "type": "kb_article"
     },
     "kernel": {
       "caption": "Kernel",
@@ -2926,6 +2926,12 @@
       "caption": "Source URL",
       "description": "The URL pointing towards the source of an entity. See specific usage.",
       "type": "url_t"
+    },
+    "standards":{
+      "caption": "Security Standards",
+      "description": "A list of security standards associated to a compliance finding.",
+      "is_array": true,
+      "type": "string_t"
     },
     "start_address": {
       "caption": "Start Address",

--- a/events/findings/vulnerability_finding.json
+++ b/events/findings/vulnerability_finding.json
@@ -36,10 +36,6 @@
       "group": "primary",
       "requirement": "recommended"
     },
-    "remediation": {
-      "group": "context",
-      "requirement": "optional"
-    },
     "status": {
       "description": "The normalized status of the vulnerability finding.",
       "group": "context",

--- a/objects/affected_package.json
+++ b/objects/affected_package.json
@@ -4,7 +4,17 @@
   "extends": "package",
   "name": "affected_package",
   "attributes": {
+    "fixed_in_version": {
+      "requirement": "optional"
+    },
     "package_manager": {
+      "requirement": "optional"
+    },
+    "path": {
+      "description": "The installation path of the affected package.",
+      "requirement": "optional"
+    },
+    "remediation": {
       "requirement": "optional"
     }
   }

--- a/objects/remediation.json
+++ b/objects/remediation.json
@@ -6,10 +6,11 @@
   "attributes": {
     "desc": {
       "description": "The description of the remediation strategy.",
-      "requirement": "optional"
+      "requirement": "required"
     },
-    "kb_articles": {
-      "requirement": "recommended"
+    "references": {
+      "description": "A list of supporting URL/s, references that help describe the remediation strategy.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -20,6 +20,9 @@
     "fix_available": {
       "requirement": "optional"
     },
+    "kb_articles": {
+      "requirement": "optional"
+    },
     "last_seen_time": {
       "description": "The time when the vulnerability was most recently observed.",
       "requirement": "optional"
@@ -29,6 +32,10 @@
       "requirement": "recommended"
     },
     "related_vulnerabilities": {
+      "requirement": "optional"
+    },
+    "remediation": {
+      "description": "The remediation recommendations on how to mitigate the identified vulnerability.",
       "requirement": "optional"
     },
     "severity": {


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/discussions/684

#### Description of changes:
1. Adding `fixed_in_version`, `kb_articles` (attribute only) and `standards` to dictionary
2. Replacing `kb_articles` with `references` in `remediation` object
3. Adding `kb_articles` and `remediation` in `vulnerability` object
4. Adding `fixed_in_version`, `path`, `remediation` in `affected_package` object
5. Removing `remediation` from the base vulnerability finding class, (each vulnerability has it's own contextual remediation) 
