### PR TITLE
Expand scalar observable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+#### Data Types
+* New data types and observables for User ID, Group Name, Group ID, Vulnerability ID, Process ID, Resource Name, and User Agent.
+
+### Improved
+#### Objects
+* Added observables for `port_t` and `subnet_t`.
+* Added new observables to User, Group, CWE, CVE, Resource Details, Device, Endpoint, Resource Details, and HTTP Request. 
+
 <!-- All available sections in the Changelog:
 
 ### Added

--- a/dictionary.json
+++ b/dictionary.json
@@ -4119,7 +4119,7 @@
 		  "description": "A unique identifier for a process",
 		  "type": "string_t",
 		  "type_name": "String",
-		  "observable": 17,
+		  "observable": 17
 	  },
 	  "resource_name_t": {
 		  "caption": "Resource Name",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4028,7 +4028,8 @@
           65535
         ],
         "type": "integer_t",
-        "type_name": "Integer"
+        "type_name": "Integer",
+		"observable": 11
       },
       "process_name_t": {
         "caption": "Process Name",
@@ -4055,7 +4056,8 @@
       "description": "The subnet represented in a CIDR notation, using the format network_address/prefix_length. The network_address can be in either IPv4 or IPv6 format. The prefix length indicates the number of bits used for the network portion, and the remaining bits are available for host addresses within that subnet. <div>For example:<ul><li>192.168.1.0/24</li><li>2001:0db8:85a3:0000::/64</li></ul></div>",
         "max_len": 42,
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+		"observable": 12
       },
       "timestamp_t": {
         "caption": "Timestamp",
@@ -4083,7 +4085,56 @@
         "regex": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
         "type": "string_t",
         "type_name": "String"
-      }
+      },
+	  "user_id_t": {
+		  "caption": "User ID",
+		  "description": "User identifier. For example, a Microsoft Active Directory UPN or Google Workspaces Unique ID.",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 13
+	  },
+	  "group_name_t": {
+		  "caption": "Group Name",
+		  "description": "Group Name. For example: <code>it_users</code>",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 14
+	  },
+	  "group_id_t": {
+		  "caption": "Group ID",
+		  "description": "Group identifier.",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 15
+	  },
+	  "vulnerability_id_t": {
+		  "caption": "Vulnerability ID",
+		  "description": "A unique identifier for a reported vulnerability such as a CVE or CWE ID.",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 16
+	  },
+	  "process_id_t": {
+		  "caption": "Process ID",
+		  "description": "A unique identifier for a process",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 17,
+	  },
+	  "resource_name_t": {
+		  "caption": "Resource Name",
+		  "description": "The name of a resource",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 18
+	  },
+	  "user_agent_t": {
+		  "caption": "HTTP User Agent",
+		  "description": "An HTTP User Agent. For example <code>AppleWebKit/537.36 (KHTML, like Gecko)</code>",
+		  "type": "string_t",
+		  "type_name": "String",
+		  "observable": 19
+		}
     }
   }
 }

--- a/dictionary.json
+++ b/dictionary.json
@@ -1162,7 +1162,7 @@
       },
       "caption": "CWE UID",
       "description": "The <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> unique identifier. For example: <code>CWE-787</code>.",
-      "type": "string_t"
+      "type": "vulnerability_id_t"
     },
     "cwe_url": {
       "@deprecated": {
@@ -2668,7 +2668,7 @@
     "pid": {
       "caption": "Process ID",
       "description": "The process identifier, as reported by the operating system. Process ID (PID) is a number used by the operating system to uniquely identify an active process.",
-      "type": "integer_t"
+      "type": "process_id_t"
     },
     "pod_uuid": {
       "caption": "Pod UUID",
@@ -3609,7 +3609,7 @@
     "tid": {
       "caption": "Thread ID",
       "description": "The Identifier of the thread associated with the event, as returned by the operating system.",
-      "type": "integer_t"
+      "type": "process_id_t"
     },
     "time": {
       "caption": "Event Time",
@@ -3755,7 +3755,7 @@
     "user_agent": {
       "caption": "HTTP User-Agent",
       "description": "The request header that identifies the operating system and web browser.",
-      "type": "string_t"
+      "type": "user_agent_t"
     },
     "user_result": {
       "caption": "User Result",

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -14,7 +14,8 @@
     },
     "name": {
       "description": "The name of the resource.",
-      "requirement": "optional"
+      "requirement": "optional",
+	  "type": "resource_name_t"
     },
     "type": {
       "description": "The resource type as defined by the event source.",

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -51,7 +51,8 @@
     "uid": {
       "caption": "CVE ID",
       "description": "The Common Vulnerabilities and Exposures unique number assigned to a specific computer vulnerability. A CVE Identifier begins with 4 digits representing the year followed by a sequence of digits that acts as a unique identifier. For example: <code>CVE-2021-12345</code>.",
-      "requirement": "required"
+      "requirement": "required",
+	  "type": "vulnerability_id"
     }
   }
 }

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -52,7 +52,7 @@
       "caption": "CVE ID",
       "description": "The Common Vulnerabilities and Exposures unique number assigned to a specific computer vulnerability. A CVE Identifier begins with 4 digits representing the year followed by a sequence of digits that acts as a unique identifier. For example: <code>CVE-2021-12345</code>.",
       "requirement": "required",
-	  "type": "vulnerability_id"
+	  "type": "vulnerability_id_t"
     }
   }
 }

--- a/objects/cwe.json
+++ b/objects/cwe.json
@@ -15,7 +15,8 @@
     "uid": {
       "caption": "CWE ID",
       "description": "The Common Weakness Enumeration unique number assigned to a specific weakness. A CWE Identifier begins \"CWE\" followed by a sequence of digits that acts as a unique identifier. For example: <code>CWE-123</code>.",
-      "requirement": "required"
+      "requirement": "required",
+	  "type": "vulnerability_id_t"
     }
   }
 }

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -43,7 +43,8 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The short name of the endpoint."
+      "description": "The short name of the endpoint.",
+	  "type": "resource_name_t"
     },
     "os": {
       "description": "The endpoint operating system.",

--- a/objects/group.json
+++ b/objects/group.json
@@ -13,7 +13,8 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The group name."
+      "description": "The group name.",
+	  "type": "group_name_t"
     },
     "privileges": {
       "description": "The group privileges.",
@@ -25,7 +26,8 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier of the group. For example, for Windows events this is the security identifier (SID) of the group."
+      "description": "The unique identifier of the group. For example, for Windows events this is the security identifier (SID) of the group.",
+	  "type": "group_id_t"
     }
   }
 }

--- a/objects/process.json
+++ b/objects/process.json
@@ -85,7 +85,8 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process."
+      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process.",
+	  "type": "process_id_t"
     },
     "user": {
       "description": "The user under which this process is running.",

--- a/objects/user.json
+++ b/objects/user.json
@@ -69,11 +69,13 @@
     },
     "uid": {
       "description": "The unique user identifier. For example, the Windows user SID, ActiveDirectory DN or AWS user ARN.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+	  "type": "user_id_t"
     },
     "uid_alt": {
       "description": "The alternate user identifier. For example, the Active Directory user GUID or AWS user Principal ID.",
-      "requirement": "optional"
+      "requirement": "optional",
+	  "type": "user_id_t"
     }
   },
   "constraints": {


### PR DESCRIPTION
#### Related Issue: 
This PR adds several new scalar observables to address [Issue 960](https://github.com/ocsf/ocsf-schema/issues/960) . Two – port and subnet – use existing data types, while others introduce new data types and change the type of several attributes in the schema from `string_t` to a new data type (which still ultimately resolves to `string_t`).

