### PR TITLE
Move 'Network File Activity' to 'Application -> File Hosting Activity'

### DIFF
--- a/events/application/cloud_file_storage.json
+++ b/events/application/cloud_file_storage.json
@@ -1,14 +1,10 @@
 {
-  "@deprecated": {
-    "message": "Use the new specific class according to the use-case: <code>Cloud File Storage Activity in the Application category</code>",
-    "since": "1.1.0"
-  },
-  "caption": "Network File Activity",
-  "description": "Network File Activity events report file activities traversing the network, including file storage services such as Box, MS OneDrive, or Google Drive.",
-  "category": "network",
-  "extends": "network",
-  "name": "network_file_activity",
-  "uid": 10,
+  "caption": "File Sync & Share",
+  "description": "File Sync & Share events report the actions taken by file management applications, including file sharing services such as Box, MS OneDrive, or Google Drive.",
+  "category": "application",
+  "extends": "application",
+  "name": "cloud_file_storage",
+  "uid": 6,
   "attributes": {
     "activity_id": {
       "enum": {

--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -3,7 +3,7 @@
   "description": "File Hosting Activity events report the actions taken by file management applications, including file sharing servers like Sharepoint and services such as Box, MS OneDrive, or Google Drive.",
   "category": "application",
   "extends": "application",
-  "name": "cloud_file_storage",
+  "name": "file_hosting",
   "uid": 6,
   "attributes": {
     "activity_id": {

--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -1,6 +1,6 @@
 {
-  "caption": "File Sync & Share",
-  "description": "File Sync & Share events report the actions taken by file management applications, including file sharing services such as Box, MS OneDrive, or Google Drive.",
+  "caption": "File Hosting Activity",
+  "description": "File Hosting Activity events report the actions taken by file management applications, including file sharing servers like Sharepoint and services such as Box, MS OneDrive, or Google Drive.",
   "category": "application",
   "extends": "application",
   "name": "cloud_file_storage",

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -1,6 +1,6 @@
 {
   "@deprecated": {
-    "message": "Use the new specific class according to the use-case: <code>Cloud File Storage Activity in the Application category</code>",
+    "message": "Use the new class: <code>'File Hosting Activity' in the 'Application'  category.</code>",
     "since": "1.1.0"
   },
   "caption": "Network File Activity",


### PR DESCRIPTION
#### Related Issue: #905 

#### Description of changes: 
This PR Deprecates the `Network -> Network File Activity` class and replaces it with the `Application -> File Hosting Activity` class. Tested and validated with our Box and OneDrive mappings.

<img width="659" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/27d61bee-79e9-4230-9ebd-b2878823e52c">

<img width="198" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/bae07ad9-f9b2-48d9-9098-e0bbef0de351">

<img width="1059" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/b45f307e-3d00-41df-9b08-1bb21d8408b6">
