### PR TITLE
Fixed is_array property for loggers

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1992,7 +1992,7 @@
     "loggers": {
       "caption": "Loggers",
       "description": "An array of Logger objects that describe the devices and logging products between the event source and its eventual destination. Note, this attribute can be used when there is a complex end-to-end path of event flow.",
-      "is_array": "true",
+      "is_array": true,
       "type": "logger"
     },
     "logon_process": {


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:
This was a simple fix discovered via testing through enhancements to the new metaschemas from https://github.com/ocsf/ocsf-schema/pull/736 that cover `dictionary.json` files. `is_array` is meant to be a boolean field (`true`) but in this case is defined as a string instead `"true"`.