### PR TITLE
Add is_vpn attribute to session object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1870,6 +1870,11 @@
       "description": "The event occurred on a trusted device.",
       "type": "boolean_t"
     },
+    "is_vpn": {
+      "caption": "VPN Session",
+      "description": "The indication of whether the session is a VPN session.",
+      "type": "boolean_t"
+    },
     "isp": {
       "caption": "ISP",
       "description": "The name of the Internet Service Provider (ISP).",

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -49,41 +49,48 @@
       "description": "The endpoint type ID.",
       "enum": {
         "1": {
-          "caption": "Server"
+          "caption": "Server",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Server/'>server</a>."
         },
         "2": {
-          "caption": "Desktop"
+          "caption": "Desktop",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:DesktopComputer/'>desktop computer</a>."
         },
         "3": {
-          "caption": "Laptop"
+          "caption": "Laptop",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:LaptopComputer/'>laptop computer</a>."
         },
         "4": {
-          "caption": "Tablet"
+          "caption": "Tablet",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:TabletComputer/'>tablet computer</a>."
         },
         "5": {
-          "caption": "Mobile"
+          "caption": "Mobile",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:MobilePhone/'>mobile phone</a>."
         },
         "6": {
-          "caption": "Virtual"
+          "caption": "Virtual",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:VirtualizationSoftware/'>virtual machine</a>."
         },
         "7": {
-          "caption": "IOT"
+          "caption": "IOT",
+          "description": "A <a target='_blank' href='https://www.techtarget.com/iotagenda/definition/IoT-device'>IOT (Internet of Things) device</a>."
         },
         "8": {
-          "caption": "Browser"
+          "caption": "Browser",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Browser/'>web browser</a>."
         },
         "9": {
-          "caption": "Firewall"
+          "caption": "Firewall",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Firewall/'>networking firewall</a>."
         },
         "10": {
-          "caption": "Switch"
+          "caption": "Switch",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Switch/'>networking switch</a>."
         },
         "11": {
-          "caption": "UTM",
-          "description": "Unified Threat Management device"
-        },
-        "12": {
-          "caption": "Hub"
+          "caption": "Hub",
+          "description": "A <a target='_blank' href='https://en.wikipedia.org/wiki/Ethernet_hub'>networking hub</a>."
         }
       },
       "requirement": "recommended"

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -71,6 +71,19 @@
         },
         "8": {
           "caption": "Browser"
+        },
+        "9": {
+          "caption": "Firewall"
+        },
+        "10": {
+          "caption": "Switch"
+        },
+        "11": {
+          "caption": "UTM",
+          "description": "Unified Threat Management device"
+        },
+        "12": {
+          "caption": "Hub"
         }
       },
       "requirement": "recommended"

--- a/objects/session.json
+++ b/objects/session.json
@@ -22,9 +22,7 @@
       "requirement": "optional"
     },
     "is_vpn": {
-      "caption": "VPN Session",
-      "description": "The indication of whether the session is a VPN session.",
-      "type": "boolean_t"
+      "requirement": "optional"
     },
     "issuer": {
       "description": "The identifier of the session issuer.",

--- a/objects/session.json
+++ b/objects/session.json
@@ -21,6 +21,11 @@
     "is_mfa":{
       "requirement": "optional"
     },
+    "is_vpn": {
+      "caption": "VPN Session",
+      "description": "The indication of whether the session is a VPN session.",
+      "type": "boolean_t"
+    },
     "issuer": {
       "description": "The identifier of the session issuer.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes: 
This PR adds an `is_vpn` attribute to the `session` object. This is a useful way to signify that a given session in any event class is a vpn session - particularly this is useful for security analysts and detection engineers, without the need for a yet-another-profile.

<img width="805" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/ac046ec2-af8b-4770-bbc9-6a29d65273fa">
