### PR TITLE
Add the domain attribute to the group object

### DIFF
--- a/objects/group.json
+++ b/objects/group.json
@@ -8,6 +8,10 @@
       "description": "The group description.",
       "requirement": "optional"
     },
+    "domain": {
+      "description": "The domain where the group is defined. For example: the LDAP or Active Directory domain.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The group name."
     },


### PR DESCRIPTION
#### Description of changes:

The `group` object does not contain a pertinent piece of info which is common in logs: the group's `domain`. This PR simply adds the `domain` attribute to the `group` object.

Here are some examples of when the group's `domain` is logged:

- https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4732
- https://learn.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4733

<img width="985" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/9b1524eb-457a-4377-bf80-ec7bbfccd1ca">
