### PR TITLE
[DRAFT] security_alert object draft (based on security_incident and current security_finding)

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -86,6 +86,11 @@
       "description": "The integer value of TLS alert if present. The alerts are defined in the TLS specification in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc2246'>RFC-2246</a>.",
       "type": "integer_t"
     },
+    "alert_uid": {
+      "caption": "Alert UID",
+      "description": "The unique identifier of the alert.",
+      "type": "integer_t"
+    },
     "algorithm": {
       "caption": "Algorithm",
       "description": "The applicable algorithm, normalized to the caption of 'algorithm_id'. See specific usage.",
@@ -139,6 +144,11 @@
     "args": {
       "caption": "HTTP Arguments",
       "description": "The arguments sent along with the HTTP request.",
+      "type": "string_t"
+    },
+    "assignee": {
+      "caption": "Assignee",
+      "description": "The name of the assigned person.",
       "type": "string_t"
     },
     "attempt": {
@@ -2581,6 +2591,43 @@
       "is_array": true,
       "type": "string_t"
     },
+    "resolution": {
+      "caption": "Resolution",
+      "description": "The resolution detail for closing the incident.",
+      "type": "string_t"
+    },
+    "resolution_id": {
+      "caption": "Resolution ID",
+      "description": "The normalized identifier of the resolution detail, populated when closing an incident.",
+      "enum": {
+        "99": {
+          "caption": "Other"
+        },
+        "0": {
+          "caption": "Unknown"
+        },
+        "1": {
+          "caption": "Insufficient data"
+        },
+        "2": {
+          "caption": "Security risk"
+        },
+        "3": {
+          "caption": "False positive"
+        },
+        "4": {
+          "caption": "Managed externally"
+        },
+        "5": {
+          "caption": "Benign"
+        },
+        "6": {
+          "caption": "Test"
+        }
+      },
+      "sibling": "resolution",
+      "type": "integer_t"
+    },
     "resource": {
       "caption": "Resource",
       "description": "The target resource.",
@@ -3042,6 +3089,11 @@
       "caption": "Surname",
       "description": "The last or family name for the user.",
       "type": "string_t"
+    },
+    "suspected_breach": {
+      "caption": "Suspected Breach",
+      "description": "A determination based on analytics whether a potential breach was found.",
+      "type": "boolean_t"
     },
     "svc_name": {
       "caption": "Service Name",

--- a/enums/incident_state.json
+++ b/enums/incident_state.json
@@ -1,0 +1,32 @@
+{
+    "enum": {
+      "0": {
+        "caption": "Unknown",
+        "description": "The incident state is not known."
+      },
+      "1": {
+        "caption": "New",
+        "description": "The service desk has received the incident but has not assigned it to an agent."
+      },
+      "2": {
+        "caption": "In Progress",
+        "description": "The incident has been assigned to an agent but has not been resolved. The agent is actively working with the user to diagnose and resolve the incident."
+      },
+      "3": {
+        "caption": "On Hold",
+        "description": "The incident requires some information or response from the user or from a third party."
+      },
+      "4": {
+        "caption": "Resolved",
+        "description": "The service desk has confirmed that the incident is resolved."
+      },
+      "5": {
+        "caption": "Closed",
+        "description": "The incident is resolved and no further action is necessary."
+      },
+      "99": {
+        "caption": "Other",
+        "description": "The incident state is other. See the State attribute."
+      }
+    }
+  }

--- a/enums/priority.json
+++ b/enums/priority.json
@@ -1,0 +1,28 @@
+{
+    "enum": {
+      "0": {
+        "description": "No priority is assigned.",
+        "caption": "Unknown"
+      },
+      "1": {
+        "description": "Application or personal procedure unusable, where a workaround is available or a repair is possible.",
+        "caption": "Low"
+      },
+      "2": {
+        "description": "Non-critical function or procedure, unusable or hard to use having an operational impact, but with no direct impact on services availability. A workaround is available.",
+        "caption": "Medium"
+      },
+      "3": {
+        "description": "Critical functionality or network access interrupted, degraded or unusable, having a severe impact on services availability. No acceptable alternative is possible.",
+        "caption": "High"
+      },
+      "4": {
+        "description": "Interruption making a critical functionality inaccessible or a complete network interruption causing a severe impact on services availability. There is no possible alternative.",
+        "caption": "Critical"
+      },
+      "99": {
+        "description": "The priority is not normalized.",
+        "caption": "Other"
+      }
+    }
+  }

--- a/events/findings/security_alert.json
+++ b/events/findings/security_alert.json
@@ -2,7 +2,7 @@
   "caption": "Security Alert",
   "category": "findings",
   "description": "Security Alert events report the creation, update, or closure of alerts as a result of detections and/or analytics.",
-  "extends": "finding",
+  "extends": "base_event",
   "name": "security_alert",
   "uid": 3,
   "attributes": {
@@ -32,6 +32,10 @@
       "group": "primary",
       "requirement": "optional"
     },
+    "finding": {
+      "group": "primary",
+      "requirement": "required"
+    },
     "impact": {
       "group": "primary",
       "requirement":"optional"
@@ -59,6 +63,10 @@
       "requirement": "recommended",
       "$include": "enums/priority.json"
     },
+    "remediation": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "resolution": {
       "group": "primary",
       "requirement": "optional"
@@ -66,6 +74,10 @@
     "resolution_id": {
       "group": "primary",
       "requirement": "optional"
+    },
+    "rule": {
+      "group": "primary",
+      "requirement": "recommended"
     },
     "state": {
       "description": "The alert state.",
@@ -80,21 +92,6 @@
     },
     "suspected_breach": {
       "group": "primary",
-      "requirement": "optional"
-    },
-    "rule_id": {
-      "description": "The identifier of the rule that triggered the alert",
-      "group": "classification",
-      "requirement": "optional"
-    },
-    "rule_name": {
-      "description": "The name of the rule that triggered the alert",
-      "group": "classification",
-      "requirement": "optional"
-    },
-    "rule_type": {
-      "description": "The type of rule that triggered the alert, e.g. custom-defined or built-in",
-      "group": "classification",
       "requirement": "optional"
     },
     "user": {

--- a/events/findings/security_alert.json
+++ b/events/findings/security_alert.json
@@ -1,0 +1,106 @@
+{
+  "caption": "Security Alert",
+  "category": "findings",
+  "description": "Security Alert events report the creation, update, or closure of alerts as a result of detections and/or analytics.",
+  "extends": "finding",
+  "name": "security_alert",
+  "uid": 3,
+  "attributes": {
+    "alert_uid": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "assignee": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "attacks": {
+      "description": "An array of attacks associated with the alert.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "comment": {
+      "description": "Additional user supplied details for creating, updating or closing the alert.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "confidence": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "confidence_id": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "impact": {
+      "group": "primary",
+      "requirement":"optional"
+    },
+    "impact_id": {
+      "group": "primary",
+      "requirement": "recommended",
+      "sibling": "impact"
+    },
+    "impact_score": {
+      "group": "primary",
+      "requirement":"optional"
+    },
+    "kill_chain": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "priority": {
+      "description": "The priority name, as defined by <code>priority_id</code> enum value.",
+      "group": "primary"
+    },
+    "priority_id": {
+      "description": "The normalized priority.</p>Priority identifies the relative importance of the alert. It is a measurement of urgency.",
+      "group": "primary",
+      "requirement": "recommended",
+      "$include": "enums/priority.json"
+    },
+    "resolution": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "resolution_id": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "state": {
+      "description": "The alert state.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "state_id": {
+      "description": "The alert state identifier.",
+      "group": "primary",
+      "requirement": "required",
+      "$include": "enums/incident_state.json"
+    },
+    "suspected_breach": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "rule_id": {
+      "description": "The identifier of the rule that triggered the alert",
+      "group": "classification",
+      "requirement": "optional"
+    },
+    "rule_name": {
+      "description": "The name of the rule that triggered the alert",
+      "group": "classification",
+      "requirement": "optional"
+    },
+    "rule_type": {
+      "description": "The type of rule that triggered the alert, e.g. custom-defined or built-in",
+      "group": "classification",
+      "requirement": "optional"
+    },
+    "user": {
+      "description": "The creator of the rule that triggered the alert, or the user associated with an alert update or closure.",
+      "group": "primary",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
Draft of Security Alert event (within Findings category). Not currently testing against OCSF server. **I will be redoing this proposal based on conversations from the OCSF weekly call.**

**Notes and questions:** 
- Need better description for security alert (i.e. how to differentiate between alert and incident)
- If finding class is not to be extended by alert and incident, and since it's so barebones, why is it still here? Is anyone using it? Can we refactor it so that it can be a generic class from which both incident and alert inherit? 
- Deeper-dive discussion into Conclusions vs. Findings; single Security Alert should have one finding/conclusion, whereas single Security Incident could have multiple findings/conclusions
- Since Vulnerability Finding was published as UID 2, should make Security Alert UID 3 and Security Incident UID 4
- Re: the description for “comment” attribute, comments should be allowed upon creation of alert/incident, not just update or close (e.g. creation of a test incident); also, do we like the name “comment” or should we change it to “notes” (e.g. analyst notes)? Should that be an object unto itself, with user, comment, date attributes? Array of comments vs. singleton comment? 
- Tags attribute? 
- What to do re: Security Control profile and overlap of certain profile fields getting added directly to the Security-related objects. Since this is an explicit Security Alert, should we automatically apply that profile? (Same question for Security Incident.) If so, can remove Attacks from Security Alert definition. Almost wondering if the profile fields should be baked directly into the Security Alert and Security Incident objects because they’re so essential. (Based on this answer, may need to add malware and disposition attributes to Security Alert/Security Incident later on as well.)
- Why is Attacks in Security Control profile but not Kill Chain? Consider adding to profile. 
- Also re: Security Control profile, this would need to be added to the overall Security Alert/Security Incident wrapper object as well as the individual event objects. For example, a Security Incident can have an overall Attacks array for all TTPs found in the incident, but each contributing event to the incident will have a subset of those TTPs that should be listed in its own Attacks object. Likewise, a Security Alert might have one overall disposition but the individual pieces of evidence may have their own disposition values. 
- Separate from disposition, should we introduce a verdict attribute for the security alert? E.g. verdict could be suspicious, malicious, etc. 
- Included the same priority enum for Security Alert from Security Incident, but I think the descriptions need to be more generalized.  Shouldn’t just be based on availability/functionality of device/network but also how likely the alert is truly malicious and can cause immediate compromise or breach.
- Similar issue as above for state and state_id from Security Incident. 
- Need to have a broader severity vs. priority discussion. Why is priority introduced as an enum but severity ID isn’t? Most MDRs will use one or the other field to determine triaging order, and sometimes there are used interchangeably. Should have well-defined descriptions to ensure standard use across vendors and consumers of data. 
- Will Type UID will be calculated automatically, or does it have to be defined manually? 
- Is there a way to *hide*/discourage devs from populating Alert fields that were inherited from base event? (E.g. all the status fields, which should really be populated in the individual Evidence events) 
- URL attributes: There is almost always a primary URL for Security Alerts/Incidents to view directly in a portal/dashboard, but some vendors give secondary and even tertiary URLs (e.g. a URL to see where else this file or application is used in the customer's environment). Again, need to better define which URL attributes should be used for which URLs. There's a URL field in metadata, a URL field in finding (assuming Security Alert should still use that), and we may want to introduce another URL field directly into the Security Alert object itself. Should consider this as well for Security Incident. 
- In Security Incident, start_time and end_time are defined, but these should be inherited from base event, so why are they redefined in the Security Incident object? 
- In dictionary, rule is not defined as an array, but the caption says rules plural. Should change it to singular "rule." 
