### PR TITLE
Adding consistency in boolean attribute naming

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1412,6 +1412,10 @@
       "type": "string_t"
     },
     "fix_available": {
+      "@deprecated": {
+        "message": "Use the <code> is_fix_available </code> attribute instead.",
+        "since": "v1.0.0"
+      },
       "caption": "Fix Availability",
       "description": "Indicates if a fix is available for the reported vulnerability.",
       "type": "boolean_t"
@@ -1701,6 +1705,11 @@
     "is_exploit_available":{
       "caption": "Exploit Availability",
       "description": "Indicates if an exploit or a PoC (proof-of-concept) is available for the reported vulnerability.",
+      "type": "boolean_t"
+    },
+    "is_fix_available": {
+      "caption": "Fix Availability",
+      "description": "Indicates if a fix is available for the reported vulnerability.",
       "type": "boolean_t"
     },
     "is_managed": {

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -17,9 +17,6 @@
       "description": "The description of the vulnerability.",
       "requirement": "optional"
     },
-    "is_exploit_available":{
-      "requirement": "optional"
-    },
     "first_seen_time": {
       "description": "The time when the vulnerability was first observed.",
       "requirement": "optional"
@@ -28,6 +25,12 @@
       "requirement": "optional"
     },
     "kb_articles": {
+      "requirement": "optional"
+    },
+    "is_exploit_available":{
+      "requirement": "optional"
+    },
+    "is_fix_available": {
       "requirement": "optional"
     },
     "last_seen_time": {


### PR DESCRIPTION
#### Description of changes:
1. Adding a new attribute `is_fix_available` as a replacement for `fix_available`. This is to bring consistency in OCSF's boolean attributes
2. deprecating fix_available
![Screenshot 2023-10-04 at 11 21 14 AM](https://github.com/ocsf/ocsf-schema/assets/89877409/34e7a9cb-7a2b-4a68-9c3e-0d9cabc2ad54)
