### PR TITLE
Add Package Info event

### DIFF
--- a/events/discovery/package_info.json
+++ b/events/discovery/package_info.json
@@ -1,0 +1,13 @@
+{
+  "caption": "Package Info",
+  "description": "Package Info events report information about packages that are present on the system.",
+  "extends": "discovery_result",
+  "name": "package_info",
+  "uid": 19,
+  "attributes": {
+    "package": {
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
#### Description of changes:
Adding Package Info discovery event. Can be used when a package is discovered and then is later used as a related event for a finding. 

