### PR TITLE
Add firewall profile to network activity events

### DIFF
--- a/events/network/dhcp.json
+++ b/events/network/dhcp.json
@@ -5,13 +5,15 @@
   "extends": "base_event",
   "name": "dhcp_activity",
   "profiles": [
-    "host"
+    "host",
+    "firewall"
   ],
   "uid": 4,
   "attributes": {
     "$include": [
       "profiles/cloud.json",
-      "profiles/host.json"
+      "profiles/host.json",
+      "profiles/firewall.json"
     ],
     "activity_id": {
       "enum": {

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -5,13 +5,7 @@
   "extends": "network_activity",
   "name": "http_activity",
   "uid": 2,
-  "profiles": [
-    "firewall"
-  ],
   "attributes": {
-    "$include": [
-      "profiles/firewall.json"
-    ],
     "activity_id": {
       "enum": {
         "1": {

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -8,13 +8,15 @@
   "profiles": [
     "host",
     "network_proxy",
-    "security_control"
+    "security_control",
+    "firewall"
   ],
   "attributes": {
     "$include": [
       "profiles/host.json",
       "profiles/network_proxy.json",
-      "profiles/security_control.json"
+      "profiles/security_control.json",
+      "profiles/firewall.json"
     ],
     "activity_id": {
       "enum": {


### PR DESCRIPTION
#### Related Issue: 
#749 
#### Description of changes:
Add firewall profile to all network events besides the email activity ones

![image](https://github.com/ocsf/ocsf-schema/assets/6465263/49e9a250-2198-4b64-bacc-da8e664444cf)

