### PR TITLE
[DRAFT] Broaden the Security Control profile

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1700,6 +1700,11 @@
       "description": "The IP address, in either IPv4 or IPv6 format.",
       "type": "ip_t"
     },
+    "is_alert": {
+      "caption": "Alertable event",
+      "description": "The the event is alertable. See specific usage.",
+      "type": "boolean_t"
+    },
     "is_cleartext": {
       "caption": "Cleartext Credentials",
       "description": "Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>",
@@ -2496,6 +2501,18 @@
       "description": "The data describing the DNS resource. The meaning of this data depends on the type and class of the resource record.",
       "type": "string_t"
     },
+    "reason": {
+      "caption": "Reason",
+      "description": "The reason for the outcome, normalized to the caption of the reason_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "reason_id": {
+      "caption": "Reason ID",
+      "description": "The normalized identifier of the reason why the security control reported the disposition or the outcome.",
+      "enum":{},
+      "sibling": "reason",
+      "type": "integer_t"
+    },
     "references": {
       "caption": "References",
       "description": "A list of reference URLs supporting the finding/detection.",
@@ -2763,6 +2780,16 @@
         }
       },
       "sibling": "score",
+      "type": "integer_t"
+    },
+    "sec_control_type": {
+      "description": "The type of security control solution that produced the event, normalized to the caption of the sec_control_type_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "sec_control_type_id": {
+      "description": "The normalized type of security control solution that produced the event.",
+      "enum": {},
+      "sibling": "sec_control_type",
       "type": "integer_t"
     },
     "secure": {

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -1,5 +1,5 @@
 {
-  "description": "The attributes that identify security controls such as malware or policy violations.",
+  "description": "The attributes reported by security solutions that represent detections, alerts or policy violations.",
   "meta": "profile",
   "caption": "Security Control",
   "name": "security_control",
@@ -16,8 +16,84 @@
     "disposition_id": {
       "requirement": "required"
     },
+    "firewall_rule": {
+      "requirement": "optional"
+    },
+    "is_alert": {
+      "description": "The security control considered the event alertable.",
+      "requirement": "optional"
+    },
     "malware": {
       "requirement": "optional"
+    },
+    "reason": {
+      "description": "The reason for the outcome, normalized to the caption of the reason_id value. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "reason_id": {
+      "description": "The normalized identifier of the reason why the security control reported the disposition or the outcome.",
+      "enum":{
+        "0": {
+          "caption": "Unknown"
+        },
+        "1":{
+          "caption": "Malware Found"
+        },
+        "2":{
+          "caption": "Instrusion Detected"
+        },
+        "3":{
+          "caption": "Policy Violation"
+        },
+        "4":{
+          "caption": "Vulnerability"
+        },
+        "5":{
+          "caption": "Exposure"
+        },
+        "99":{
+          "caption": "Other"
+        }
+      },
+      "requirement": "recommended"
+    },
+    "sec_control_type": {
+      "description": "The type of security control solution that produced the event, normalized to the caption of the sec_control_type_id value. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "sec_control_type_id": {
+      "description": "The normalized type of security control solution that produced the event.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The type of security control is unknown."
+        },
+        "1": {
+          "caption": "Firewall",
+          "description": "The event was produced by a Firewall."
+        },
+        "2": {
+          "caption": "Email Service",
+          "description": "The event was produced by an Email Security solution."
+        },
+        "3": {
+          "caption": "Endpoint Security",
+          "description": "The event was produced by an Endpoint Security solution."
+        },
+        "4": {
+          "caption": "Gateway",
+          "description": "The event was produced by a Gateway or Proxy service."
+        },
+        "5":{
+          "caption": "DLP",
+          "description:": "The event was produced by a Data Loss Prevention solution."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The security control is not mapped."
+        }
+      },
+      "requirement": "required"
+      }
     }
   }
-}


### PR DESCRIPTION
This is in response to Issue #725 - an example of how the broader profile could be structured, including the flag that the security control event is alertable.  The enum of reasons and the control types are a starting point.

Although a specific `firewall_rule` is carried over from the `Firewall` profile, a more general `Policy` object from the `dev` repo could be resurrected for other policy types such as DLP.