### PR TITLE
Add request length to the http_request object

### DIFF
--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -49,6 +49,11 @@
       },
       "type": "string_t"
     },
+    "length": {
+      "caption": "Request Length",
+      "description": "The HTTP request length, in number of bytes.",
+      "requirement": "optional"
+    },
     "referrer": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: #757 

#### Description of changes:

- Add request length to the `http_request` object

<img width="1097" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/7039aa6f-babb-42b6-ba77-6d5436b0c297">

