### PR TITLE
Correction of version values in @deprecated tags

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1024,7 +1024,7 @@
     "customer_uid": {
       "@deprecated": {
         "message": "Use the <code> tenant_uid </code> attribute instead.",
-        "since": "v1.1.0"
+        "since": "1.1.0"
       },
       "caption": "Customer UID",
       "description": "The unique customer identifier.",
@@ -1429,7 +1429,7 @@
     "fix_available": {
       "@deprecated": {
         "message": "Use the <code> is_fix_available </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "caption": "Fix Availability",
       "description": "Indicates if a fix is available for the reported vulnerability.",
@@ -1545,7 +1545,7 @@
     "http_only": {
       "@deprecated": {
         "message": "Use the <code> is_http_only </code> attribute instead.",
-        "since": "v1.1.0"
+        "since": "1.1.0"
       },
       "caption": "HTTP Only",
       "description": "A cookie attribute to make it inaccessible via JavaScript",
@@ -1564,7 +1564,7 @@
     "http_status": {
       "@deprecated": {
         "message": "Use the <code> http_response.code </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "caption": "HTTP Status",
       "description": "The Hypertext Transfer Protocol (HTTP) <a target='_blank' href='https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
@@ -2281,7 +2281,7 @@
     "packages": {
       "@deprecated": {
         "message": "Use the <code> affected_packages </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "caption": "Software Packages",
       "description": "List of vulnerable packages as identified by the security product",
@@ -2521,7 +2521,7 @@
     "proxy": {
       "@deprecated": {
         "message": "Use the <code> proxy_endpoint </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "caption": "Proxy",
       "description": "The proxy (server) in a network connection.",
@@ -2889,7 +2889,7 @@
     "secure": {
       "@deprecated": {
         "message": "Use the <code> is_secure </code> attribute instead.",
-        "since": "v1.1.0"
+        "since": "1.1.0"
       },
       "caption": "Secure",
       "description": "The cookie attribute to only send cookies to the server with an encrypted request over the HTTPS protocol.",
@@ -3238,7 +3238,7 @@
     "tactics": {
       "@deprecated": {
         "message": "Use the <code> tactic </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "caption": "Tactics",
       "description": "The Tactic object describes the tactic ID and/or tactic name that are associated with the attack technique, as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -18,7 +18,7 @@
     "related_analytics": {
       "@deprecated": {
         "message": "Related Analytics has been decoupled from this object, instead use <code>finding_info.related_analytics</code>.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       },
       "description": "Other analytics related to this analytic.",
       "requirement": "optional"

--- a/objects/finding.json
+++ b/objects/finding.json
@@ -5,7 +5,7 @@
   "name": "finding",
   "@deprecated": {
     "message": "Use the new <code>finding_info</code> object.",
-    "since": "v1.0.0"
+    "since": "1.0.0"
   },
   "attributes": {
     "created_time": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -14,7 +14,7 @@
       "requirement": "optional",
       "@deprecated": {
         "message": "Use the <code> extensions </code> attribute instead.",
-        "since": "v1.0.0"
+        "since": "1.0.0"
       }
     },
     "extensions": {


### PR DESCRIPTION
#### Related PR: https://github.com/ocsf/ocsf-server/pull/57

#### Description of changes:

1. Cleaning up incorrect version definitions in `@deprecated` tags
