### PR TITLE
Deprecate unused group_name

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1485,6 +1485,10 @@
       "type": "group"
     },
     "group_name": {
+      "@deprecated": {
+        "message": "Use the <code> group.name </code> attribute instead.",
+        "since": "v1.1.0"
+      },
       "caption": "Group Name",
       "description": "The name of the group that the resource belongs to.",
       "type": "string_t"

--- a/dictionary.json
+++ b/dictionary.json
@@ -1487,7 +1487,7 @@
     "group_name": {
       "@deprecated": {
         "message": "Use the <code> group.name </code> attribute instead.",
-        "since": "v1.1.0"
+        "since": "1.1.0"
       },
       "caption": "Group Name",
       "description": "The name of the group that the resource belongs to.",

--- a/objects/group.json
+++ b/objects/group.json
@@ -8,6 +8,10 @@
       "description": "The group description.",
       "requirement": "optional"
     },
+    "domain": {
+      "description": "The domain where the group is defined. For example: the LDAP or Active Directory domain.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The group name."
     },


### PR DESCRIPTION
#### Related Issue: #872

#### Description of changes:

Deprecates the un-referenced `group_name` attribute, which is supplemented by the existing `group.name` attribute.

<img width="886" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/e208090f-0eb0-44d5-8841-926b8c28b6f4">
