### PR TITLE
Adding Exploit Availability field to the vulnerability object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1349,6 +1349,11 @@
       "description": "The expiration time. See specific usage.",
       "type": "timestamp_t"
     },
+    "exploit_available":{
+      "caption": "Exploit Availability",
+      "description": "Indicates if an exploit is available for the reported vulnerability.",
+      "type": "boolean_t"
+    },
     "extension": {
       "caption": "Schema Extension",
       "description": "The schema extension used to create the event.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1351,7 +1351,7 @@
     },
     "exploit_available":{
       "caption": "Exploit Availability",
-      "description": "Indicates if an exploit is available for the reported vulnerability.",
+      "description": "Indicates if an exploit or a PoC (proof-of-concept) is available for the reported vulnerability.",
       "type": "boolean_t"
     },
     "extension": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1349,11 +1349,6 @@
       "description": "The expiration time. See specific usage.",
       "type": "timestamp_t"
     },
-    "exploit_available":{
-      "caption": "Exploit Availability",
-      "description": "Indicates if an exploit or a PoC (proof-of-concept) is available for the reported vulnerability.",
-      "type": "boolean_t"
-    },
     "extension": {
       "caption": "Schema Extension",
       "description": "The schema extension used to create the event.",
@@ -1701,6 +1696,11 @@
     "is_default": {
       "caption": "Default Value",
       "description": "The indication of whether the value is from a default value name. For example, the value name could be missing.",
+      "type": "boolean_t"
+    },
+    "is_exploit_available":{
+      "caption": "Exploit Availability",
+      "description": "Indicates if an exploit or a PoC (proof-of-concept) is available for the reported vulnerability.",
       "type": "boolean_t"
     },
     "is_managed": {

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -17,7 +17,7 @@
       "description": "The description of the vulnerability.",
       "requirement": "optional"
     },
-    "exploit_available":{
+    "is_exploit_available":{
       "requirement": "optional"
     },
     "first_seen_time": {

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -17,6 +17,9 @@
       "description": "The description of the vulnerability.",
       "requirement": "optional"
     },
+    "exploit_available":{
+      "requirement": "optional"
+    },
     "first_seen_time": {
       "description": "The time when the vulnerability was first observed.",
       "requirement": "optional"


### PR DESCRIPTION
#### Description of changes:

Adding a new field to indicate availability of an exploit for a given vulnerability finding.  
Reference for a source that provides this info - [AWS Inspector](https://docs.aws.amazon.com/inspector/latest/user/eventbridge-integration.html#event-finding)

![Screenshot 2023-09-13 at 1 17 58 PM](https://github.com/ocsf/ocsf-schema/assets/89877409/c14b38e7-b110-47e3-9ba6-52df5d7e0a03)

