### PR TITLE
#833 add tenant_uid to metadata

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1028,6 +1028,10 @@
       "type": "string_t"
     },
     "customer_uid": {
+      "@deprecated": {
+        "message": "Use the <code> tenant_uid </code> attribute instead.",
+        "since": "v1.1.0"
+      },
       "caption": "Customer UID",
       "description": "The unique customer identifier.",
       "type": "string_t"
@@ -3229,6 +3233,11 @@
       "caption": "Timezone Offset",
       "description": "The number of minutes that the reported event <code>time</code> is ahead or behind UTC, in the range -1,080 to +1,080.",
       "type": "integer_t"
+    },
+    "tenant_uid": {
+      "caption": "Tenant UID",
+      "description": "The unique tenant identifier.",
+      "type": "string_t"
     },
     "title": {
       "caption": "Title",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -7,9 +7,6 @@
     "correlation_uid": {
       "requirement": "optional"
     },
-    "customer_uid": {
-      "requirement": "recommended"
-    },
     "event_code": {
       "requirement": "optional"
     },
@@ -61,6 +58,9 @@
     },
     "sequence": {
       "requirement": "optional"
+    },
+    "tenant_uid": {
+      "requirement": "recommended"
     },
     "uid": {
       "caption": "Event UID",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -7,6 +7,9 @@
     "correlation_uid": {
       "requirement": "optional"
     },
+    "customer_uid": {
+      "requirement": "recommended"
+    },
     "event_code": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: #833 

#### Description of changes:

Adds the `tenant_uid` attribute to the `metadata` object. See Issue #833 for background.

<img width="993" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/c0709dd0-8d37-4125-a891-d3da685e8870">