### PR TITLE
Adding optional UID attribute to Certificate object

### DIFF
--- a/objects/certificate.json
+++ b/objects/certificate.json
@@ -31,6 +31,10 @@
       "description": "The certificate subject distinguished name.",
       "requirement": "recommended"
     },
+    "uid": {
+      "description": "The unique identifier of the certificate.",
+      "requirement": "optional"
+    },
     "version": {
       "description": "The certificate version.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: [838](https://github.com/ocsf/ocsf-schema/issues/838)

#### Description of changes: 
Updated the `certificate` object to include an optional `UID` attribute. This will allow certificate names to be captured in logs. 

![image](https://github.com/ocsf/ocsf-schema/assets/51964316/60d34943-8aa8-4a83-9ca8-ce95126cd3a5)
