### PR TITLE
Move 'extensions' to 'schema_extensions_list'

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1462,7 +1462,7 @@
     },
     "extension": {
       "@deprecated": {
-        "message": "Use the <code> schema_extensions </code> attribute instead.",
+        "message": "Use the <code> schema_extension_list </code> attribute instead.",
         "since": "1.0.0"
       },
       "caption": "Schema Extension",

--- a/dictionary.json
+++ b/dictionary.json
@@ -3046,9 +3046,9 @@
       "description": "The unique identifier of the schedule associated with a scan job.",
       "type": "string_t"
     },
-    "schema_extensions": {
-      "caption": "Schema Extensions",
-      "description": "The schema extensions used to create the event.",
+    "schema_extension_list": {
+      "caption": "Schema Extension List",
+      "description": "The list of schema extensions used to create the event.",
       "is_array": true,
       "type": "extension"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -1461,14 +1461,12 @@
       "type": "timestamp_t"
     },
     "extension": {
+      "@deprecated": {
+        "message": "Use the <code> schema_extensions </code> attribute instead.",
+        "since": "1.0.0"
+      },
       "caption": "Schema Extension",
       "description": "The schema extension used to create the event.",
-      "type": "extension"
-    },
-    "extensions": {
-      "caption": "Schema Extensions",
-      "description": "The schema extensions used to create the event.",
-      "is_array": true,
       "type": "extension"
     },
     "extension_list": {
@@ -3047,6 +3045,12 @@
       "caption": "Schedule UID",
       "description": "The unique identifier of the schedule associated with a scan job.",
       "type": "string_t"
+    },
+    "schema_extensions": {
+      "caption": "Schema Extensions",
+      "description": "The schema extensions used to create the event.",
+      "is_array": true,
+      "type": "extension"
     },
     "scheme": {
       "caption": "Scheme",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -49,7 +49,7 @@
     "profiles": {
       "requirement": "optional"
     },
-    "schema_extensions": {
+    "schema_extension_list": {
       "requirement": "optional"
     },
     "sequence": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -11,13 +11,6 @@
       "requirement": "optional"
     },
     "extension": {
-      "requirement": "optional",
-      "@deprecated": {
-        "message": "Use the <code> extensions </code> attribute instead.",
-        "since": "1.0.0"
-      }
-    },
-    "extensions": {
       "requirement": "optional"
     },
     "labels": {
@@ -54,6 +47,9 @@
       "requirement": "required"
     },
     "profiles": {
+      "requirement": "optional"
+    },
+    "schema_extensions": {
       "requirement": "optional"
     },
     "sequence": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes: 
Moves `extensions` to `schema_extension_list` prior to OCSF 1.1 Release, so as to not cause confusion with the TLS attribute `extension_list`

<img width="1100" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/1124c13d-fc2f-447c-acc9-a22489ea9f56">
