### PR TITLE
Deprecate 'extension_list' and rename to 'tls_extension_list'

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1447,6 +1447,10 @@
       "type": "extension"
     },
     "extension_list": {
+      "@deprecated": {
+        "message": "Use the <code> tls_extension_list </code> attribute instead.",
+        "since": "1.1.0"
+      },
       "caption": "Extension List",
       "description": "The list of TLS extensions.",
       "is_array": true,
@@ -3491,6 +3495,12 @@
       "caption": "TLS",
       "description": "The Transport Layer Security (TLS) attributes.",
       "type": "tls"
+    },
+    "tls_extension_list": {
+      "caption": "TLS Extension List",
+      "description": "The list of TLS extensions.",
+      "is_array": true,
+      "type": "tls_extension"
     },
     "to": {
       "caption": "To",

--- a/objects/tls.json
+++ b/objects/tls.json
@@ -22,6 +22,9 @@
     "extension_list": {
       "requirement": "optional"
     },
+    "tls_extension_list": {
+      "requirement": "optional"
+    },
     "handshake_dur": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
#935 

#### Description of changes:
Within the TLS object rename the `extension_list` attribute to `tls_extension_list`.

<img width="1492" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/16f70fa6-e78d-44e8-b94f-d8a218934511">

