### PR TITLE
Issue 756: Deprecate `http_status`

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1530,6 +1530,10 @@
       "type": "http_response"
     },
     "http_status": {
+      "@deprecated": {
+        "message": "Use the <code> http_response.status </code> attribute instead.",
+        "since": "v1.0.0"
+      },
       "caption": "HTTP Status",
       "description": "The Hypertext Transfer Protocol (HTTP) <a target='_blank' href='https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
       "type": "integer_t"
@@ -1835,7 +1839,7 @@
     },
     "latency": {
       "caption": "Latency",
-      "description": "TODO: The HTTP response latency. In seconds, milliseconds, etc.?",
+      "description": "The HTTP response latency measured in milliseconds.",
       "type": "integer_t"
     },
     "ldap_cn": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1531,7 +1531,7 @@
     },
     "http_status": {
       "@deprecated": {
-        "message": "Use the <code> http_response.status </code> attribute instead.",
+        "message": "Use the <code> http_response.code </code> attribute instead.",
         "since": "v1.0.0"
       },
       "caption": "HTTP Status",

--- a/objects/http_response.json
+++ b/objects/http_response.json
@@ -5,7 +5,7 @@
   "name": "http_response",
   "attributes": {
     "code": {
-      "description": "The numeric code sent from the web server to the requester.",
+      "description": "The Hypertext Transfer Protocol (HTTP) status code returned from the web server to the client. For example, 200.",
       "requirement": "required"
     },
     "content_type": {
@@ -22,7 +22,7 @@
     },
     "status": {
       "requirement": "optional",
-      "description": "The response status. For example: A successful HTTP status of 'OK' which corresponds to a code of '200'."
+      "description": "The response status. For example: A successful HTTP status of 'OK' which corresponds to a code of 200."
     }
   }
 }

--- a/objects/http_response.json
+++ b/objects/http_response.json
@@ -22,7 +22,7 @@
     },
     "status": {
       "requirement": "optional",
-      "description": "The response status. For example: Kubernetes responseStatus.status."
+      "description": "The response status. For example: A successful HTTP status of 'OK' which corresponds to a code of '200'."
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: #756 

#### Description of changes:

- Update redundant http_status to be deprecated 
- Alter descriptions of `latency` and http response status

<img width="1134" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/98d7121f-6d56-4d7a-818b-4071f902f6b6">


<img width="1369" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/ce14f353-456a-4f9d-9901-a0185ede6d01">


