### PR TITLE
replace kb_articles with patch_list dictionary.json

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1831,7 +1831,7 @@
       "caption": "Knowledgebase Articles",
       "description": "The KB article/s related to the entity. A KB Article contains metadata that describes the patch or an update.",
       "is_array": true,
-      "type": "kb_article"
+      "type": "string_t"
     },
     "kernel": {
       "caption": "Kernel",
@@ -2327,6 +2327,12 @@
       "caption": "Parent Process",
       "description": "The parent process of this process object. It is recommended to only populate this field for the first process object, to prevent deep nesting.",
       "type": "process"
+    },
+    "patch_list": {
+      "caption": "Knowledgebase Articles",
+      "description": "A list KB articles or patches related to an endpoint.",
+      "is_array": true,
+      "type": "kb_article"
     },
     "path": {
       "caption": "Path",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2330,7 +2330,7 @@
     },
     "patch_list": {
       "caption": "Knowledgebase Articles",
-      "description": "A list KB articles or patches related to an endpoint.",
+      "description": "A list of KB articles or patches related to an endpoint.",
       "is_array": true,
       "type": "kb_article"
     },


### PR DESCRIPTION
Fix the type back to string_t for issue: 855 Breaking change in kb_articles between 1.0.0 and 1.1.0-dev
Create new patch_list that can be used by the kb_article object to contain an array of kb or patches.

#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/855





