### PR TITLE
Add cpe_name to os object

### DIFF
--- a/objects/os.json
+++ b/objects/os.json
@@ -11,6 +11,9 @@
       "description": "The operating system country code, as defined by the ISO 3166-1 standard (Alpha-2 code). For the complete list of country codes, see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en'>ISO 3166-1 alpha-2 codes</a>.",
       "requirement": "optional"
     },
+    "cpe_name": {
+      "requirement": "optional"
+    },
     "cpu_bits": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
New dictionary attribute for Common Platform Enumeration `cpe_name`.

#### Description of changes:
This change adds this newish attribute to the OS object for use in describing the operating system using the Common Platform Enumeration schema.
