### PR TITLE
Add plural 'extensions' array

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1365,6 +1365,12 @@
       "description": "The schema extension used to create the event.",
       "type": "extension"
     },
+    "extensions": {
+      "caption": "Schema Extensions",
+      "description": "The schema extensions used to create the event.",
+      "is_array": true,
+      "type": "extension"
+    },
     "extension_list": {
       "caption": "Extension List",
       "description": "The list of TLS extensions.",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -11,6 +11,13 @@
       "requirement": "optional"
     },
     "extension": {
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code> extensions </code> attribute instead.",
+        "since": "v1.0.0"
+      }
+    },
+    "extensions": {
       "requirement": "optional"
     },
     "labels": {


### PR DESCRIPTION
#### Related Issue: #808

#### Description of changes:
1. Create an `extensions` object and add to the base event metadata.
1. Deprecate the use of the singular `extension` in the base event metadata.
1. Leave the `optional` requirement as-is. No need to change the requirement level.

#### What it looks like:

<img width="1194" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/4b5d3495-a563-43ab-acd1-88d85ae52f1d">

<img width="997" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/76fd0361-1d36-4a97-8759-04ea0a361741">

