### PR TITLE
#816 Boolean-Type Consistency

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1735,7 +1735,7 @@
     },
     "is_http_only": {
       "caption": "HTTP Only",
-      "description": "A cookie attribute to make it inaccessible via JavaScript",
+      "description": "This attribute prevents the cookie from being accessed via JavaScript.",
       "type": "boolean_t"
     },
     "is_managed": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2879,7 +2879,7 @@
         "since": "v1.1.0"
       },
       "caption": "Secure",
-      "description": "The cookie attribute indicates that cookies are sent to the server only when the request is encrypted using the HTTPS protocol.",
+      "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
       "type": "boolean_t"
     },
     "security_descriptor": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2879,7 +2879,7 @@
         "since": "v1.1.0"
       },
       "caption": "Secure",
-      "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
+      "description": "The cookie attribute indicates that cookies are sent to the server only when the request is encrypted using the HTTPS protocol.",
       "type": "boolean_t"
     },
     "security_descriptor": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1775,7 +1775,7 @@
     },
     "is_secure": {
       "caption": "Secure",
-      "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
+      "description": "The cookie attribute indicates that cookies are sent to the server only when the request is encrypted using the HTTPS protocol.",
       "type": "boolean_t"
     },
     "is_superseded": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1541,6 +1541,10 @@
       "type": "string_t"
     },
     "http_only": {
+      "@deprecated": {
+        "message": "Use the <code> is_http_only </code> attribute instead.",
+        "since": "v1.1.0"
+      },
       "caption": "HTTP Only",
       "description": "A cookie attribute to make it inaccessible via JavaScript",
       "type": "boolean_t"
@@ -1729,6 +1733,11 @@
       "description": "Indicates if a fix is available for the reported vulnerability.",
       "type": "boolean_t"
     },
+    "is_http_only": {
+      "caption": "HTTP Only",
+      "description": "A cookie attribute to make it inaccessible via JavaScript",
+      "type": "boolean_t"
+    },
     "is_managed": {
       "caption": "Managed Device",
       "description": "The event occurred on a managed device.",
@@ -1762,6 +1771,16 @@
     "is_renewal": {
       "caption": "Renewal",
       "description": "The indication of whether this is a lease/session renewal event.",
+      "type": "boolean_t"
+    },
+    "is_secure": {
+      "caption": "Secure",
+      "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
+      "type": "boolean_t"
+    },
+    "is_superseded": {
+      "caption": "The patch is superseded.",
+      "description": "The vendor patch has been replaced by another.",
       "type": "boolean_t"
     },
     "is_system": {
@@ -2855,6 +2874,10 @@
       "type": "integer_t"
     },
     "secure": {
+      "@deprecated": {
+        "message": "Use the <code> is_secure </code> attribute instead.",
+        "since": "v1.1.0"
+      },
       "caption": "Secure",
       "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
       "type": "boolean_t"
@@ -3178,11 +3201,6 @@
       "caption": "Supporting Data",
       "description": "Additional data supporting a finding as provided by security tool",
       "type": "json_t"
-    },
-    "superseded": {
-      "caption": "The patch is superseded.",
-      "description": "The vendor patch has been replaced by another.",
-      "type": "boolean_t"
     },
     "surname": {
       "caption": "Surname",

--- a/objects/http_cookie.json
+++ b/objects/http_cookie.json
@@ -14,6 +14,12 @@
     "http_only": {
       "requirement": "optional"
     },
+    "is_http_only": {
+      "requirement": "optional"
+    },
+    "is_secure": {
+      "requirement": "optional"
+    },
     "name": {
       "description": "The HTTP cookie name.",
       "requirement": "required"

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -28,7 +28,7 @@
       "description": "The product details the kb article applies.",
       "requirement": "optional"
     },
-    "superseded": {
+    "is_superseded": {
       "description": "The kb article has been replaced by another.",
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: #816 

#### Description of changes:

This PR establishes a consistent convention of prepending `is_` to our naming of boolean-type fields. 

To ensure this is non-breaking, the following `v1.0.0` fields were deprecated:

- `http_only` - now use `is_http_only`
-  `secure` - now use `is_secure`

In addition, the `1.1.0-dev` field `superseded` has become `is_superseded`.

All field references were updated to reflect the change:

<img width="782" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/ab3bdfb6-e1df-45a4-8f63-3d347f7170c8">

<img width="751" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/0b9e178f-4a99-4a90-9140-be14cce49b20">

<img width="801" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/806c26ac-8aed-45f0-beb2-aaf284b9dc54">


