### PR TITLE
Adding containers array to request and response object, to handle container activity logs

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3314,6 +3314,11 @@
       "caption": "Rate Limit",
       "description": "The rate limit for a rate-based rule.",
       "type": "integer_t"
+    },
+    "verbosity": {
+      "caption": "Verbosity",
+      "description": "The audit level at which an event was generated.",
+      "type": "string_t"
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2030,7 +2030,7 @@
     },
     "namespace": {
       "caption": "Namespace",
-      "description": "The namespace is useful in merger or acquisition situations. For example, when similar entities exists that you need to keep separate.",
+      "description": "The namespace is useful in merger or acquisition situations. For example, when similar entities exist that you need to keep separate.",
       "type": "string_t"
     },
     "namespace_pid": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -908,8 +908,8 @@
       "type": "container"
     },
     "containers": {
-      "caption": "Container",
-      "description": "The set of container objects in an event.",
+      "caption": "Containers",
+      "description": "When working with containerized applications, the set of containers which write to the standard the output of a particular logging driver. For example, this may be the set of containers involved in handling api requests and responses for a containerized application.",
       "is_array": true,
       "type": "container"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -907,6 +907,12 @@
       "description": "The information describing an instance of a container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd.",
       "type": "container"
     },
+    "containers": {
+      "caption": "Container",
+      "description": "The set of container objects in an event.",
+      "is_array": true,
+      "type": "container"
+    },
     "content_type": {
       "caption": "HTTP Content Type",
       "description": "The request header that identifies the original <a target='_blank' href='https://www.iana.org/assignments/media-types/media-types.xhtml'>media type </a> of the resource (prior to any content encoding applied for sending).",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1919,6 +1919,11 @@
       "description": "The detailed geographical location usually associated with an IP address.",
       "type": "location"
     },
+    "log_level": {
+      "caption": "Log Level",
+      "description": "The audit level at which an event was generated.",
+      "type": "string_t"
+    },
     "log_name": {
       "caption": "Log Name",
       "description": "The event log name. For example, syslog file name or Windows logging subsystem: Security.",
@@ -3320,11 +3325,6 @@
       "caption": "Rate Limit",
       "description": "The rate limit for a rate-based rule.",
       "type": "integer_t"
-    },
-    "log_level": {
-      "caption": "log_level",
-      "description": "The audit level at which an event was generated.",
-      "type": "string_t"
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3315,8 +3315,8 @@
       "description": "The rate limit for a rate-based rule.",
       "type": "integer_t"
     },
-    "verbosity": {
-      "caption": "Verbosity",
+    "log_level": {
+      "caption": "log_level",
       "description": "The audit level at which an event was generated.",
       "type": "string_t"
     }

--- a/events/application/api.json
+++ b/events/application/api.json
@@ -4,13 +4,7 @@
     "extends": "application",
     "caption": "API Activity",
     "name": "api_activity",
-    "profiles": [
-      "container"
-    ],
     "attributes": {
-        "$include": [
-          "profiles/container.json"
-        ],
         "activity_id": {
             "enum": {
                 "1": {

--- a/events/application/api.json
+++ b/events/application/api.json
@@ -4,7 +4,13 @@
     "extends": "application",
     "caption": "API Activity",
     "name": "api_activity",
+    "profiles": [
+      "container"
+    ],
     "attributes": {
+        "$include": [
+          "profiles/container.json"
+        ],
         "activity_id": {
             "enum": {
                 "1": {

--- a/objects/api.json
+++ b/objects/api.json
@@ -4,7 +4,7 @@
   "extends": "object",
   "name": "api",
   "attributes": {
-    "group": 
+    "group": {
       "description": "The information pertaining to the API group.",
       "requirement": "optional"
     },

--- a/objects/api.json
+++ b/objects/api.json
@@ -4,7 +4,8 @@
   "extends": "object",
   "name": "api",
   "attributes": {
-    "group": {
+    "group": 
+      "description": "The information pertaining to the API group.",
       "requirement": "optional"
     },
     "operation": {

--- a/objects/api.json
+++ b/objects/api.json
@@ -4,6 +4,9 @@
   "extends": "object",
   "name": "api",
   "attributes": {
+    "group": {
+      "requirement": "optional"
+    },
     "operation": {
       "requirement": "required"
     },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -21,6 +21,9 @@
     "log_version": {
       "requirement": "optional"
     },
+    "verbosity": {
+      "requirement": "optional"
+    },
     "logged_time": {},
     "modified_time": {
       "description": "The time when the event was last modified or enriched."

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -12,6 +12,9 @@
     "labels": {
       "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>"
     },
+    "log_level": {
+      "requirement": "optional"
+    },
     "log_name": {
       "requirement": "recommended"
     },
@@ -19,9 +22,6 @@
       "requirement": "recommended"
     },
     "log_version": {
-      "requirement": "optional"
-    },
-    "verbosity": {
       "requirement": "optional"
     },
     "logged_time": {},

--- a/objects/request.json
+++ b/objects/request.json
@@ -4,16 +4,16 @@
   "extends": "object",
   "name": "request",
   "attributes": {
+    "data": {
+      "description": "The additional data that is associated with the api request.",
+      "requirement": "optional"
+    },
     "flags": {
       "requirement": "optional"
     },
     "uid": {
       "description": "The unique request identifier.",
       "requirement": "required"
-    },
-    "data": {
-      "description": "The additional data that is associated with the api request.",
-      "requirement": "optional"
     }
   }
 }

--- a/objects/request.json
+++ b/objects/request.json
@@ -5,7 +5,8 @@
   "name": "request",
   "attributes": {
     "containers": {
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": "container"
     },
     "data": {
       "description": "The additional data that is associated with the api request.",

--- a/objects/request.json
+++ b/objects/request.json
@@ -5,8 +5,7 @@
   "name": "request",
   "attributes": {
     "containers": {
-      "requirement": "optional",
-      "profile": "container"
+      "requirement": "optional"
     },
     "data": {
       "description": "The additional data that is associated with the api request.",

--- a/objects/request.json
+++ b/objects/request.json
@@ -10,6 +10,10 @@
     "uid": {
       "description": "The unique request identifier.",
       "requirement": "required"
+    },
+    "data": {
+      "description": "The additional data that is associated with the api request.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/request.json
+++ b/objects/request.json
@@ -4,6 +4,9 @@
   "extends": "object",
   "name": "request",
   "attributes": {
+    "containers": {
+      "requirement": "optional"
+    },
     "data": {
       "description": "The additional data that is associated with the api request.",
       "requirement": "optional"

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -16,6 +16,10 @@
       "description": "The name of the related resource group.",
       "requirement": "optional"
     },
+    "namespace": {
+      "description": "The namespace is useful when similar entities exists that you need to keep separate.",
+      "requirement": "optional"
+    },
     "owner": {
       "description": "The identity of the service or user account that owns the resource.",
       "requirement": "recommended"

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -17,7 +17,7 @@
       "requirement": "optional"
     },
     "namespace": {
-      "description": "The namespace is useful when similar entities exists that you need to keep separate.",
+      "description": "The namespace is useful when similar entities exist that you need to keep separate.",
       "requirement": "optional"
     },
     "owner": {

--- a/objects/response.json
+++ b/objects/response.json
@@ -7,6 +7,10 @@
     "code": {
       "requirement": "recommended"
     },
+    "data": {
+      "description": "The additional data that is associated with the api response.",
+      "requirement": "optional"
+    },
     "error": {
       "requirement": "recommended"
     },

--- a/objects/response.json
+++ b/objects/response.json
@@ -8,8 +8,7 @@
       "requirement": "recommended"
     },
     "containers": {
-      "requirement": "optional",
-      "profile": "container"
+      "requirement": "optional"
     },
     "data": {
       "description": "The additional data that is associated with the api response.",

--- a/objects/response.json
+++ b/objects/response.json
@@ -8,7 +8,8 @@
       "requirement": "recommended"
     },
     "containers": {
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": "container"
     },
     "data": {
       "description": "The additional data that is associated with the api response.",

--- a/objects/response.json
+++ b/objects/response.json
@@ -7,6 +7,9 @@
     "code": {
       "requirement": "recommended"
     },
+    "containers": {
+      "requirement": "optional"
+    },
     "data": {
       "description": "The additional data that is associated with the api response.",
       "requirement": "optional"

--- a/profiles/container.json
+++ b/profiles/container.json
@@ -4,7 +4,7 @@
   "caption": "Container",
   "name": "container",
   "attributes": {
-    "container": {
+    "containers": {
       "requirement": "recommended"
     },
     "namespace_pid": {

--- a/profiles/container.json
+++ b/profiles/container.json
@@ -4,7 +4,7 @@
   "caption": "Container",
   "name": "container",
   "attributes": {
-    "containers": {
+    "container": {
       "requirement": "recommended"
     },
     "namespace_pid": {


### PR DESCRIPTION
Adding containers array to request and response object, to handle container activity logs

1. This change adds `group` as an `optional` to api object

2. This change adds `containers[]` as an `optional` to api.request
3. This change adds `data' as an `optional` to api.request
4. This change adds `containers[]` as an `optional` to api.response
5. This change adds `data' as an `optional` to api.response

6. This change adds `namespace' as an `optional` to resource_details
7. This change adds `log_level` as an `optional` to metadata object

8. This change adds `log_level` to dictionary
9. This change adds `containers[]` to dictionary





