### PR TITLE
Demote class and type within dns_query/dns_answer to be recommended

### DIFF
--- a/objects/_dns.json
+++ b/objects/_dns.json
@@ -7,7 +7,7 @@
     "class": {
       "description": "The class of resource records being queried. See <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc1035.txt'>RFC1035</a>. For example: <code>IN</code>.",
       "caption": "Resource Record Class",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "packet_uid": {
       "description": "The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.",
@@ -16,7 +16,7 @@
     "type": {
       "description": "The type of resource records being queried. See <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc1035.txt'>RFC1035</a>. For example: A, AAAA, CNAME, MX, and NS.",
       "caption": "Resource Record Type",
-      "requirement": "required"
+      "requirement": "recommended"
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: 
#878 
#### Description of changes:

- Changed the requirement for the `class` and `type` attributes within the `dns_query` and `dns_answer` objects to be `recommended` instead of `required`.

<img width="1479" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/0762a558-537c-4cc7-ae01-f9cf4eab4c2a">

<img width="1473" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/efe99d42-e99f-4620-a70d-274c27f5d529">

