### PR TITLE
Adding namespace to API service

### DIFF
--- a/objects/service.json
+++ b/objects/service.json
@@ -11,6 +11,10 @@
     "name": {
       "description": "The name of the service."
     },
+    "namespace": {
+      "description": "API namespaces provides a mechanism for isolating groups of apis. APIs are typically similar within a namespace, but not across namespaces.",
+      "requirement": "optional"
+    },
     "uid": {
       "description": "The unique identifier of the service."
     },


### PR DESCRIPTION
Adding namespace field as an optional attribute to the service object within the API object. (api.service.namespace)

This will be useful in accommodating APIs which interact with container based services like Kubernetes which often use namespaces to delineate the resources for which the APIs interact. 