### PR TITLE
Demote dst_endpoint from 'required' to 'recommended' in the DNS event…

### DIFF
--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -25,6 +25,9 @@
       "group": "context",
       "requirement": "optional"
     },
+    "dst_endpoint": {
+      "requirement": "recommended"
+    },
     "query": {
       "group": "primary",
       "requirement": "recommended"


### PR DESCRIPTION
… class

#### Related Issue: 
#899 

#### Description of changes:
Alter requirement for the `dst_endpoint` within the DNS event class from `required` to `recommended`.


<img width="1187" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/584476ea-f8bd-4d78-9154-3cb8c2753fcb">
