### PR TITLE
Fixing a missing dictionary entry for the run_count field.

### DIFF
--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -18,6 +18,11 @@
       "description": "The registry value.",
       "type": "registry_value"
     },
+    "run_count": {
+      "caption": "Run Count",
+      "description": "The prefetch file run count.",
+      "type": "integer_t"
+    },
     "prev_reg_value": {
       "caption": "Previous Registry Value",
       "description": "The registry value before the mutation",


### PR DESCRIPTION
Fixed a missing dictionary entry for the run_count field.
It is for the prefetch event class (part of the Windows extension).
