### PR TITLE
Adding a new Affected code object to the vulnerability object.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -75,6 +75,12 @@
       "description": "The permissions that were granted to the in a platform-native format.",
       "type": "integer_t"
     },
+    "affected_code": {
+      "caption": "Affected Code",
+      "description": "List of Affected Code objects that describe details about code blocks identified as vulnerable.",
+      "is_array": true,
+      "type": "affected_code"
+    },
     "affected_packages": {
       "caption": "Affected Software Packages",
       "description": "List of software packages identified as affected by a vulnerability/vulnerabilities.",
@@ -1287,6 +1293,11 @@
       "caption": "Employee ID",
       "description": "The employee identifier assigned to the user by the organization.",
       "type": "string_t"
+    },
+    "end_line": {
+      "caption": "End Line",
+      "description": "The line number of the last line of code block identified as vulnerable.",
+      "type": "integer_t"
     },
     "end_time": {
       "caption": "End Time",
@@ -3003,6 +3014,11 @@
       "caption": "Start Address",
       "description": "The start address of the execution.",
       "type": "string_t"
+    },
+    "start_line": {
+      "caption": "Start Line",
+      "description": "The line number of the first line of code block identified as vulnerable.",
+      "type": "integer_t"
     },
     "start_time": {
       "caption": "Start Time",

--- a/objects/affected_code.json
+++ b/objects/affected_code.json
@@ -12,7 +12,7 @@
       "requirement": "required"
     },
     "owner": {
-      "description": "Details about the user that owns affected file.",
+      "description": "Details about the user that owns the affected file.",
       "requirement": "optional"
     },
     "remediation": {

--- a/objects/affected_code.json
+++ b/objects/affected_code.json
@@ -1,0 +1,25 @@
+{
+  "caption": "Affected Code",
+  "description": "The Affected Code object describes details about a code block identified as vulnerable.",
+  "extends": "object",
+  "name": "affected_code",
+  "attributes": {
+    "end_line": {
+      "requirement": "recommended"
+    },
+    "file": {
+      "description": "Details about the file that contains the affected code block.",
+      "requirement": "required"
+    },
+    "owner": {
+      "description": "Details about the user that owns affected file.",
+      "requirement": "optional"
+    },
+    "remediation": {
+      "requirement": "optional"
+    },
+    "start_line": {
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -4,8 +4,11 @@
   "extends": "object",
   "name": "vulnerability",
   "attributes": {
+    "affected_code": {
+      "requirement": "optional"
+    },
     "affected_packages": {
-      "requirement": "recommended"
+      "requirement": "optional"
     },
     "cve": {
       "requirement": "recommended"


### PR DESCRIPTION
#### Description of changes:  non-breaking

Followup of a topic in the weekly Findings call.

1. Adding affected_code object to vulnerability object to support sast finding or any other code scanning related vulnerability findings.
2. Example data from AWS Inspector's lambda code scanning findings can be found [here](https://docs.aws.amazon.com/securityhub/latest/userguide/asff-top-level-attributes.html#asff-vulnerabilities). 
![Screenshot 2023-10-05 at 3 18 56 PM](https://github.com/ocsf/ocsf-schema/assets/89877409/53d81550-1d1c-49d2-9be9-1b090b66eeaa)

