### PR TITLE
Updating HTTP Activity class with HTTP Cookies Object 

### DIFF
--- a/events/network/http.json
+++ b/events/network/http.json
@@ -42,6 +42,10 @@
         }
       }
     },
+    "http_cookies": {
+      "group": "primary",
+      "requirement": "optional"
+    },
     "http_request": {
       "group": "primary",
       "requirement": "required"


### PR DESCRIPTION
#### Related Issue: [814](https://github.com/ocsf/ocsf-schema/issues/814l)

#### Description of changes:
- Updating the HTTP Activity class to include the `http_cookies` object as an optional field in order to capture cookie related log content. 
- HTTP Cookies was already in the attribute dictionary, it was just not being referenced by anything. 
