### PR TITLE
Correct type for priority field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Thankyou! -->
 
 -->
 
+### Misc
+    1. Changed datatype of `priority` from `integer_t` to `string_t`
+
 ## [v1.1.0] - January 25th, 2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ Thankyou! -->
 -->
 
 ### Misc
-    1. Changed datatype of `priority` from `integer_t` to `string_t`
+    1. Changed datatype of `priority` from `integer_t` to `string_t` #959
 
 ## [v1.1.0] - January 25th, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -2733,7 +2733,7 @@
     "priority": {
       "caption": "Priority",
       "description": "The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.",
-      "type": "integer_t"
+      "type": "string_t"
     },
     "priority_id": {
       "caption": "Priority ID",


### PR DESCRIPTION
#### Description of changes:
Other normalized string fields that map to an enum are strings, not integers. The sample data API generates a string for the `priority` field, which fails the JSON schema validation. This corrects the type to reflect the paradigm in the rest of the schema.
