### PR TITLE
Remove start/end session activity_ids (reverts #882)

### DIFF
--- a/events/iam/authorize_session.json
+++ b/events/iam/authorize_session.json
@@ -14,14 +14,6 @@
         "2": {
           "description": "Assign special groups to a new logon.",
           "caption": "Assign Groups"
-        },
-        "3": {
-          "description": "Start a new session.",
-          "caption": "Start Session"
-        },
-        "4": {
-          "description": "End a session.",
-          "caption": "End Session"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: 
Reverts PR #882, as this was never needed. Non-breaking because this was done in the `1.1-dev` window. The `Authorize Session` class is all about assigning privileges and groups. After some discussion, we determined that the class should not have `session start` and `session stop` activities, as those activities are out-of-scope for the class. In addition, my original use case (VPN log mapping) is being satisfied via a Splunk Extension class for `Network Tunneling`. If there is appetite in the future, that class could be considered for promotion to OCSF core.

#### Description of changes: 
Reverts PR #882 (removes start/stop session activities from Authorize Session class). This one I would say is time-sensitive since we don't want it to mistakenly go into the `1.1` release.

<img width="1151" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/2d2116e4-1823-42fd-a0a3-c41144669efd">
