### PR TITLE
Adding the existing Policy object to the account change event class.

### DIFF
--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -33,11 +33,11 @@
         },
         "7": {
           "caption": "Attach Policy",
-          "description": "A user/role was changed."
+          "description": "An IAM Policy was attached to a user/role."
         },
         "8": {
           "caption": "Detach Policy",
-          "description": "A user/role was changed."
+          "description": "An IAM Policy was detached from a user/role."
         },
         "9": {
           "caption": "Lock",
@@ -60,6 +60,11 @@
     },
     "http_request": {
       "description": "Details about the underlying http request.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "policy": {
+      "description": "Details about the IAM policy associated to the Attach/Detach Policy activities.",
       "group": "context",
       "requirement": "optional"
     },


### PR DESCRIPTION
Current Account Change class doesn't account for policy details that events provide for Attach, Detach Policy activity_ids. Adding the existing object to this class to support it. 

#### Description of changes:

1. Adding Policy object to the account_change event class.
2. Adding clearer descriptions to Attach/Detach Policy activity ids

![Screenshot 2023-11-06 at 9 12 42 AM](https://github.com/ocsf/ocsf-schema/assets/89877409/5b403970-ad58-4b78-aedb-0b93a391ba2a)
