### PR TITLE
Remove the default version from metadata

### DIFF
--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -43,7 +43,6 @@
       "requirement": "optional"
     },
     "version": {
-      "default": "1.0.0",
       "description": "The version of the OCSF schema, using Semantic Versioning Specification (<a target='_blank' href='https://semver.org'>SemVer</a>). For example: 1.0.0. Event consumers use the version to determine the available event attributes.",
       "requirement": "required"
     }


### PR DESCRIPTION
Having a default value for the schema version is a mistake. There is no good default value, i.e., we should not assume a specific version. The version is a required attribute, and it should be always present in the event data.
