### PR TITLE
Move 'Email' classes to 'Application' category

### DIFF
--- a/events/application/email_file.json
+++ b/events/application/email_file.json
@@ -1,14 +1,10 @@
 {
-  "@deprecated": {
-    "message": "Use the new class: <code>'Email URL Activity' in the 'Application' category.</code>",
-    "since": "1.1.0"
-  },
-  "description": "Email URL Activity events report URLs within an email.",
+  "description": "Email File Activity events report files within emails.",
   "extends": "base_event",
-  "caption": "Email URL Activity",
-  "name": "email_url_deprecated",
-  "category": "network",
-  "uid": 12,
+  "caption": "Email File Activity",
+  "name": "email_file_activity",
+  "category": "application",
+  "uid": 7,
   "profiles": [
     "host",
     "security_control"
@@ -29,7 +25,7 @@
         },
         "3": {
           "caption": "Scan",
-          "description": "Email URL being scanned (example: security scanning)."
+          "description": "Email file being scanned (example: security scanning)."
         }
       }
     },
@@ -37,8 +33,8 @@
       "requirement": "required",
       "group": "primary"
     },
-    "url": {
-      "description": "The URL included in the email content.",
+    "file": {
+      "description": "The email file attachment.",
       "group": "primary",
       "requirement": "required"
     }

--- a/events/application/email_url.json
+++ b/events/application/email_url.json
@@ -1,14 +1,10 @@
 {
-  "@deprecated": {
-    "message": "Use the new class: <code>'Email URL Activity' in the 'Application' category.</code>",
-    "since": "1.1.0"
-  },
   "description": "Email URL Activity events report URLs within an email.",
   "extends": "base_event",
   "caption": "Email URL Activity",
-  "name": "email_url_deprecated",
-  "category": "network",
-  "uid": 12,
+  "name": "email_url_activity",
+  "category": "application",
+  "uid": 8,
   "profiles": [
     "host",
     "security_control"

--- a/events/network/email_file.json
+++ b/events/network/email_file.json
@@ -1,8 +1,12 @@
 {
+  "@deprecated": {
+    "message": "Use the new class: <code>'Email File Activity' in the 'Application' category.</code>",
+    "since": "1.1.0"
+  },
   "description": "Email File Activity events report files within emails.",
   "extends": "base_event",
   "caption": "Email File Activity",
-  "name": "email_file_activity",
+  "name": "email_file_deprecated",
   "category": "network",
   "uid": 11,
   "profiles": [

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -1,6 +1,6 @@
 {
   "@deprecated": {
-    "message": "Use the new class: <code>'File Hosting Activity' in the 'Application'  category.</code>",
+    "message": "Use the new class: <code>'File Hosting Activity' in the 'Application' category.</code>",
     "since": "1.1.0"
   },
   "caption": "Network File Activity",


### PR DESCRIPTION
#### Related Issue: 
#905 

#### Description of changes:

Moves `Email File Activity` and `Email URL Activity` to the Application classes. Deprecates the classes in the `Network` category to ensure non-breaking.

<img width="226" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/672590d4-4863-4a1c-bfbb-8c1d0953deac">

<img width="372" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/e57aa0c6-7699-48e9-8927-9ff59f2c9102">

<img width="362" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/90688a9b-9bf4-45d8-ab23-75cb2e7d663e">

