### PR TITLE
minor fix for related_analytics JSON

### DIFF
--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -16,7 +16,7 @@
       "description": "The name of the analytic that generated the finding."
     },
     "related_analytics": {
-      "description:": "Other analytics related to this analytic ",
+      "description": "Other analytics related to this analytic.",
       "requirement": "optional"
     },
     "type": {


### PR DESCRIPTION
#### Description of changes:

the `related_analytics` attribute in the **Analytic** object has a typo in the JSON, well-formed but with the wrong property key.

ocsf-server runs without error on this branch, and reveals that for this property, without this change, the description from the dictionary was being presented

![image](https://github.com/ocsf/ocsf-schema/assets/1017053/e68c4ae7-92d3-4b17-aae2-ab5d173d2edf)

when presumably the intent was to present the value from `analytic.json`, as is done with this change:

![image](https://github.com/ocsf/ocsf-schema/assets/1017053/a29df6f0-4854-43ea-8a0f-fab649aa1053)
