### PR TITLE
Added LDAP attributes, DN and CN to the Person profile.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1864,6 +1864,16 @@
       "description": "TODO: The HTTP response latency. In seconds, milliseconds, etc.?",
       "type": "integer_t"
     },
+    "ldap_cn": {
+      "caption": "LDAP Common Name",
+      "description": "The LDAP and X.500 commonName attribute, from RFC4517: 'typically the full name of the person.'",
+      "type": "string_t"
+    },
+    "ldap_dn": {
+      "caption": "LDAP Distinguished Name",
+      "description": "The LDAP distinguished name , from RFC4517",
+      "type": "string_t"
+    },
     "lease_dur": {
       "caption": "Lease Duration",
       "description": "This represents the length of the DHCP lease in seconds. This is present in DHCP Ack events. (activity_id = 1)",

--- a/profiles/person.json
+++ b/profiles/person.json
@@ -36,6 +36,14 @@
     "last_login_time": {
       "requirement": "optional"
     },
+    "ldap_cn": {
+      "description": "The LDAP and X.500 commonName attribute, from RFC4517: 'typically the full name of the person.'",
+      "requirement": "optional"
+    },
+    "ldap_dn": {
+      "description": "The LDAP distinguished name , from RFC4517",
+      "requirement": "optional"
+    },
     "leave_datetime": {
       "requirement": "optional"
     },


### PR DESCRIPTION
The Person profile has many of the same attributes as the LDAP person objectclass, but the schema is missing the DN.  CN is the same as user.name but for consistency, I thought to add it.

We should consider looking at the other attributes, such as job_title, which corresponds to the LDAP organizationalPerson attribute `title` and name it `ldap_title` but that may be going too far, unless we want `Person` profile to actually implement the LDAP objectclass.
