### PR TITLE
Updating http_response object to include http_header object

### DIFF
--- a/objects/http_response.json
+++ b/objects/http_response.json
@@ -11,6 +11,9 @@
     "content_type": {
       "requirement": "optional"
     },
+    "http_headers": {
+      "requirement": "recommended"
+    },
     "latency": {
       "requirement": "optional"
     },


### PR DESCRIPTION
Updating http_response object to include http_headers as a recommended attribute following the same structure as seen in the http_request object. 

#### Related Issue: #798 

#### Description of changes: 

- Added http_headers to http_response 


