### PR TITLE
Issue-748: Change activity id group to classification

### DIFF
--- a/events/network/email.json
+++ b/events/network/email.json
@@ -27,8 +27,7 @@
           "caption": "Scan",
           "description": "Email being scanned (example: security scanning)"
         }
-      },
-      "group": "context"
+      }
     },
     "attempt": {
       "requirement": "optional",

--- a/events/network/email_file.json
+++ b/events/network/email_file.json
@@ -27,8 +27,7 @@
           "caption": "Scan",
           "description": "Email file being scanned (example: security scanning)."
         }
-      },
-      "group": "context"
+      }
     },
     "email_uid": {
       "requirement": "required",

--- a/events/network/email_url.json
+++ b/events/network/email_url.json
@@ -27,8 +27,7 @@
           "caption": "Scan",
           "description": "Email URL being scanned (example: security scanning)."
         }
-      },
-      "group": "context"
+      }
     },
     "email_uid": {
       "requirement": "required",


### PR DESCRIPTION
#### Related Issue: #748 

#### Description of changes:
Change group in the email activity event classes to be `classification` instead of `context`

![image](https://github.com/ocsf/ocsf-schema/assets/6465263/dd7ab091-8163-488b-b34d-a061beaa3867)

