### PR TITLE
Add a Logger object that represents a device and associated product where events are logged.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1935,6 +1935,12 @@
       "description": "<p>The time when the logging system collected and logged the event.</p>This attribute is distinct from the event time in that event time typically contain the time extracted from the original event. Most of the time, these two times will be different.",
       "type": "timestamp_t"
     },
+    "loggers": {
+      "caption": "Loggers",
+      "description": "An array of Logger objects that describe the devices and logging products between the event source and its eventual destination. Note, this attribute can be used when there is a complex end-to-end path of event flow.",
+      "is_array": "true",
+      "type": "logger"
+    },
     "logon_process": {
       "caption": "Logon Process",
       "description": "The trusted process that validated the authentication credentials.",
@@ -3208,6 +3214,11 @@
       "caption": "Transaction UID",
       "description": "The unique identifier of the transaction.",
       "type": "string_t"
+    },
+    "transmit_time": {
+      "caption": "Transmission Time",
+      "description": "The event transmission time from one device to another.  See specific usage",
+      "type": "timestamp_t"
     },
     "tree_uid": {
       "caption": "Tree UID",

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -1,0 +1,45 @@
+{
+    "caption": "Logger",
+    "description": "The Logger object represents the device and product where events are stored with times for receipt and transmission.  This may be at the source device where the event occurred, a remote scanning device, intermediate hops, or the ultimate destination.",
+    "name": "logger",
+    "extends": "_entity",
+    "attributes": {
+        "device": {
+            "description": "The device where the events are logged.",
+            "requirement": "recommended"
+        },
+        "log_level": {
+            "requirement": "optional"
+        },
+        "log_name": {
+            "requirement": "recommended"
+        },
+        "log_provider": {
+            "requirement": "recommended"
+        },
+        "log_version": {
+            "requirement": "optional"
+        },
+        "logged_time": {},
+        "name": {
+            "description": "The name of the logging product instance.",
+            "requirement": "recommended"
+        },
+        "product": {
+            "description": "The product logging the event.  This may be the event source product, a management server product, a scanning product, a SIEM, etc.",
+            "requirement": "recommended"
+        },
+        "transmit_time": {
+            "description": "The time when the event was transmitted from the logging device to it's next destination",
+            "requirement": "optional"
+        },
+        "uid": {
+            "description": "The unique identifier of the logging product instance.",
+            "requirement": "recommended"
+          },      
+        "version": {
+            "description": "The version of the logging product.",
+            "requirement": "optional"
+        }
+    }
+}  

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -28,6 +28,7 @@
     "modified_time": {
       "description": "The time when the event was last modified or enriched."
     },
+    "loggers": {},
     "original_time": {
       "requirement": "recommended"
     },


### PR DESCRIPTION
When events travel from source to destination, often there are multiple hops along the way, including store and forward logs, each with a receive and transmit time that in some cases need to be captured.  This PR expands on the `log_xx` attributes in `Metadata` that were targeted at the source log in most cases (e.g. Windows Event Log).

This PR generalizes this concept with an array of `Logger` objects, in cases where the path of the event is known.

Note: I did not deprecate the existing `log_xx` attributes, in case the multi-hop situation is uncommon.