### PR TITLE
Fix #754: Cleanup user object

### DIFF
--- a/objects/user.json
+++ b/objects/user.json
@@ -41,7 +41,6 @@
     },
     "type_id": {
       "description": "The account type identifier.",
-      "name": "integer_t",
       "requirement": "required",
       "enum": {
         "0": {


### PR DESCRIPTION
Remove the `name` property from the `user.type_id` attribute.