### PR TITLE
New class for OS patching using kb_articles object

### DIFF
--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -12,7 +12,7 @@
       "group": "primary",
       "requirement": "required"
     },
-    "kb_article": {
+    "kb_articles": {
       "group": "primary"
     }
   }

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -1,6 +1,6 @@
 {
   "caption": "Operating System Patch State",
-  "description": "Operating System Patch State reports the installation of OS patch.",
+  "description": "Operating System Patch State reports the installation of an OS patch.",
   "extends": "discovery",
   "name": "patch_state",
   "uid": 4,
@@ -14,6 +14,12 @@
     },
     "kb_articles": {
       "group": "primary"
-    }
+    },
+    "constraints": {
+        "at_least_one": [
+            "device.os.sp_name",
+            "device.os.sp_ver",
+            "device.os.version"
+    ]
   }
 }

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -1,0 +1,19 @@
+{
+  "caption": "Operating System Patch State",
+  "description": "Operating System Patch State reports the installation of OS patch.",
+  "extends": "discovery",
+  "name": "patch_state",
+  "uid": 4,
+  "profiles": [
+    "host"
+  ],
+  "attributes": {
+    "device": {
+      "group": "primary",
+      "requirement": "required",
+    },
+    "kb_article": {
+      "group": "primary"
+    }
+  }
+}

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -10,7 +10,7 @@
   "attributes": {
     "device": {
       "group": "primary",
-      "requirement": "required",
+      "requirement": "required"
     },
     "kb_article": {
       "group": "primary"

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -14,7 +14,8 @@
     },
     "kb_articles": {
       "group": "primary"
-    },
+    }
+  },
     "constraints": {
         "at_least_one": [
             "device.os.sp_name",


### PR DESCRIPTION
#### Related Issue: 
Resulting from Vulnerability Findings work.

#### Description of changes:
Add a new class to Discovery for the install state of an OS patch. This new class includes the Host profile for Device as well as the kb_articles object.

Please comment on any additions/changes.