### PR TITLE
Issue 750: Add `device` and `log_device` to metadata

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1899,7 +1899,7 @@
     },
     "log_device": {
       "caption": "Log Device",
-      "description": "The device that sent the log.",
+      "description": "The logging device responsible for recording the event or the device from which the event was initially retrieved. Note that in some instances, this might be the same as the device where the event was generated.",
       "type": "device"
     },
     "log_level": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1897,6 +1897,11 @@
       "description": "The detailed geographical location usually associated with an IP address.",
       "type": "location"
     },
+    "log_device": {
+      "caption": "Log Device",
+      "description": "The device that sent the log.",
+      "type": "device"
+    },
     "log_level": {
       "caption": "Log Level",
       "description": "The audit level at which an event was generated.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1127,7 +1127,7 @@
     },
     "device": {
       "caption": "Device",
-      "description": "An addressable device, computer system or host.",
+      "description": "An addressable device, computer system or host that is the subject of the event.",
       "type": "device"
     },
     "devices": {
@@ -1899,7 +1899,7 @@
     },
     "log_device": {
       "caption": "Log Device",
-      "description": "The logging device responsible for recording the event or the device from which the event was initially retrieved. Note that in some instances, this might be the same as the device where the event was generated.",
+      "description": "The logging device responsible for transmitting the event. Note that in some instances, this might be the same as the device where the event occurred.",
       "type": "device"
     },
     "log_level": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -5,12 +5,20 @@
   "name": "metadata",
   "attributes": {
     "correlation_uid": {},
+    "device": {
+      "description": "The device that logged the event.",
+      "requirement": "recommended"
+    },
     "event_code": {
       "requirement": "optional"
     },
     "extension": {},
     "labels": {
       "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>"
+    },
+    "log_device": {
+      "description": "The device that transmitted the log. Note that in some instances, this might be the same as the device that logged the event.",
+      "requirement": "recommended"
     },
     "log_level": {
       "requirement": "optional"

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -6,7 +6,7 @@
   "attributes": {
     "correlation_uid": {},
     "device": {
-      "description": "The device that logged the event.",
+      "description": "The device where the event was generated.",
       "requirement": "recommended"
     },
     "event_code": {
@@ -17,7 +17,6 @@
       "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>"
     },
     "log_device": {
-      "description": "The device that transmitted the log. Note that in some instances, this might be the same as the device that logged the event.",
       "requirement": "recommended"
     },
     "log_level": {


### PR DESCRIPTION
#### Related Issue: #750 

#### Description of changes:

- Add `log_device` attribute to dictionary
- Add `device` and `log_device` to metadata

<img width="1371" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/bfdec37b-a41b-43cd-8bdf-55bc7c02f7ba">

