### PR TITLE
Add Sync/Unsync activity_ids to Network File Activity

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -63,6 +63,14 @@
         "14": {
           "caption": "Open",
           "description": "Open a file."
+        },
+        "15": {
+          "caption": "Sync",
+          "description": "Mark a file or folder to sync with a computer."
+        },
+        "16": {
+          "caption": "Unsync",
+          "description": "Mark a file or folder to not sync with a computer."
         }
       }
     },

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -9,46 +9,60 @@
     "activity_id": {
       "enum": {
         "1": {
-          "caption": "Upload"
+          "caption": "Upload",
+          "description": "Upload a file."
         },
         "2": {
-          "caption": "Download"
+          "caption": "Download",
+          "description": "Download a file."
         },
         "3": {
-          "caption": "Update"
+          "caption": "Update",
+          "description": "Update a file."
         },
         "4": {
-          "caption": "Delete"
+          "caption": "Delete",
+          "description": "Delete a file."
         },
         "5": {
-          "caption": "Rename"
+          "caption": "Rename",
+          "description": "Rename a file."
         },
         "6": {
-          "caption": "Copy"
+          "caption": "Copy",
+          "description": "Copy a file."
         },
         "7": {
-          "caption": "Move"
+          "caption": "Move",
+          "description": "Move a file."
         },
         "8": {
-          "caption": "Restore"
+          "caption": "Restore",
+          "description": "Restore a file."
         },
         "9": {
-          "caption": "Preview"
+          "caption": "Preview",
+          "description": "Preview a file."
         },
         "10": {
-          "caption": "Lock"
+          "caption": "Lock",
+          "description": "Lock a file."
         },
         "11": {
-          "caption": "Unlock"
+          "caption": "Unlock",
+          "description": "Unlock a file."
         },
         "12": {
-          "caption": "Share"
+          "caption": "Share",
+          "description": "Share a file."
         },
         "13": {
-          "caption": "Unshare"
+          "caption": "Unshare",
+          "description": "Unshare a file."
         },
         "14": {
-          "caption": "Open"
+          "caption": "Open",
+          "description": "Open a file."
         }
       }
     },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -7,9 +7,6 @@
     "correlation_uid": {
       "requirement": "optional"
     },
-    "customer_uid": {
-      "requirement": "recommended"
-    },
     "event_code": {
       "requirement": "optional"
     },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -7,6 +7,9 @@
     "correlation_uid": {
       "requirement": "optional"
     },
+    "customer_uid": {
+      "requirement": "recommended"
+    },
     "event_code": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Description of changes:
Adds activity_id's for `Sync` and `Unsync`, which are common activities for `Network File Activity` services such as `Box, MS OneDrive, or Google Drive. These have been tested thoroughly in the Splunk extension and commonly used for Box and OneDrive event mappings.

Here is the result:

<img width="882" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/a48f85fd-6280-4f69-8c3d-557ea3724692">

