### PR TITLE
New Load Balancer object for HTTP Activity 4002

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1302,6 +1302,18 @@
       "description": "The end time of a time period. See specific usage.",
       "type": "timestamp_t"
     },
+    "endpoint": {
+      "caption": "Endpoints",
+      "description": "The Endpoint/s related to the entity.",
+      "is_array": true,
+      "type": "network_endpoint"
+    },
+    "endpoint_connections": {
+      "caption": "Endpoint Connections",
+      "description": "Connection attempts and their responses. See specific usage.",
+      "is_array": true,
+      "type": "endpoint_connections"
+    },
     "enrichments": {
       "caption": "Enrichments",
       "description": "The additional information from an external data source, which is associated with the event. For example add location information for the IP address in the DNS answers:</p><code>[{\"name\": \"answers.ip\", \"value\": \"92.24.47.250\", \"type\": \"location\", \"data\": {\"city\": \"Socotra\", \"continent\": \"Asia\", \"coordinates\": [-25.4153, 17.0743], \"country\": \"YE\", \"desc\": \"Yemen\"}}]</code>",
@@ -1948,6 +1960,11 @@
       "caption": "Software License",
       "description": "The name or identifier of the license applied on package or software. See <a target='_blank' href='https://spdx.org/licenses/'>SPDX License List</a>.",
       "type": "string_t"
+    },
+    "load_balancer": {
+      "caption": "Load Balancer",
+      "description": "The Load Balancer object contains information related to the device that is distributing incoming traffic to specified destinations.",
+      "type": "load_balancer"
     },
     "load_type": {
       "caption": "Load Type",

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -56,6 +56,10 @@
     },
     "http_status": {
       "group": "primary"
+    },
+    "load_balancer":{
+      "group": "primary",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/endpoint_connections.json
+++ b/objects/endpoint_connections.json
@@ -1,0 +1,26 @@
+{
+    "caption": "Endpoint Connections",
+    "name": "endpoint_connections",
+    "description": "The Endpoint Connections object contains information regarding the connections to multiple destination endpoints.",
+    "extends": "object",
+    "attributes": {
+        "code": { 
+            "caption": "Response Code",
+            "description": "A numeric response status code detailing the connection.",
+            "requirement": "optional"
+            },
+        "endpoint": {  
+            "caption": "Endpoint Array", 
+            "description": "An array of endpoint/s that fielded the connection attempt.",
+            "requirement": "optional"
+        }
+    },
+    "constraints": {
+        "at_least_one": [
+          "endpoint",
+          "code"
+        ]
+    }
+}
+    
+  

--- a/objects/load_balancer.json
+++ b/objects/load_balancer.json
@@ -1,0 +1,57 @@
+{
+    "caption": "Load Balancer",
+    "name": "load_balancer",
+    "extends": "_entity", 
+    "description": "The load balancer object describes the load balancer entity and contains additional information regarding the distribution of traffic across a network.",
+    "attributes": {
+ 
+    "metrics": {
+        "caption": "Metrics",
+        "description": "General purpose metrics associated with the load balancer.",
+        "is_array": true,
+        "requirement": "optional"
+        },
+    "dst_endpoint": { 
+        "caption": "Destination Endpoint",
+        "description": "The destination that the load balancer is distibuting traffic to.",
+        "requirement": "recommended"
+        },
+    "code": {
+        "caption": "Response Code",
+        "description": "The numeric response status code detailing the connection from the load balancer to the destination target.",
+        "requirement": "recommended"
+        },
+    "endpoint_connections":{
+        "caption": "Endpoint Connections",
+        "description": "An object detailing the load balancer connection attempts and responses.",
+        "requirement": "recommended"
+    },    
+    "classification": {
+        "caption": "Classification",
+        "description": "The request classification as defined by the load balancer.",
+        "requirement": "optional"
+        },
+    "status_detail": {
+        "caption": "Status Detail",
+        "description": "The status detail contains additional status information about the load balancer distribution event.",
+        "requirement": "optional"
+        },
+    "error_message": {
+        "caption": "Error Message",
+        "description": "The load balancer error message.",
+        "requirement": "optional"
+        },
+    "message": {
+        "caption": "Message",
+        "description": "The load balancer message.",
+        "requirement": "optional"
+        }, 
+    "name": {
+        "description": "The name of the load balancer."
+        },
+    "uid": {
+        "description": "The unique identfier for the load balancer."
+        }
+
+    }
+} 


### PR DESCRIPTION
#### Related Issue: [Discussion 846](https://github.com/ocsf/ocsf-schema/discussions/846)

#### Description of changes: Updated from [Draft PR 861](https://github.com/ocsf/ocsf-schema/pull/861). 

- Created a new `Load Balancer` object that contains specific Load Balancer related information and added that object as an optional attribute in HTTP Activity 4002
- Created a new `endpoint_connections` object that sits as an attribute inside of the `load_balancer` object
- Created a new `endpoint` attribute that is an array of Network Endpoint objects
- Lastly, updated the dictionary with the necessary additions `endpoint`, `endpoint_connections`, and `load_balancer `

