### PR TITLE
Issue #799 add a terminal object for tty/pts and other pseudo terminals

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3163,6 +3163,11 @@
       "description": "The attack technique.",
       "type": "technique"
     },
+    "terminal": {
+      "description": "The Pseudo Terminal. Ex: the tty or pts value.",
+      "requirement": "optional",
+      "type": "string_t"
+    },
     "terminated_time": {
       "caption": "Terminated Time",
       "description": "The time when the entity was terminated. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3164,6 +3164,7 @@
       "type": "technique"
     },
     "terminal": {
+      "caption": "Terminal",
       "description": "The Pseudo Terminal. Ex: the tty or pts value.",
       "requirement": "optional",
       "type": "string_t"

--- a/objects/session.json
+++ b/objects/session.json
@@ -22,6 +22,10 @@
       "description": "The identifier of the session issuer.",
       "requirement": "recommended"
     },
+    "terminal": {
+      "description": "The Pseudo Terminal assicoated with the session. Ex: the tty or pts value.",
+      "requirement": "optional"
+    },
     "uid": {
       "description": "The unique identifier of the session.",
       "requirement": "recommended"

--- a/objects/session.json
+++ b/objects/session.json
@@ -23,7 +23,7 @@
       "requirement": "recommended"
     },
     "terminal": {
-      "description": "The Pseudo Terminal assicoated with the session. Ex: the tty or pts value.",
+      "description": "The Pseudo Terminal associated with the session. Ex: the tty or pts value.",
       "requirement": "optional"
     },
     "uid": {


### PR DESCRIPTION
#### Related Issue: #799 

#### Description of changes:
- This PR adds an attribute to the `session` object for logging the pseudo-terminal, a valuable piece of information for detection engineering. For more info see Issue #799.

<img width="1135" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/72fb5e14-973b-4206-82f0-1e11a06b575e">
