### PR TITLE
Replace "File Hash" observable Caption with "Hash"

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3615,7 +3615,7 @@
       },
       "file_hash_t": {
         "caption": "Hash",
-        "description": "hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema.",
+        "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>",
         "max_len": 64,
         "observable": 8,
         "type": "string_t",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3614,8 +3614,8 @@
         "type_name": "String"
       },
       "file_hash_t": {
-        "caption": "File Hash",
-        "description": "File hash. A unique value that corresponds to the content of the file.",
+        "caption": "Hash",
+        "description": "hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema.",
         "max_len": 64,
         "observable": 8,
         "type": "string_t",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3615,7 +3615,7 @@
       },
       "file_hash_t": {
         "caption": "Hash",
-        "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>",
+        "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>.",
         "max_len": 64,
         "observable": 8,
         "type": "string_t",


### PR DESCRIPTION
#### Related Issue: (https://github.com/ocsf/ocsf-schema/issues/891)
#### Description of changes:
This change is to edit the Caption and description of Observable `"File Hash"` to read just `"Hash"`
<img width="701" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/13574947/10148db1-b482-4c04-a626-da16dd0e055e">

