### PR TITLE
Add verdict, verdict_id, verdict_type, and verdict_type_id to Incident_findings class

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3637,7 +3637,7 @@
         },
         "9": {
           "caption": "Managed Externally",
-          "description": "The incident remediation or action items are managed externally."
+          "description": "The incident remediation or required actions are managed externally."
         },
         "10": {
           "caption": "Duplicate",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3627,6 +3627,76 @@
       "description": "The name of the vendor. See specific usage.",
       "type": "string_t"
     },
+    "verdict_type": {
+      "caption": "Verdict Type",
+      "description": "The verdict type assigned to an Incident finding.",
+      "type": "string_t"
+    },
+    "verdict_type_id": {
+      "caption": "Verdict Type ID",
+      "description": "The normalized verdict type of an Incident. This describes person or entity that passed judgment on this verdict.",
+      "enum": {
+        "99": {
+          "caption": "Other",
+          "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
+        },
+        "1": {
+          "caption": "Analyst Verdict",
+          "description": "A internal analyst has made this verdict."
+        },
+        "2": {
+          "caption": "Provider",
+          "description": "A provider or external party has made this verdict."
+        },
+        "0": {
+          "caption": "Unknown",
+          "description": "The type is unknown."
+        }
+      },
+        "sibling": "verdict_type",
+        "type": "integer_t"
+    },
+    "verdict": {
+      "caption": "Verdict",
+      "description": "The verdict assigned to an Incident finding.",
+      "type": "string_t"
+    },
+    "verdict_id": {
+      "caption": "Verdict ID",
+      "description": "The normalized verdict of an Incident.",
+      "enum": {
+        "99": {
+          "caption": "Other",
+          "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
+        },
+        "1": {
+          "caption": "False Positive",
+          "description": "The incident verdict is a false positive."
+        },
+        "2": {
+          "caption": "True Positive",
+          "description": "The incident verdict is a true positive."
+        },
+        "3": {
+          "caption": "Disregard",
+          "description": "The incident verdict can be disregarded"
+        },
+        "4": {
+          "caption": "suspicious",
+          "description": "The incident verdict is suspicious"
+        },
+        "5": {
+          "caption": "benign",
+          "description": "The incident verdict is benign"
+        },
+        "0": {
+          "caption": "Unknown",
+          "description": "The type is unknown."
+        }
+      },
+      "sibling": "verdict",
+      "type": "integer_t"
+    },
     "version": {
       "caption": "Version",
       "description": "The version that pertains to the event or object. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2850,43 +2850,6 @@
       "is_array": true,
       "type": "string_t"
     },
-    "resolution": {
-      "caption": "Resolution",
-      "description": "The resolution detail for closing the incident.",
-      "type": "string_t"
-    },
-    "resolution_id": {
-      "caption": "Resolution Id",
-      "description": "The normalized identifier of the resolution detail, populated when closing an incident.",
-      "enum": {
-        "99": {
-          "caption": "Other"
-        },
-        "0": {
-          "caption": "Unknown"
-        },
-        "1": {
-          "caption": "Insufficient data"
-        },
-        "2": {
-          "caption": "Security risk"
-        },
-        "3": {
-          "caption": "False positive"
-        },
-        "4": {
-          "caption": "Managed externally"
-        },
-        "5": {
-          "caption": "Benign"
-        },
-        "6": {
-          "caption": "Test"
-        }
-      },
-      "sibling": "resolution",
-      "type": "integer_t"
-    },
     "resource": {
       "caption": "Resource",
       "description": "The target resource.",
@@ -3688,6 +3651,26 @@
         "5": {
           "caption": "Benign",
           "description": "The incident verdict is benign."
+        },
+        "6": {
+          "caption": "Test",
+          "description": "The incident is a test"
+        },
+        "7": {
+          "caption": "Insufficient Data",
+          "description": "The incident has insufficient data to make a verdict"
+        },
+        "8": {
+          "caption": "Security Risk",
+          "description": "The incident is a security risk"
+        },
+        "9": {
+          "caption": "Managed Externally",
+          "description": "The incident is managed externally,"
+        },
+        "10": {
+          "caption": "Duplicate",
+          "description": "The incident is a duplicate"
         },
         "0": {
           "caption": "Unknown",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3679,15 +3679,15 @@
         },
         "3": {
           "caption": "Disregard",
-          "description": "The incident verdict can be disregarded"
+          "description": "The incident verdict can be disregarded."
         },
         "4": {
           "caption": "Suspicious",
-          "description": "The incident verdict is suspicious"
+          "description": "The incident verdict is suspicious."
         },
         "5": {
           "caption": "Benign",
-          "description": "The incident verdict is benign"
+          "description": "The incident verdict is benign."
         },
         "0": {
           "caption": "Unknown",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3637,7 +3637,7 @@
         },
         "9": {
           "caption": "Managed Externally",
-          "description": "The incident is managed externally."
+          "description": "The incident remediation or action items are managed externally."
         },
         "10": {
           "caption": "Duplicate",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3590,35 +3590,6 @@
       "description": "The name of the vendor. See specific usage.",
       "type": "string_t"
     },
-    "verdict_type": {
-      "caption": "Verdict Type",
-      "description": "The verdict type assigned to an Incident finding.",
-      "type": "string_t"
-    },
-    "verdict_type_id": {
-      "caption": "Verdict Type ID",
-      "description": "The normalized verdict type of an Incident. This describes person or entity that passed judgment on this verdict.",
-      "enum": {
-        "99": {
-          "caption": "Other",
-          "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
-        },
-        "1": {
-          "caption": "Analyst Verdict",
-          "description": "A internal analyst has made this verdict."
-        },
-        "2": {
-          "caption": "Provider",
-          "description": "A provider or external party made this verdict."
-        },
-        "0": {
-          "caption": "Unknown",
-          "description": "The type is unknown."
-        }
-      },
-        "sibling": "verdict_type",
-        "type": "integer_t"
-    },
     "verdict": {
       "caption": "Verdict",
       "description": "The verdict assigned to an Incident finding.",
@@ -3642,7 +3613,7 @@
         },
         "3": {
           "caption": "Disregard",
-          "description": "The incident can be disregarded as it was unimportant and error or accident."
+          "description": "The incident can be disregarded as it is unimportant, an error or accident."
         },
         "4": {
           "caption": "Suspicious",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3646,7 +3646,7 @@
         },
         "2": {
           "caption": "Provider",
-          "description": "A provider or external party has made this verdict."
+          "description": "A provider or external party made this verdict."
         },
         "0": {
           "caption": "Unknown",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3682,11 +3682,11 @@
           "description": "The incident verdict can be disregarded"
         },
         "4": {
-          "caption": "suspicious",
+          "caption": "Suspicious",
           "description": "The incident verdict is suspicious"
         },
         "5": {
-          "caption": "benign",
+          "caption": "Benign",
           "description": "The incident verdict is benign"
         },
         "0": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3628,29 +3628,29 @@
       "caption": "Verdict ID",
       "description": "The normalized verdict of an Incident.",
       "enum": {
-        "99": {
-          "caption": "Other",
-          "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
+        "0": {
+          "caption": "Unknown",
+          "description": "The type is unknown."
         },
         "1": {
           "caption": "False Positive",
-          "description": "The incident verdict is a false positive."
+          "description": "The incident is a false positive."
         },
         "2": {
           "caption": "True Positive",
-          "description": "The incident verdict is a true positive."
+          "description": "The incident is a true positive."
         },
         "3": {
           "caption": "Disregard",
-          "description": "The incident verdict can be disregarded as it was unimportant and error or accident."
+          "description": "The incident can be disregarded as it was unimportant and error or accident."
         },
         "4": {
           "caption": "Suspicious",
-          "description": "The incident verdict is suspicious."
+          "description": "The incident is suspicious."
         },
         "5": {
           "caption": "Benign",
-          "description": "The incident verdict is benign."
+          "description": "The incident is benign."
         },
         "6": {
           "caption": "Test",
@@ -3672,9 +3672,9 @@
           "caption": "Duplicate",
           "description": "The incident is a duplicate."
         },
-        "0": {
-          "caption": "Unknown",
-          "description": "The type is unknown."
+        "99": {
+        "caption": "Other",
+        "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
         }
       },
       "sibling": "verdict",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3642,7 +3642,7 @@
         },
         "3": {
           "caption": "Disregard",
-          "description": "The incident verdict can be disregarded."
+          "description": "The incident verdict can be disregarded as it was unimportant and error or accident."
         },
         "4": {
           "caption": "Suspicious",
@@ -3654,23 +3654,23 @@
         },
         "6": {
           "caption": "Test",
-          "description": "The incident is a test"
+          "description": "The incident is a test."
         },
         "7": {
           "caption": "Insufficient Data",
-          "description": "The incident has insufficient data to make a verdict"
+          "description": "The incident has insufficient data to make a verdict."
         },
         "8": {
           "caption": "Security Risk",
-          "description": "The incident is a security risk"
+          "description": "The incident is a security risk."
         },
         "9": {
           "caption": "Managed Externally",
-          "description": "The incident is managed externally,"
+          "description": "The incident is managed externally."
         },
         "10": {
           "caption": "Duplicate",
-          "description": "The incident is a duplicate"
+          "description": "The incident is a duplicate."
         },
         "0": {
           "caption": "Unknown",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -182,15 +182,15 @@
         },
         "3": {
           "caption": "Disregard",
-          "description": "The incident verdict can be disregarded"
+          "description": "The incident verdict can be disregarded."
         },
         "4": {
           "caption": "Suspicious",
-          "description": "The incident verdict is suspicious"
+          "description": "The incident verdict is suspicious."
         },
         "5": {
           "caption": "Benign",
-          "description": "The incident verdict is benign"
+          "description": "The incident verdict is benign."
         }
       },
       "group": "primary",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -91,14 +91,6 @@
       "group": "context",
       "requirement": "recommended"
     },
-    "resolution": {
-      "group": "context",
-      "requirement": "optional"
-    },
-    "resolution_id": {
-      "group": "context",
-      "requirement": "optional"
-    },
     "src_url": {
       "description": "A Url link used to access the original incident.",
       "group": "primary",
@@ -150,19 +142,8 @@
       "requirement": "optional"
     },
     "verdict_type_id": {
-      "description": "The normalized verdict type of an Incident. This describes person or entity that passed judgment on this verdict.",
-      "enum": {
-        "1": {
-          "caption": "Analyst Verdict",
-          "description": "A internal analyst has made this verdict."
-        },
-        "2": {
-          "caption": "Provider",
-          "description": "A provider or external party made this verdict."
-        }
-      },
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "verdict": {
       "description": "The normalized verdict of the Incident normalized to the caption of the verdict_id value. In the case of 'Other', it is defined by the source.",
@@ -170,31 +151,8 @@
       "requirement": "optional"
     },
     "verdict_id": {
-      "description": "The normalized verdict of an Incident.",
-      "enum": {
-        "1": {
-          "caption": "False Positive",
-          "description": "The incident verdict is a false positive."
-        },
-        "2": {
-          "caption": "True Positive",
-          "description": "The incident verdict is a true positive."
-        },
-        "3": {
-          "caption": "Disregard",
-          "description": "The incident verdict can be disregarded."
-        },
-        "4": {
-          "caption": "Suspicious",
-          "description": "The incident verdict is suspicious."
-        },
-        "5": {
-          "caption": "Benign",
-          "description": "The incident verdict is benign."
-        }
-      },
       "group": "primary",
-      "requirement": "required"
+      "requirement": "recommended"
     }
   },
   "constraints": {

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -143,6 +143,58 @@
     "is_suspected_breach": {
       "group": "context",
       "requirement": "optional"
+    },
+    "verdict_type": {
+      "description": "The normalized verdict type of the Incident normalized to the caption of the verdict_type_id value. In the case of 'Other', it is defined by the source.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "verdict_type_id": {
+      "description": "The normalized verdict type of an Incident. This describes person or entity that passed judgment on this verdict.",
+      "enum": {
+        "1": {
+          "caption": "Analyst Verdict",
+          "description": "A internal analyst has made this verdict."
+        },
+        "2": {
+          "caption": "Provider",
+          "description": "A provider or external party has made this verdict."
+        }
+      },
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "verdict": {
+      "description": "The normalized verdict of the Incident normalized to the caption of the verdict_id value. In the case of 'Other', it is defined by the source.",
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "verdict_id": {
+      "description": "The normalized verdict of an Incident.",
+      "enum": {
+        "1": {
+          "caption": "False Positive",
+          "description": "The incident verdict is a false positive."
+        },
+        "2": {
+          "caption": "True Positive",
+          "description": "The incident verdict is a true positive."
+        },
+        "3": {
+          "caption": "Disregard",
+          "description": "The incident verdict can be disregarded"
+        },
+        "4": {
+          "caption": "suspicious",
+          "description": "The incident verdict is suspicious"
+        },
+        "5": {
+          "caption": "benign",
+          "description": "The incident verdict is benign"
+        }
+      },
+      "group": "primary",
+      "requirement": "required"
     }
   },
   "constraints": {

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -158,7 +158,7 @@
         },
         "2": {
           "caption": "Provider",
-          "description": "A provider or external party has made this verdict."
+          "description": "A provider or external party made this verdict."
         }
       },
       "group": "primary",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -137,7 +137,6 @@
       "requirement": "optional"
     },
     "verdict_type": {
-      "description": "The normalized verdict type of the Incident normalized to the caption of the verdict_type_id value. In the case of 'Other', it is defined by the source.",
       "group": "primary",
       "requirement": "optional"
     },
@@ -146,7 +145,6 @@
       "requirement": "recommended"
     },
     "verdict": {
-      "description": "The normalized verdict of the Incident normalized to the caption of the verdict_id value. In the case of 'Other', it is defined by the source.",
       "group": "primary",
       "requirement": "optional"
     },

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -185,11 +185,11 @@
           "description": "The incident verdict can be disregarded"
         },
         "4": {
-          "caption": "suspicious",
+          "caption": "Suspicious",
           "description": "The incident verdict is suspicious"
         },
         "5": {
-          "caption": "benign",
+          "caption": "Benign",
           "description": "The incident verdict is benign"
         }
       },

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -136,14 +136,6 @@
       "group": "context",
       "requirement": "optional"
     },
-    "verdict_type": {
-      "group": "primary",
-      "requirement": "optional"
-    },
-    "verdict_type_id": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
     "verdict": {
       "group": "primary",
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/902
#### Description of changes:  
In this PR I am adding verdict, verdict_id, vedict_type, and verdict_type_id. the new fields will all be used in the incident finding and should be the last PR entered in V1.1 

<img width="1762" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/13574947/44959a13-7d46-4196-bf7e-84b7916607d8">
