### PR TITLE
chore: fix whitespace issues in the CVSS object

### DIFF
--- a/objects/cvss.json
+++ b/objects/cvss.json
@@ -12,7 +12,7 @@
       "requirement": "recommended"
     },
     "metrics": {
-      "description": "The Common Vulnerability Scoring System metrics.This attribute contains information on the CVE's impact. If the CVE has been analyzed, this attribute will contain any CVSSv2 or CVSSv3 information associated with the vulnerability. For example: <code> {{\"Access Vector\", \"Network\"}, {\"Access Complexity\", \"Low\"}, ...}</code>.",
+      "description": "The Common Vulnerability Scoring System metrics. This attribute contains information on the CVE's impact. If the CVE has been analyzed, this attribute will contain any CVSSv2 or CVSSv3 information associated with the vulnerability. For example: <code>{ {\"Access Vector\", \"Network\"}, {\"Access Complexity\", \"Low\"}, ...}</code>.",
       "requirement": "optional"
     },
     "overall_score": {


### PR DESCRIPTION
#### Related Issue: 

None.

#### Description of changes:

The `objects/cvss.json` object contains description that misses a whitespace but an additional whitespace within the `<code>` block.

The `{{` pattern in the example within the current description string also causes confusion with readers that it is related to templating syntaxes such as handlebars or liquid.