### PR TITLE
Incident Finding event class definition

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -180,8 +180,13 @@
     },
     "assignee": {
       "caption": "Assignee",
-      "description": "The name of the user assgined to an Incident.",
+      "description": "The details of the user assgined to an Incident.",
       "type": "user"
+    },
+    "assignee_group": {
+      "caption": "Assignee Group",
+      "description": "The details of the group assgined to an Incident.",
+      "type": "group"
     },
     "attacks": {
       "caption": "MITRE ATT&CK® Details",
@@ -1479,7 +1484,7 @@
     },
     "finding_info_list": {
       "caption": "Finding Information List",
-      "description": "A list of associated <code>finding_info</code> objects associated to an incident.",
+      "description": "A list of <code>finding_info</code> objects associated to an incident.",
       "is_array": true,
       "type": "finding_info"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -2558,15 +2558,15 @@
           "caption": "Unknown"
         },
         "1": {
-          "description": "Application or personal procedure unusable, where a workaround is available or a repair is possible.",
+          "description": "Application or personal procedure is unusable, where a workaround is available or a repair is possible.",
           "caption": "Low"
         },
         "2": {
-          "description": "Non-critical function or procedure, unusable or hard to use having an operational impact, but with no direct impact on services availability. A workaround is available.",
+          "description": "Non-critical function or procedure is unusable or hard to use causing operational disruptions with no direct impact on a service's availability. A workaround is available.",
           "caption": "Medium"
         },
         "3": {
-          "description": "Critical functionality or network access interrupted, degraded or unusable, having a severe impact on services availability. No acceptable alternative is possible.",
+          "description": "Critical functionality or network access is interrupted, degraded or unusable, having a severe impact on services availability. No acceptable alternative is possible.",
           "caption": "High"
         },
         "4": {
@@ -3389,7 +3389,7 @@
     },
     "is_suspected_breach": {
       "caption": "Suspected Breach",
-      "description": "A determination based on analytics whether a potential breach was found.",
+      "description": "A determination based on analytics as to whether a potential breach was found.",
       "type": "boolean_t"
     },
     "svc_name": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -180,12 +180,12 @@
     },
     "assignee": {
       "caption": "Assignee",
-      "description": "The details of the user assgined to an Incident.",
+      "description": "The details of the user assigned to an Incident.",
       "type": "user"
     },
     "assignee_group": {
       "caption": "Assignee Group",
-      "description": "The details of the group assgined to an Incident.",
+      "description": "The details of the group assigned to an Incident.",
       "type": "group"
     },
     "attacks": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -178,6 +178,11 @@
       "description": "The arguments sent along with the HTTP request.",
       "type": "string_t"
     },
+    "assignee": {
+      "caption": "Assignee",
+      "description": "The name of the user assgined to an Incident.",
+      "type": "user"
+    },
     "attacks": {
       "caption": "MITRE ATT&CK® Details",
       "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques identified by a security control or finding.",
@@ -1472,6 +1477,12 @@
       "description": "Describes the supporting information about a generated finding.",
       "type": "finding_info"
     },
+    "finding_info_list": {
+      "caption": "Finding Information List",
+      "description": "A list of associated <code>finding_info</code> objects associated to an incident.",
+      "is_array": true,
+      "type": "finding_info"
+    },
     "fingerprint": {
       "caption": "Fingerprint",
       "description": "The digital fingerprint associated with an object.",
@@ -2530,13 +2541,38 @@
     },
     "priority": {
       "caption": "Priority",
-      "description": "The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source. See specific usage.",
+      "description": "The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.",
       "type": "integer_t"
     },
     "priority_id": {
       "caption": "Priority ID",
-      "description": "The normalized priority. See specific usage.",
-      "enum": {},
+      "description": "The normalized priority. Priority identifies the relative importance of the finding. It is a measurement of urgency.",
+      "enum": {
+        "0": {
+          "description": "No priority is assigned.",
+          "caption": "Unknown"
+        },
+        "1": {
+          "description": "Application or personal procedure unusable, where a workaround is available or a repair is possible.",
+          "caption": "Low"
+        },
+        "2": {
+          "description": "Non-critical function or procedure, unusable or hard to use having an operational impact, but with no direct impact on services availability. A workaround is available.",
+          "caption": "Medium"
+        },
+        "3": {
+          "description": "Critical functionality or network access interrupted, degraded or unusable, having a severe impact on services availability. No acceptable alternative is possible.",
+          "caption": "High"
+        },
+        "4": {
+          "description": "Interruption making a critical functionality inaccessible or a complete network interruption causing a severe impact on services availability. There is no possible alternative.",
+          "caption": "Critical"
+        },
+        "99": {
+          "description": "The priority is not normalized.",
+          "caption": "Other"
+        }
+      },
       "sibling": "priority",
       "type": "integer_t"
     },
@@ -2793,6 +2829,43 @@
       "description": "A list of requirements associated to a specific control in an industry or regulatory framework. e.g. <code> NIST.800-53.r5 AU-10 </code>",
       "is_array": true,
       "type": "string_t"
+    },
+    "resolution": {
+      "caption": "Resolution",
+      "description": "The resolution detail for closing the incident.",
+      "type": "string_t"
+    },
+    "resolution_id": {
+      "caption": "Resolution Id",
+      "description": "The normalized identifier of the resolution detail, populated when closing an incident.",
+      "enum": {
+        "99": {
+          "caption": "Other"
+        },
+        "0": {
+          "caption": "Unknown"
+        },
+        "1": {
+          "caption": "Insufficient data"
+        },
+        "2": {
+          "caption": "Security risk"
+        },
+        "3": {
+          "caption": "False positive"
+        },
+        "4": {
+          "caption": "Managed externally"
+        },
+        "5": {
+          "caption": "Benign"
+        },
+        "6": {
+          "caption": "Test"
+        }
+      },
+      "sibling": "resolution",
+      "type": "integer_t"
     },
     "resource": {
       "caption": "Resource",
@@ -3308,6 +3381,11 @@
       "caption": "Surname",
       "description": "The last or family name for the user.",
       "type": "string_t"
+    },
+    "is_suspected_breach": {
+      "caption": "Suspected Breach",
+      "description": "A determination based on analytics whether a potential breach was found.",
+      "type": "boolean_t"
     },
     "svc_name": {
       "caption": "Service Name",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -1,0 +1,145 @@
+{
+  "uid": 3,
+  "caption": "Security Incident",
+  "category": "findings",
+  "description": "Security Incident events report the creation, update, or closure of incidents as a result of detections and/or analytics.",
+  "extends": "base_event",
+  "name": "security_incident",
+  "profiles": [
+    "security_control"
+  ],
+  "attributes": {
+    "$include": [
+      "profiles/security_control.json"
+    ],
+    "activity_id": {
+      "description": "The normalized identifier of the Incident activity.",
+      "enum": {
+        "1": {
+          "caption": "Create",
+          "description": "Reports the creation of an Incident."
+        },
+        "2": {
+          "caption": "Update",
+          "description": "Reports updates to an Incident."
+        },
+        "3": {
+          "caption": "Close",
+          "description": "Reports closure of an Incident ."
+        }
+      },
+      "requirement": "required"
+    },
+    "activity_name": {
+      "description": "The Incident activity name, as defined by the <code>activity_id</code>.",
+      "requirement": "optional"
+    },
+    "assignee": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "comment": {
+      "description": "Additional user supplied details for updating or closing the incident.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "confidence": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "confidence_id": {
+      "group": "context",
+      "requirement": "recommended"
+    },
+    "confidence_score": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "desc": {
+      "description": "The short description of the Incident.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "end_time": {
+      "description": "The time of the most recent event included in the incident.",
+      "requirement": "optional"
+    },
+    "finding_info_list": {
+      "group": "primary",
+      "requirement": "required"
+    },
+    "impact": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "impact_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "impact_score": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "priority": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "priority_id": {
+      "group": "context",
+      "requirement": "recommended"
+    },
+    "resolution": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "resolution_id": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "src_url": {
+      "description": "A Url link used to access the original incident.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "start_time": {
+      "description": "The time of the least recent event included in the incident.",
+      "requirement": "optional"
+    },
+    "status": {
+      "description": "The normalized status of the Incident normalized to the caption of the status_id value. In the case of 'Other', it is defined by the source.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "status_id": {
+      "description": "The normalized status identifier of the Incident.",
+      "enum": {
+        "1": {
+          "caption": "New",
+          "description": "The service desk has received the incident but has not assigned it to an agent."
+        },
+        "2": {
+          "caption": "In Progress",
+          "description": "The incident has been assigned to an agent but has not been resolved. The agent is actively working with the user to diagnose and resolve the incident."
+        },
+        "3": {
+          "caption": "On Hold",
+          "description": "The incident requires some information or response from the user or from a third party."
+        },
+        "4": {
+          "caption": "Resolved",
+          "description": "The service desk has confirmed that the incident is resolved."
+        },
+        "5": {
+          "caption": "Closed",
+          "description": "The incident is resolved and no further action is necessary."
+        }
+      },
+      "group": "primary",
+      "requirement": "required"
+    },
+    "is_suspected_breach": {
+      "group": "context",
+      "requirement": "optional"
+    }
+  }
+}

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -5,13 +5,7 @@
   "description": "An Incident Finding reports the creation, update, or closure of security incidents as a result of detections and/or analytics.",
   "extends": "base_event",
   "name": "incident_finding",
-  "profiles": [
-    "security_control"
-  ],
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "activity_id": {
       "description": "The normalized identifier of the Incident activity.",
       "enum": {

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -36,6 +36,11 @@
       "group": "context",
       "requirement": "optional"
     },
+    "attacks": {
+      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques assocaited to the Incident.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "comment": {
       "description": "Additional user supplied details for updating or closing the incident.",
       "group": "context",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -1,10 +1,10 @@
 {
-  "uid": 3,
-  "caption": "Security Incident",
+  "uid": 5,
+  "caption": "Incident Finding",
   "category": "findings",
-  "description": "Security Incident events report the creation, update, or closure of incidents as a result of detections and/or analytics.",
+  "description": "An Incident Finding reports the creation, update, or closure of security incidents as a result of detections and/or analytics.",
   "extends": "base_event",
-  "name": "security_incident",
+  "name": "incident_finding",
   "profiles": [
     "security_control"
   ],
@@ -35,6 +35,10 @@
       "requirement": "optional"
     },
     "assignee": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "assignee_group": {
       "group": "context",
       "requirement": "optional"
     },
@@ -141,5 +145,11 @@
       "group": "context",
       "requirement": "optional"
     }
+  },
+  "constraints": {
+    "at_least_one" :[
+      "assignee",
+      "assignee_group"
+    ]
   }
 }

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -37,7 +37,7 @@
       "requirement": "optional"
     },
     "attacks": {
-      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques assocaited to the Incident.",
+      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Incident.",
       "group": "context",
       "requirement": "optional"
     },
@@ -146,7 +146,7 @@
     }
   },
   "constraints": {
-    "at_least_one" :[
+    "at_least_one": [
       "assignee",
       "assignee_group"
     ]


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/902 
#### Related PR: https://github.com/ocsf/ocsf-schema/pull/786

#### Description of changes:

1. Refactoring, @maxhotta 's PR to account for the new finding_info object, removing duplicates, adding descriptions.
2. Removing separate enum definitions, since that concept has been deprecated in OCSF.

A few topics to discuss based on https://github.com/ocsf/ocsf-schema/pull/786 - 

1. `findings_info` vs `finding_info_list` - I am okay with either of the two, however finding_info_list makes it easier to distinguish it from finding_info. - based on weekly call - `finding_info_list`
2. `user` vs `assignee` - are both necessary in the class? - keeping assignee, adding `assignee_group`
3. `incident_uid` - haven't added it, `metadata_uid` should be used instead.
