### PR TITLE
objects/user: make $include be a list of strings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ More details about OCSF concepts, terminology and use-cases can be found in [Und
 ### In brief -
 
 1. Determine all the `attributes` (including fields and objects) you would want to add in the `event_class`
+    1. `$include` → If you are including attributes from other places, specify an attribute called `$include` and give its value as the list of files (relative to the root of the repository) that should contribute their attributes to this event class.
 2. Check the [dictionary](https://github.com/ocsf/ocsf-schema/blob/main/dictionary.json) and the [/objects](https://github.com/ocsf/ocsf-schema/tree/main/objects) folder, many of your desired attributes may already be present.
 3. Define the missing attributes → [Adding/Modifying an `attribute`](#addingmodifying-an-attribute)
 4. Determine which category you would want to add your event_class in, note it’s  `name`
@@ -101,6 +102,7 @@ An example `vulnerability.json` object file,
 7. `name` → Add a **unique** name of the object. `name` must match the filename of the actual `.json` file.
 8.  `attributes` → Add the attributes that you want to define in the object, 
     1. `requirement` →  For each attribute ensure you add a requirement value. Valid values are `optional`, `required`, `recommended` 
+    2. `$include` → If you are including attributes from other places, specify the list of files (relative to the root of the repository) that should contribute their attributes to this object.
 
 **Note:** If you want to create an object which would act only as a base for other objects, you must prefix the object `name` and the actual `json` filename with an `_`. The resultant object will not be visible in the [OCSF Server.](https://schema.ocsf.io/1.0.0-rc.2/objects) For example, take a look at the [entity](https://github.com/ocsf/ocsf-schema/blob/main/objects/_entity.json) object. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ More details about OCSF concepts, terminology and use-cases can be found in [Und
 ### In brief -
 
 1. Determine all the `attributes` (including fields and objects) you would want to add in the `event_class`
-    1. `$include` → If you are including attributes from other places, specify an attribute called `$include` and give its value as the list of files (relative to the root of the repository) that should contribute their attributes to this event class.
 2. Check the [dictionary](https://github.com/ocsf/ocsf-schema/blob/main/dictionary.json) and the [/objects](https://github.com/ocsf/ocsf-schema/tree/main/objects) folder, many of your desired attributes may already be present.
 3. Define the missing attributes → [Adding/Modifying an `attribute`](#addingmodifying-an-attribute)
 4. Determine which category you would want to add your event_class in, note it’s  `name`
@@ -102,7 +101,15 @@ An example `vulnerability.json` object file,
 7. `name` → Add a **unique** name of the object. `name` must match the filename of the actual `.json` file.
 8.  `attributes` → Add the attributes that you want to define in the object, 
     1. `requirement` →  For each attribute ensure you add a requirement value. Valid values are `optional`, `required`, `recommended` 
-    2. `$include` → If you are including attributes from other places, specify the list of files (relative to the root of the repository) that should contribute their attributes to this object.
+    2. `$include` → You can include attributes from other places; to do so, specify a virtual attribute called `$include` and give its value as the list of files (relative to the root of the schema repository) that should contribute their attributes to this object.  _e.g._
+        ```
+        "attributes": {
+          "$include": [
+            "profiles/person.json"
+          ],
+          ...
+        }
+        ```
 
 **Note:** If you want to create an object which would act only as a base for other objects, you must prefix the object `name` and the actual `json` filename with an `_`. The resultant object will not be visible in the [OCSF Server.](https://schema.ocsf.io/1.0.0-rc.2/objects) For example, take a look at the [entity](https://github.com/ocsf/ocsf-schema/blob/main/objects/_entity.json) object. 
 
@@ -143,6 +150,17 @@ Choose a **unique** object you want to add, `vulnerability` in the example above
     8. `attributes` → Add the attributes that you want to define in the event_class, 
         1. `group` → For each attribute ensure you add a group value. Valid values are - `classification`, `context`, `occurrence`, `primary`
         2. `requirement` →  For each attribute ensure you add a requirement value. Valid values are `optional`, `required`, `recommended`
+        3. `$include` → As for objects, you can also include attributes from other places; to do so, specify the list of files (relative to the root of the schema repository) that should contribute their attributes to this object.  _e.g._
+        ```
+        "attributes": {
+          "$include": [
+            "includes/occurrence.json",
+            "profiles/cloud.json"
+          ],
+          ...
+        }
+        ```
+
     9. `constraints` → For each class you can add constraints on the attribute requirements. Valid constraint types are `at_least_one`, `just_one`. e.g.
         ```
          "constraints": {

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -42,7 +42,7 @@
       "requirement": "optional"
     },
     "related_analytics": {
-      "description:": "Other analytics related to this finding.",
+      "description": "Other analytics related to this finding.",
       "requirement": "optional"
     },
     "src_url": {

--- a/objects/user.json
+++ b/objects/user.json
@@ -8,7 +8,7 @@
     "person"
   ],
   "attributes": {
-    "$include": "profiles/person.json",
+    "$include": ["profiles/person.json"],
     "account": {
       "description": "The user's account or the account associated with the user.",
       "requirement": "optional"

--- a/objects/user.json
+++ b/objects/user.json
@@ -8,7 +8,9 @@
     "person"
   ],
   "attributes": {
-    "$include": ["profiles/person.json"],
+    "$include": [
+      "profiles/person.json"
+    ],
     "account": {
       "description": "The user's account or the account associated with the user.",
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: 

#791 Rationalize $include to always be a list of strings
 
#### Description of changes:

Updated the one use of `$include`, in `objects/user.json`, that _was_ string-valued to be a list instead.

