### PR TITLE
Removing unused default keys from the dictionary

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -348,19 +348,16 @@
     },
     "bytes": {
       "caption": "Total Bytes",
-      "default": 0,
       "description": "The total number of bytes (in and out).",
       "type": "long_t"
     },
     "bytes_in": {
       "caption": "Bytes In",
-      "default": 0,
       "description": "The number of bytes sent from the destination to the source.",
       "type": "long_t"
     },
     "bytes_out": {
       "caption": "Bytes Out",
-      "default": 0,
       "description": "The number of bytes sent from the source to the destination.",
       "type": "long_t"
     },
@@ -665,7 +662,6 @@
     },
     "category_uid": {
       "caption": "Category ID",
-      "default": 0,
       "description": "The category unique identifier of the event.",
       "sibling": "category_name",
       "type": "integer_t"
@@ -736,7 +732,6 @@
     },
     "class_uid": {
       "caption": "Class ID",
-      "default": 0,
       "description": "The unique identifier of a class. A Class describes the attributes available in an event.",
       "sibling": "class_name",
       "type": "integer_t"
@@ -963,7 +958,6 @@
     },
     "count": {
       "caption": "Count",
-      "default": 1,
       "description": "The number of times that events in the same logical group occurred during the event <strong>Start Time</strong> to <strong>End Time</strong> period.",
       "type": "integer_t"
     },
@@ -2302,19 +2296,16 @@
     },
     "packets": {
       "caption": "Total Packets",
-      "default": 0,
       "description": "The total number of packets (in and out).",
       "type": "long_t"
     },
     "packets_in": {
       "caption": "Packets In",
-      "default": 0,
       "description": "The number of packets sent from the destination to the source.",
       "type": "long_t"
     },
     "packets_out": {
       "caption": "Packets Out",
-      "default": 0,
       "description": "The number of packets sent from the source to the destination.",
       "type": "long_t"
     },
@@ -3343,7 +3334,6 @@
     },
     "type_id": {
       "caption": "Type ID",
-      "default": 0,
       "description": "The normalized type identifier of an object. See specific usage.",
       "enum": {
         "99": {


### PR DESCRIPTION
#### Description of changes:

1. Removing `default` keys from the dictionary. @rickmode confirmed these are unused in the server and serve no purpose. 

