### PR TITLE
Fixes and improvements to datetime_t regex

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3387,7 +3387,7 @@
       "datetime_t": {
         "caption": "Datetime",
         "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
-        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}%3A\\d{2}(?:.\\d+)?[A-Z]?(?:[.-](?:08:\\d{2}|\\d{2}[A-Z]))?$",
+        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?[A-Z]?(?:[.-](?:\\d{2}|\\d{2}[A-Z]))?$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3387,7 +3387,7 @@
       "datetime_t": {
         "caption": "Datetime",
         "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
-        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?[A-Z]?(Z|[\\+-]\\d{2}:\\d{2})?$",
+        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?[A-Z]?(Z|[\\+-]\\d{2}:\\d{2})?$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3387,7 +3387,7 @@
       "datetime_t": {
         "caption": "Datetime",
         "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
-        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?[A-Z]?(?:[.-](?:\\d{2}|\\d{2}[A-Z]))?$",
+        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:.\\d+)?[A-Z]?(Z|[\\+-]\\d{2}:\\d{2})?$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3387,7 +3387,7 @@
       "datetime_t": {
         "caption": "Datetime",
         "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example <code>1985-04-12T23:20:50.52Z</code>.",
-        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?[A-Z]?(Z|[\\+-]\\d{2}:\\d{2})?$",
+        "regex": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(Z|[\\+-]\\d{2}:\\d{2})?$",
         "type": "string_t",
         "type_name": "String"
       },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/752
#### Description of changes:
Update the `datetime_t` validation regex to enable validation of timestamps, and to ensure that timestamps not matching RFC-3339 are not considered valid. 
