### PR TITLE
Changed the type of type_uid from integer to long.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3466,7 +3466,7 @@
       "caption": "Type ID",
       "description": "The event/finding type ID. It identifies the event's semantics and structure. The value is calculated by the logging system as: <code>class_uid * 100 + activity_id</code>.",
       "sibling": "type_name",
-      "type": "integer_t"
+      "type": "long_t"
     },
     "types": {
       "caption": "Types",


### PR DESCRIPTION
#### Related Issue: 812

#### Description of changes: Changed the data type of `type_uid` from `integer_t` to `long_t`.

The value can overflow when extensions are in play.

