### PR TITLE
Fixed requirement for compliance standards

### DIFF
--- a/objects/compliance.json
+++ b/objects/compliance.json
@@ -11,7 +11,7 @@
       "requirement": "optional"
     },
     "standards": {
-      "requirement": "requirement"
+      "requirement": "required"
     },
     "status": {
       "description": "The resultant status of the compliance check  normalized to the caption of the <code>status_id</code> value. In the case of 'Other', it is defined by the event source.",


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:
This was a simple fix discovered via testing through the new metaschemas from #736.  `"requirement"` is not a valid value for `"requirement"`, I assume it was meant to be `"required"`.
