### PR TITLE
Issue 854: Add URL to network activity class

### DIFF
--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -2,7 +2,7 @@
   "uid": 3,
   "caption": "DNS Activity",
   "description": "DNS Activity events report DNS queries and answers as seen on the network.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "dns_activity",
   "attributes": {
     "activity_id": {

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -2,7 +2,7 @@
   "caption": "Network File Activity",
   "description": "Network File Activity events report file activities traversing the network, including file storage services such as Box, MS OneDrive, or Google Drive.",
   "category": "network",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "network_file_activity",
   "uid": 10,
   "attributes": {

--- a/events/network/ftp.json
+++ b/events/network/ftp.json
@@ -1,7 +1,7 @@
 {
   "caption": "FTP Activity",
   "description": "File Transfer Protocol (FTP) Activity events report file transfers between a server and a client as seen on the network.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "ftp_activity",
   "uid": 8,
   "attributes": {

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -2,7 +2,7 @@
   "caption": "HTTP Activity",
   "category": "network",
   "description": "HTTP Activity events report HTTP connection and traffic information.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "http_activity",
   "uid": 2,
   "attributes": {

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -1,10 +1,9 @@
 {
-  "caption": "Network Activity",
+  "caption": "Network",
   "category": "network",
-  "description": "Network Activity events report network connection and traffic activity.",
+  "description": "Network event is a generic event that defines a set of attributes available in the Network category.",
   "extends": "base_event",
-  "name": "network_activity",
-  "uid": 1,
+  "name": "network",
   "profiles": [
     "host",
     "network_proxy",

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -1,0 +1,15 @@
+{
+  "caption": "Network Activity",
+  "category": "network",
+  "description": "Network Activity events report network connection and traffic activity.",
+  "extends": "network",
+  "name": "network_activity",
+  "uid": 1,
+  "attributes": {
+    "url": {
+      "description": "The URL details relevant to the network traffic.",
+      "group": "primary",
+      "requirement": "optional"
+    }
+  }
+}

--- a/events/network/ntp.json
+++ b/events/network/ntp.json
@@ -1,7 +1,7 @@
 {
   "caption": "NTP Activity",
   "description": "The Network Time Protocol (NTP) Activity events report instances of remote clients synchronizing their clocks with an NTP server, as observed on the network.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "ntp_activity",
   "uid": 13,
   "attributes": {

--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -1,7 +1,7 @@
 {
   "caption": "RDP Activity",
   "description": "Remote Desktop Protocol (RDP) Activity events report remote client connections to a server as seen on the network.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "rdp_activity",
   "uid": 5,
   "attributes": {

--- a/events/network/smb.json
+++ b/events/network/smb.json
@@ -1,7 +1,7 @@
 {
   "caption": "SMB Activity",
   "description": "Server Message Block (SMB) Protocol Activity events report client/server connections sharing resources within the network.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "smb_activity",
   "uid": 6,
   "attributes": {

--- a/events/network/ssh.json
+++ b/events/network/ssh.json
@@ -1,7 +1,7 @@
 {
   "caption": "SSH Activity",
   "description": "SSH Activity events report remote client connections to a server using the Secure Shell (SSH) Protocol.",
-  "extends": "network_activity",
+  "extends": "network",
   "name": "ssh_activity",
   "uid": 7,
   "attributes": {


### PR DESCRIPTION
#### Related Issue: 
#854 
#### Description of changes:
- Create network base class to be extended by other network activity events
- Add optional URL attribute to Network Activity event class

<img width="1290" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/4d08cc0a-2cf0-4706-9fee-ec0f39a98a36">

