### PR TITLE
adding type/type_id to datastore class

### DIFF
--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -1,83 +1,112 @@
 {
-    "uid": 5,
-    "description": "Datastore events describe general activities (Read, Update, Query, Delete, etc.) which affect datastores or data within those datastores, e.g. (AWS RDS, AWS S3).",
-    "extends": "application",
-    "caption": "Datastore Activity",
-    "name": "datastore_activity",
-    "attributes": {
-        "activity_id": {
-            "enum": {
-                "1": {
-                    "caption": "Read",
-                    "description": "The datastore activity in the event pertains to a 'Read' operation."
-                },
-                "2": {
-                    "caption": "Update",
-                    "description": "The datastore activity in the event pertains to a 'Update' operation."
-                },
-                "3": {
-                    "caption": "Connect",
-                    "description": "The datastore activity in the event pertains to a 'Connect' operation."
-                },
-                "4": {
-                    "caption": "Query",
-                    "description": "The datastore activity in the event pertains to a 'Query' operation."
-                },
-                "5": {
-                    "caption": "Write",
-                    "description": "The datastore activity in the event pertains to a 'Write' operation."
-                },
-                "6": {
-                    "caption": "Create",
-                    "description": "The datastore activity in the event pertains to a 'Create' operation."
-                },
-                "7": {
-                    "caption": "Delete",
-                    "description": "The datastore activity in the event pertains to a 'Delete' operation."
-                }
-            }
-        },
-        "database": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "databucket": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "table": {
-            "group": "primary",
-            "requirement": "optional"
-        },
-        "query_info": {
-            "group": "primary",
-            "requirement": "optional"
-        },
-        "dst_endpoint": {
-            "description": "Details about the endpoint hosting the datastore application or service.",
-            "group": "primary",
-            "requirement": "optional"
-        },
-        "http_request": {
-            "description": "Details about the underlying http request.",
-            "group": "primary",
-            "requirement": "optional"
-        },
-        "actor": {
-            "group": "primary",
-            "requirement": "required"
-        },
-        "src_endpoint": {
-            "description": "Details about the source of the activity.",
-            "group": "primary",
-            "requirement": "required"
-        }
-    },
-    "constraints": {
-      "at_least_one": [
-        "database",
-        "databucket",
-        "table"
-    ]
-  }
+	"uid": 5,
+	"description": "Datastore events describe general activities (Read, Update, Query, Delete, etc.) which affect datastores or data within those datastores, e.g. (AWS RDS, AWS S3).",
+	"extends": "application",
+	"caption": "Datastore Activity",
+	"name": "datastore_activity",
+	"attributes": {
+		"activity_id": {
+			"enum": {
+				"1": {
+					"caption": "Read",
+					"description": "The datastore activity in the event pertains to a 'Read' operation."
+				},
+				"2": {
+					"caption": "Update",
+					"description": "The datastore activity in the event pertains to a 'Update' operation."
+				},
+				"3": {
+					"caption": "Connect",
+					"description": "The datastore activity in the event pertains to a 'Connect' operation."
+				},
+				"4": {
+					"caption": "Query",
+					"description": "The datastore activity in the event pertains to a 'Query' operation."
+				},
+				"5": {
+					"caption": "Write",
+					"description": "The datastore activity in the event pertains to a 'Write' operation."
+				},
+				"6": {
+					"caption": "Create",
+					"description": "The datastore activity in the event pertains to a 'Create' operation."
+				},
+				"7": {
+					"caption": "Delete",
+					"description": "The datastore activity in the event pertains to a 'Delete' operation."
+				}
+			}
+		},
+		"database": {
+			"group": "primary",
+			"requirement": "recommended"
+		},
+		"databucket": {
+			"group": "primary",
+			"requirement": "recommended"
+		},
+		"table": {
+			"group": "primary",
+			"requirement": "optional"
+		},
+		"type": {
+			"caption": "Type",
+			"description": "The datastore resource type (e.g. database, datastore, or table).",
+			"requirement": "optional"
+		},
+		"type_id": {
+			"caption": "Datastore Type ID",
+			"description": "The normalized datastore resource type identifier.",
+			"enum": {
+				"99": {
+					"caption": "Other",
+					"description": "The datastore resource type is not mapped."
+				},
+				"0": {
+					"caption": "Unknown",
+					"description": "The datastore resource type is unknown."
+				},
+				"1": {
+					"caption": "Database"
+				},
+				"2": {
+					"caption": "Databucket"
+				},
+				"3": {
+					"caption": "Table"
+				}
+			},
+			"requirement": "recommended"
+		},
+		"query_info": {
+			"group": "primary",
+			"requirement": "optional"
+		},
+		"dst_endpoint": {
+			"description": "Details about the endpoint hosting the datastore application or service.",
+			"group": "primary",
+			"requirement": "optional"
+		},
+		"http_request": {
+			"description": "Details about the underlying http request.",
+			"group": "primary",
+			"requirement": "optional"
+		},
+		"actor": {
+			"group": "primary",
+			"requirement": "required"
+		},
+		"src_endpoint": {
+			"description": "Details about the source of the activity.",
+			"group": "primary",
+			"requirement": "required"
+		}
+	},
+	"constraints": {
+		"at_least_one": [
+			"database",
+			"databucket",
+			"table"
+		]
+	}
 }

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -50,7 +50,7 @@
 			"requirement": "optional"
 		},
 		"type": {
-			"caption": "Type",
+			"caption": "Datastore Type",
 			"description": "The datastore resource type (e.g. database, datastore, or table).",
 			"requirement": "optional"
 		},


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

Adding the following to the base datastore activity class

		"type": {
			"caption": "Type",
			"description": "The datastore resource type (e.g. database, datastore, or table).",
			"requirement": "optional"
		},
		"type_id": {
			"caption": "Datastore Type ID",
			"description": "The normalized datastore resource type identifier.",
			"enum": {
				"99": {
					"caption": "Other",
					"description": "The datastore resource type is not mapped."
				},
				"0": {
					"caption": "Unknown",
					"description": "The datastore resource type is unknown."
				},
				"1": {
					"caption": "Database"
				},
				"2": {
					"caption": "Databucket"
				},
				"3": {
					"caption": "Table"
				}
			},
			"requirement": "recommended"
		},