### PR TITLE
Adding percentile attribute to the EPSS object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2300,6 +2300,11 @@
       "description": "The path that pertains to the event or object. See specific usage.",
       "type": "string_t"
     },
+    "percentile":{
+      "caption": "EPSS Percentile",
+      "description": "The EPSS score's percentile representing relative importance and ranking of the score in the larger EPSS dataset.",
+      "type": "string_t"
+    },
     "permission": {
       "caption": "Permission",
       "description": "The IAM permission related to an event",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2303,7 +2303,7 @@
     "percentile":{
       "caption": "EPSS Percentile",
       "description": "The EPSS score's percentile representing relative importance and ranking of the score in the larger EPSS dataset.",
-      "type": "string_t"
+      "type": "float_t"
     },
     "permission": {
       "caption": "Permission",

--- a/objects/epss.json
+++ b/objects/epss.json
@@ -4,17 +4,20 @@
   "extends": "object",
   "name": "epss",
   "attributes": {
-    "score":{
+    "created_time": {
+      "description": "The timestamp indicating when the EPSS score was calculated.",
+      "requirement": "recommended"
+    },
+    "percentile": {
+      "requirement": "optional"
+    },
+    "score": {
       "caption": "EPPS Score",
       "description": "The EPSS score representing the probability [0-1] of exploitation in the wild in the next 30 days (following score publication).",
       "requirement": "required"
     },
     "version": {
       "description": "The version of the EPSS model used to calcuate the score.",
-      "requirement": "recommended"
-    },
-    "created_time": {
-      "description": "The timestamp indicating when the EPSS score was calculated.",
       "requirement": "recommended"
     }
   }


### PR DESCRIPTION
#### Related PR: https://github.com/ocsf/ocsf-schema/pull/805

#### Description of changes:
1. Refactoring https://github.com/ocsf/ocsf-schema/pull/805
2. Adding EPSS percentile attribute to dictionary and the epss object
https://www.first.org/epss/articles/prob_percentile_bins
3. Sorting attributes in the epss object.
![Screenshot 2023-10-24 at 1 48 04 PM](https://github.com/ocsf/ocsf-schema/assets/89877409/3d3b6f0d-0468-48de-8418-b4b54395a892)
