### PR TITLE
Add sub_technique attribute to the attack object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3110,6 +3110,11 @@
       "description": "The system call that was invoked.",
       "type": "string_t"
     },
+    "sub_technique": {
+      "caption": "Sub Technique",
+      "description": "The MITRE ATT&CK® sub-technique.",
+      "type": "technique"
+    },
     "tactics": {
       "caption": "Tactics",
       "description": "The a list of tactic ID's/names that are associated with the attack technique, as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",
@@ -3128,7 +3133,7 @@
     },
     "technique": {
       "caption": "Technique",
-      "description": "The attack technique.",
+      "description": "The MITRE ATT&CK® technique.",
       "type": "technique"
     },
     "terminated_time": {

--- a/objects/attack.json
+++ b/objects/attack.json
@@ -4,6 +4,9 @@
   "description": "The Attack object describes the technique and associated tactics related to an attack. See <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a>.",
   "extends": "object",
   "attributes": {
+    "sub_technique": {
+      "requirement": "optional"
+    },
     "tactics": {
       "requirement": "required"
     },


### PR DESCRIPTION
Add an optional `sub_technique` attribute to the MITRE `attack` object.