### PR TITLE
Issue 826 Fix: Add activity_id descriptions to Network File Activity

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -9,46 +9,60 @@
     "activity_id": {
       "enum": {
         "1": {
-          "caption": "Upload"
+          "caption": "Upload",
+          "description": "Upload a file."
         },
         "2": {
-          "caption": "Download"
+          "caption": "Download",
+          "description": "Download a file."
         },
         "3": {
-          "caption": "Update"
+          "caption": "Update",
+          "description": "Update a file."
         },
         "4": {
-          "caption": "Delete"
+          "caption": "Delete",
+          "description": "Delete a file."
         },
         "5": {
-          "caption": "Rename"
+          "caption": "Rename",
+          "description": "Rename a file."
         },
         "6": {
-          "caption": "Copy"
+          "caption": "Copy",
+          "description": "Copy a file."
         },
         "7": {
-          "caption": "Move"
+          "caption": "Move",
+          "description": "Move a file."
         },
         "8": {
-          "caption": "Restore"
+          "caption": "Restore",
+          "description": "Restore a file."
         },
         "9": {
-          "caption": "Preview"
+          "caption": "Preview",
+          "description": "Preview a file."
         },
         "10": {
-          "caption": "Lock"
+          "caption": "Lock",
+          "description": "Lock a file."
         },
         "11": {
-          "caption": "Unlock"
+          "caption": "Unlock",
+          "description": "Unlock a file."
         },
         "12": {
-          "caption": "Share"
+          "caption": "Share",
+          "description": "Share a file."
         },
         "13": {
-          "caption": "Unshare"
+          "caption": "Unshare",
+          "description": "Unshare a file."
         },
         "14": {
-          "caption": "Open"
+          "caption": "Open",
+          "description": "Open a file."
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: #826

#### Description of changes:
Add descriptions for the Network File Activity activity_id's.
Before (the descriptions were not overridden from the `Network File Activity` class):
<img width="1094" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/b440eaae-ee17-4a82-b282-0c01412a068a">

After (the descriptions are present an override the generic descriptions:
<img width="895" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/5facc482-f727-4c4f-a93a-4da281ac5219">
