### PR TITLE
Adding requirement property to all attributes in the metadata object

### DIFF
--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -4,13 +4,18 @@
   "extends": "object",
   "name": "metadata",
   "attributes": {
-    "correlation_uid": {},
+    "correlation_uid": {
+      "requirement": "optional"
+    },
     "event_code": {
       "requirement": "optional"
     },
-    "extension": {},
+    "extension": {
+      "requirement": "optional"
+    },
     "labels": {
-      "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>"
+      "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>",
+      "requirement": "optional"
     },
     "log_level": {
       "requirement": "optional"
@@ -24,19 +29,28 @@
     "log_version": {
       "requirement": "optional"
     },
-    "logged_time": {},
+    "logged_time": {
+      "requirement": "optional"
+    },
     "modified_time": {
-      "description": "The time when the event was last modified or enriched."
+      "description": "The time when the event was last modified or enriched.",
+      "requirement": "optional"
     },
     "original_time": {
       "requirement": "recommended"
     },
-    "processed_time": {},
+    "processed_time": {
+      "requirement": "optional"
+    },
     "product": {
       "requirement": "required"
     },
-    "profiles": {},
-    "sequence": {},
+    "profiles": {
+      "requirement": "optional"
+    },
+    "sequence": {
+      "requirement": "optional"
+    },
     "uid": {
       "caption": "Event UID",
       "description": "The logging system-assigned unique identifier of an event instance.",


### PR DESCRIPTION
#### Related Issue:  https://github.com/ocsf/ocsf-schema/issues/783

#### Description of changes:

Adding explicit requirement property for attributes in the metadata object. This a non-breaking change.
