### PR TITLE
Deprecate the proxy (endpoint) object and move it to the network proxy profile

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2524,6 +2524,10 @@
       "type": "string_t"
     },
     "proxy": {
+      "@deprecated": {
+        "message": "Use the <code> proxy_endpoint </code> attribute instead.",
+        "since": "v1.0.0"
+      },
       "caption": "Proxy",
       "description": "The proxy (server) in a network connection.",
       "type": "network_proxy"

--- a/dictionary.json
+++ b/dictionary.json
@@ -2533,6 +2533,11 @@
       "description": "The proxy (server) in a network connection.",
       "type": "network_proxy"
     },
+    "purl":{
+      "caption": "Package URL",
+      "description": "A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programing languages, package managers, packaging conventions, tools, APIs and databases.",
+      "type": "string_t"
+    },
     "proxy_connection_info": {
       "caption": "Proxy Connection Info",
       "description": "The connection information from the proxy server to the remote server.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2528,10 +2528,10 @@
       "description": "The proxy (server) in a network connection.",
       "type": "network_proxy"
     },
-    "purl":{
-      "caption": "Package URL",
-      "description": "A purl is a URL string used to identify and locate a software package in a mostly universal and uniform way across programing languages, package managers, packaging conventions, tools, APIs and databases.",
-      "type": "string_t"
+    "proxy_endpoint": {
+      "caption": "Proxy Endpoint",
+      "description": "The proxy (server) in a network connection.",
+      "type": "network_proxy"
     },
     "proxy_connection_info": {
       "caption": "Proxy Connection Info",

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -60,6 +60,10 @@
       "requirement": "required"
     },
     "proxy": {
+      "@deprecated": {
+        "message": "Proxy has been decoupled from this object, instead use <code> proxy_endpoint </code> in the <code> Network Proxy </code> profile.",
+        "since": "v1.1.0"
+      },
       "group": "primary",
       "requirement": "optional"
     },

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -60,10 +60,6 @@
       "requirement": "required"
     },
     "proxy": {
-      "@deprecated": {
-        "message": "Proxy has been decoupled from this object, instead use <code> proxy_endpoint </code> in the <code> Network Proxy </code> profile.",
-        "since": "v1.1.0"
-      },
       "group": "primary",
       "requirement": "optional"
     },

--- a/profiles/network_proxy.json
+++ b/profiles/network_proxy.json
@@ -7,6 +7,10 @@
     "group": "context"
   },
   "attributes": {
+    "proxy_endpoint": {
+      "description": "The proxy (server) in a network connection.",
+      "requirement": "optional"
+    },
     "proxy_connection_info": {
       "description": "The connection information from the proxy server to the remote server.",
       "requirement": "recommended"


### PR DESCRIPTION
Deprecating the proxy (endpoint) object in order to keep the network proxy related fields together in the profile. A new field (proxy_endpoint) has been added to replace it in the profile.