### PR TITLE
Cleaning up firewall profile

### DIFF
--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -23,8 +23,8 @@
       "description": "The firewall event status code, detailing the rule action of the event source.",
       "requirement": "optional"
     },	
-    "response_time": {
-      "description": "The rule response time, usually used for challenge completion time.",
+    "duration": {
+      "description": "The rule response time duration, usually used for challenge completion time.",
       "requirement": "optional"
     },	
     "message": {

--- a/objects/firewall_rule.json
+++ b/objects/firewall_rule.json
@@ -18,17 +18,9 @@
     },	
     "rate_limit": {
       "requirement": "optional"
-    },	
-    "status_code": {
-      "description": "The firewall event status code, detailing the rule action of the event source.",
-      "requirement": "optional"
-    },	
+    },
     "duration": {
       "description": "The rule response time duration, usually used for challenge completion time.",
-      "requirement": "optional"
-    },	
-    "message": {
-      "description": "The description of the firewall event rule action, as defined by the event source.",
       "requirement": "optional"
     }
   }


### PR DESCRIPTION
1. Removing status_code from firewall_rule object, this was redundant with the base http activity class.
2. Removing message from firewall_rule object, this was also redundant with the base http activity class.
3. Moving response_time to duration for captcha/challenge time completion which fits better with WAF logs. 