### PR TITLE
Update CHANGELOG.md - priority data type change should be a bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
 
 -->
 
-### Misc
+### Bugfixes
     1. Changed datatype of `priority` from `integer_t` to `string_t` #959
 
 ## [v1.1.0] - January 25th, 2024


### PR DESCRIPTION
#### Related Issue: 
PR 959
#### Description of changes:
The change of a released attribute data type constitutes a breaking change.  We only accept bug fixes as breaking changes within a major version, and CHANGELOG has a section reserved for bug fixes - therefore the data type change should not be Misc but Bugfixes.
