### PR TITLE
Undo breaking changes for finding, remediation and vulnerability object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2206,8 +2206,18 @@
       "type": "user"
     },
     "package": {
-      "caption": "Software Packages",
+      "caption": "Software Package",
       "description": "The Software Package object describes details about a software package. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/'>d3f:SoftwarePackage</a>.",
+      "type": "package"
+    },
+    "packages": {
+      "@deprecated": {
+        "message": "Use the <code> affected_packages </code> attribute instead.",
+        "since": "v1.0.0"
+      },
+      "caption": "Software Packages",
+      "description": "List of vulnerable packages as identified by the security product",
+      "is_array": true,
       "type": "package"
     },
     "package_manager": {
@@ -3101,6 +3111,11 @@
       "caption": "Subnet UID",
       "description": "The unique identifier of a virtual subnet.",
       "type": "string_t"
+    },
+    "supporting_data": {
+      "caption": "Supporting Data",
+      "description": "Additional data supporting a finding as provided by security tool",
+      "type": "json_t"
     },
     "superseded": {
       "caption": "The patch is superseded.",

--- a/objects/finding.json
+++ b/objects/finding.json
@@ -35,8 +35,14 @@
     "related_events": {
       "requirement": "optional"
     },
+    "remediation": {
+      "requirement": "optional"
+    },
     "src_url": {
       "description": "The URL pointing to the source of the finding.",
+      "requirement": "optional"
+    },
+    "supporting_data": {
       "requirement": "optional"
     },
     "title": {

--- a/objects/remediation.json
+++ b/objects/remediation.json
@@ -11,6 +11,9 @@
     "references": {
       "description": "A list of supporting URL/s, references that help describe the remediation strategy.",
       "requirement": "optional"
+    },
+    "kb_articles": {
+      "requirement": "optional"
     }
   }
 }

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -13,6 +13,10 @@
     "cwe": {
       "requirement": "recommended"
     },
+    "desc": {
+      "description": "The description of the vulnerability.",
+      "requirement": "optional"
+    },
     "first_seen_time": {
       "description": "The time when the vulnerability was first observed.",
       "requirement": "optional"
@@ -25,6 +29,9 @@
     },
     "last_seen_time": {
       "description": "The time when the vulnerability was most recently observed.",
+      "requirement": "optional"
+    },
+    "packages": {
       "requirement": "optional"
     },
     "references": {


### PR DESCRIPTION
#### Related Issue:  https://github.com/ocsf/ocsf-schema/issues/759

#### Description of changes:

Rectifying a few breaking changes (with respect to v1.0.0) that were merged to 1.1.0-dev branch. 

The deprecated Finding object - (restoring the object v1.0.0)
* Add remediation
* Add supporting_data (to dictionary as well)

Vulnerability object -
* Add desc
* Add packages as deprecated (to dictionary as well)

Remediation object -
* Add kb_articles