### PR TITLE
DHCP event class to extend network base class

### DIFF
--- a/events/network/dhcp.json
+++ b/events/network/dhcp.json
@@ -2,7 +2,7 @@
   "caption": "DHCP Activity",
   "category": "network",
   "description": "DHCP Activity events report MAC to IP assignment via DHCP from a client or server.",
-  "extends": "base_event",
+  "extends": "network",
   "name": "dhcp_activity",
   "profiles": [
     "host",


### PR DESCRIPTION
#### Related Issue: 
#886 

#### Description of changes:
Alter DHCP event class to extends the network base class in order to inherit basic network attributes and for consistency 

<img width="1487" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/1b61e6de-ee23-478a-9e6a-737c6e6b1caa">

