### PR TITLE
Added the state sibling attribute to Network Connection Info per convention.

### DIFF
--- a/events/discovery/network_connection_info.json
+++ b/events/discovery/network_connection_info.json
@@ -14,6 +14,11 @@
       "requirement": "required",
       "group": "primary"
     },
+    "state": {
+      "description": "The state of the socket, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional",
+      "group":"primary"
+    },
     "state_id": {
       "description": "The state of the socket.",
       "requirement": "required",


### PR DESCRIPTION
#### Description of changes: 
As per OCSF convention, when an enum, such as `state_id` has an `Other` value (99), there must be a sibling optional string attribute in the same 'group' as the enum attribute; in this case `state` was missing and has been added.

