### PR TITLE
Updated dictionary deprecated attributes from 1.0.0 to 1.1.0

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1463,7 +1463,7 @@
     "extension": {
       "@deprecated": {
         "message": "Use the <code> schema_extension_list </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "Schema Extension",
       "description": "The schema extension used to create the event.",
@@ -1540,7 +1540,7 @@
     "fix_available": {
       "@deprecated": {
         "message": "Use the <code> is_fix_available </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "Fix Availability",
       "description": "Indicates if a fix is available for the reported vulnerability.",
@@ -1675,7 +1675,7 @@
     "http_status": {
       "@deprecated": {
         "message": "Use the <code> http_response.code </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "HTTP Status",
       "description": "The Hypertext Transfer Protocol (HTTP) <a target='_blank' href='https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
@@ -2470,7 +2470,7 @@
     "packages": {
       "@deprecated": {
         "message": "Use the <code> affected_packages </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "Software Packages",
       "description": "List of vulnerable packages as identified by the security product",
@@ -2736,7 +2736,7 @@
     "proxy": {
       "@deprecated": {
         "message": "Use the <code> proxy_endpoint </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "Proxy",
       "description": "The proxy (server) in a network connection.",
@@ -3482,7 +3482,7 @@
     "tactics": {
       "@deprecated": {
         "message": "Use the <code> tactic </code> attribute instead.",
-        "since": "1.0.0"
+        "since": "1.1.0"
       },
       "caption": "Tactics",
       "description": "The Tactic object describes the tactic ID and/or tactic name that are associated with the attack technique, as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",


### PR DESCRIPTION

#### Description of changes:
As the 1.1.0 release is the first post 1.0 release where we have deprecated attributes, we had an inconsistency of since when the attributes were deprecated.  12 attributes have been deprecated in the 1.1.0 release from previous RC and GA releases, hence the attributes with a `since 1.0.0` tag have been updated to `since 1.1.0`.
