### PR TITLE
Add start/end session activity_ids

### DIFF
--- a/events/iam/authorize_session.json
+++ b/events/iam/authorize_session.json
@@ -14,6 +14,14 @@
         "2": {
           "description": "Assign special groups to a new logon.",
           "caption": "Assign Groups"
+        },
+        "3": {
+          "description": "Start a new session.",
+          "caption": "Start Session"
+        },
+        "4": {
+          "description": "End a session.",
+          "caption": "End Session"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: 
#880 (Authorize Session class has no session 'start' and 'stop' activities)

#### Description of changes: 
This PR adds `start` and `end` activities to the `Authorize Session` class:

<img width="731" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/9e545e06-92aa-45d3-99ac-05498778b588">



