### PR TITLE
Clean up CIS benchmark and control objects

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -696,9 +696,20 @@
       "description": "The CIS benchmark result.",
       "type": "cis_benchmark_result"
     },
+    "cis_benchmark": {
+      "caption": "CIS Benchmark",
+      "description": "The CIS Benchmark describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the Center for Internet Security (<a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>CIS</a>).",
+      "type": "cis_benchmark"
+    },
     "cis_csc": {
       "caption": "CIS CSC",
       "description": "The CIS Critical Security Controls is a list of top 20 actions and practices an organization’s security team can take on such that cyber attacks or malware, are minimized and prevented.",
+      "is_array": true,
+      "type": "cis_control"
+    },
+    "cis_controls": {
+      "caption": "CIS Controls",
+      "description": "The CIS Critical Security Controls is a prioritized set of actions to protect your organization and data from cyber-attack vectors.",
       "is_array": true,
       "type": "cis_control"
     },

--- a/objects/cis_benchmark.json
+++ b/objects/cis_benchmark.json
@@ -1,0 +1,19 @@
+{
+  "caption": "CIS Benchmark",
+  "description": "The CIS Benchmark object describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the <a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>Center for Internet Security</a>. See also <a target='_blank' href='https://www.cisecurity.org/insights/blog/getting-to-know-the-cis-benchmarks'>Getting to Know the CIS Benchmarks</a>.",
+  "extends": "object",
+  "name": "cis_benchmark",
+  "attributes": {
+    "cis_controls": {
+      "requirement": "recommended"
+    },
+    "desc": {
+      "description": "The CIS Benchmark description. For example: <i>The cramfs filesystem type is a compressed read-only Linux filesystem embedded in small footprint systems. A cramfs image can be used without having to first decompress the image.</i>",
+      "requirement": "optional"
+    },
+    "name": {
+      "description": "The CIS Benchmark name. For example: <i>Ensure mounting of cramfs filesystems is disabled.</i>",
+      "requirement": "required"
+    }
+  }
+}

--- a/objects/cis_control.json
+++ b/objects/cis_control.json
@@ -1,14 +1,19 @@
 {
     "caption": "CIS Control",
-    "description": "The CIS Control contains information as defined by the Center for Internet Security Critical Security Control <a target='_blank' href='https://www.cisecurity.org/controls'>(CIS CSC)</a>. Prioritized set of actions to protect your organization and data from cyber-attack vectors.",
+    "description": "The CIS Control (aka Critical Security Control) object describes a prioritized set of actions to protect your organization and data from cyber-attack vectors. The <a target='_blank' href='https://www.cisecurity.org/controls'>CIS Controls</a> are defined by the Center for Internet Security.",
     "extends": "object",
     "name": "cis_control",
     "attributes": {
-      "control": {
+      "desc": {
+        "description": "The CIS Control description. For example: <i>Uninstall or disable unnecessary services on enterprise assets and software, such as an unused file sharing service, web application module, or service function.</i>",
+        "requirement": "optional"
+      },
+      "name": {
+        "description": "The CIS Control name. For example: <i>4.8 Uninstall or Disable Unnecessary Services on Enterprise Assets and Software.</i>",
         "requirement": "required"
       },
       "version": {
-        "description": "The CIS critical security control version.",
+        "description": "The CIS Control version. For example: <i>v8</i>.",
         "requirement": "recommended"
       }
     }


### PR DESCRIPTION
Clean up and improve the CIS benchmark and control objects.

The existing benchmark object was wrongly named as `cis_benchmark_result`. The CIS benchmark is a recommendation, not a result of a query or something else.

The new `cis_benchmark` object has a list of `cis_controls` as per the CIS documentation. Also, in order to decouple remediation instructions from the CIS objects, the `remediation` attribute has been removed from the CIS benchmark object.