### PR TITLE
Completing kb_articles deprecation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ An example `vulnerability.json` object file,
       "description": "The description of the vulnerability",
       "requirement": "recommended"
     },
-    "kb_articles": {
+    "kb_article_list": {
       "requirement": "optional"
     }
   }

--- a/dictionary.json
+++ b/dictionary.json
@@ -1907,13 +1907,17 @@
     },
     "kb_articles": {
       "caption": "Knowledgebase Articles",
+      "@deprecated": {
+        "message": "Use the <code> kb_article_list </code> attribute instead.",
+        "since": "1.1.0"
+      },
       "description": "The KB article/s related to the entity. A KB Article contains metadata that describes the patch or an update.",
       "is_array": true,
       "type": "string_t"
     },    
     "kb_article_list": {
       "caption": "Knowledgebase Articles",
-      "description": "A list of KB articles or patches related to an endpoint.",
+      "description": "A list of KB articles or patches related to an endpoint. A KB Article contains metadata that describes the patch or an update.",
       "is_array": true,
       "type": "kb_article"
     },

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -12,7 +12,7 @@
       "group": "primary",
       "requirement": "required"
     },
-    "kb_articles": {
+    "kb_article_list": {
       "group": "primary"
     }
   },

--- a/objects/remediation.json
+++ b/objects/remediation.json
@@ -14,6 +14,9 @@
     },
     "kb_articles": {
       "requirement": "optional"
+    },
+    "kb_article_list": {
+      "requirement": "optional"
     }
   }
 }

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -30,6 +30,9 @@
     "kb_articles": {
       "requirement": "optional"
     },
+    "kb_article_list": {
+      "requirement": "optional"
+    },
     "is_exploit_available":{
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/855 ; https://github.com/ocsf/ocsf-schema/pull/862

#### Description of changes:

1. Deprecating `kb_articles` in favor of the newly created kb_article_list
2. Removing stale references, replacing it with the newer attribute
