### PR TITLE
New Object - Adding EPSS to CVE as an optional attribute

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1297,6 +1297,11 @@
       "description": "The software package epoch. Epoch is a way to define weighted dependencies based on version numbers.",
       "type": "integer_t"
     },
+    "epss": {
+      "caption": "EPSS",
+      "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild. (<a target='_blank' href='https://www.first.org/epss/'>EPSS</a>).",
+      "type": "epss"
+    },
     "error": {
       "caption": "Error Code",
       "description": "Error Code",

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "cve",
   "attributes": {
+    "created_time": {
+      "description": "The Record Creation Date identifies when the CVE ID was issued to a CVE Numbering Authority (CNA) or the CVE Record was published on the CVE List. Note that the Record Creation Date does not necessarily indicate when this vulnerability was discovered, shared with the affected vendor, publicly disclosed, or updated in CVE.",
+      "requirement": "recommended"
+    },
     "cvss": {
       "requirement": "recommended"
     },
@@ -14,18 +18,12 @@
       "description": "A brief description of the CVE Record.",
       "requirement": "optional"
     },
+    "epss":{
+      "requirement": "optional"
+    },
     "modified_time": {
       "description": "The Record Modified Date identifies when the CVE record was last updated.",
       "requirement": "optional"
-    },
-    "created_time": {
-      "description": "The Record Creation Date identifies when the CVE ID was issued to a CVE Numbering Authority (CNA) or the CVE Record was published on the CVE List. Note that the Record Creation Date does not necessarily indicate when this vulnerability was discovered, shared with the affected vendor, publicly disclosed, or updated in CVE.",
-      "requirement": "recommended"
-    },
-    "uid": {
-      "caption": "CVE ID",
-      "description": "The Common Vulnerabilities and Exposures unique number assigned to a specific computer vulnerability. A CVE Identifier begins with 4 digits representing the year followed by a sequence of digits that acts as a unique identifier. For example: <code>CVE-2021-12345</code>.",
-      "requirement": "required"
     },
     "product": {
       "description": "The product where the vulnerability was discovered.",
@@ -43,6 +41,11 @@
       "caption": "Vulnerability Type",
       "description": "<p>The vulnerability type as selected from a large dropdown menu during CVE refinement.</p>Most frequently used vulnerability types are: <code>DoS</code>, <code>Code Execution</code>, <code>Overflow</code>, <code>Memory Corruption</code>, <code>Sql Injection</code>, <code>XSS</code>, <code>Directory Traversal</code>, <code>Http Response Splitting</code>, <code>Bypass something</code>, <code>Gain Information</code>, <code>Gain Privileges</code>, <code>CSRF</code>, <code>File Inclusion</code>. For more information see <a target='_blank' href='https://www.cvedetails.com/vulnerabilities-by-types.php'>Vulnerabilities By Type</a> distributions.",
       "requirement": "recommended"
+    },
+    "uid": {
+      "caption": "CVE ID",
+      "description": "The Common Vulnerabilities and Exposures unique number assigned to a specific computer vulnerability. A CVE Identifier begins with 4 digits representing the year followed by a sequence of digits that acts as a unique identifier. For example: <code>CVE-2021-12345</code>.",
+      "requirement": "required"
     }
   }
 }

--- a/objects/epss.json
+++ b/objects/epss.json
@@ -1,0 +1,21 @@
+{
+  "caption": "EPSS",
+  "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild. (<a target='_blank' href='https://www.first.org/epss/'>EPSS</a>).",
+  "extends": "object",
+  "name": "epss",
+  "attributes": {
+    "score":{
+      "caption": "EPPS Score",
+      "description": "The EPSS score representing the probability [0-1] of exploitation in the wild in the next 30 days (following score publication)",
+      "requirement": "required"
+    },
+    "version": {
+      "description": "The version of the EPSS model used to calcuate the score.",
+      "requirement": "recommended"
+    },
+    "created_time": {
+      "description": "The timestamp indicating when the EPSS score was calculated.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/epss.json
+++ b/objects/epss.json
@@ -6,7 +6,7 @@
   "attributes": {
     "score":{
       "caption": "EPPS Score",
-      "description": "The EPSS score representing the probability [0-1] of exploitation in the wild in the next 30 days (following score publication)",
+      "description": "The EPSS score representing the probability [0-1] of exploitation in the wild in the next 30 days (following score publication).",
       "requirement": "required"
     },
     "version": {


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/740

#### Description of changes:

1. Adding a new object to represent epss score for a cve
2. Adding epss attribute to cve, sorting the attributes
3. Consequent attribute addition in the dictionary
