### PR TITLE
Replace reg_value.type_id with official Microsoft Windows specification

### DIFF
--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -28,41 +28,41 @@
       "requirement": "required"
     },
     "type": {
-      "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a>.",
+      "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a> and <a target='_blank' href='https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/25cce700-7fcf-4bb6-a2f3-0f6d08430a55'>Registry Value Type ID</a>",
       "requirement": "optional"
     },
     "type_id": {
       "description": "The value type ID.",
       "enum": {
-        "1": {
-          "caption": "REG_BINARY"
+        "0": {
+          "caption": "REG_NONE"
         },
-        "10": {
+        "1": {
           "caption": "REG_SZ"
         },
         "2": {
-          "caption": "REG_DWORD"
-        },
-        "3": {
-          "caption": "REG_DWORD_BIG_ENDIAN"
-        },
-        "4": {
           "caption": "REG_EXPAND_SZ"
         },
+        "3": {
+          "caption": "REG_BINARY"
+        },
+        "4": {
+          "caption": "REG_DWORD"
+        },
         "5": {
-          "caption": "REG_LINK"
+          "caption": "REG_DWORD_BIG_ENDIAN"
         },
         "6": {
-          "caption": "REG_MULTI_SZ"
+          "caption": "REG_LINK"
         },
         "7": {
-          "caption": "REG_NONE"
+          "caption": "REG_MULTI_SZ"
         },
         "8": {
-          "caption": "REG_QWORD"
+          "caption": "REG_RESOURCE_LIST"
         },
-        "9": {
-          "caption": "REG_QWORD_LITTLE_ENDIAN"
+        "11": {
+          "caption": "REG_QWORD"
         }
       },
       "requirement": "recommended"


### PR DESCRIPTION
Use official Microsoft Windows Type ID for registry objects

Reference: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-rprn/25cce700-7fcf-4bb6-a2f3-0f6d08430a55

Reason: Avoid maintaining separate registry Type ID mapping for Microsoft Windows and another for OCSF registry value type ID specification