### PR TITLE
Make primary attributes at least recommended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,10 @@ Thankyou! -->
     1. Added `auth_factor` object. #949
 
 ### Improved
+
 * #### Event Classes
     1. Added `auth_factors` array to Authentication event class. #949
+    1. Modified all classes such that primary attributes are at least recommended. #664
 * #### Objects
     1. Added `lat`, `long`, `geohash` attributes to `location`  object. #971
 

--- a/events/application/api.json
+++ b/events/application/api.json
@@ -32,12 +32,12 @@
         },
         "dst_endpoint": {
             "group": "primary",
-            "requirement": "optional"
+            "requirement": "recommended"
         },
         "http_request": {
             "description":"Details about the underlying http request.",
             "group": "primary",
-            "requirement": "optional"
+            "requirement": "recommended"
         },
         "actor": {
             "group": "primary",

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -47,7 +47,7 @@
 		},
 		"table": {
 			"group": "primary",
-			"requirement": "optional"
+			"requirement": "recommended"
 		},
 		"type": {
 			"caption": "Datastore Type",
@@ -80,17 +80,17 @@
 		},
 		"query_info": {
 			"group": "primary",
-			"requirement": "optional"
+			"requirement": "recommended"
 		},
 		"dst_endpoint": {
 			"description": "Details about the endpoint hosting the datastore application or service.",
 			"group": "primary",
-			"requirement": "optional"
+			"requirement": "recommended"
 		},
 		"http_request": {
 			"description": "Details about the underlying http request.",
 			"group": "primary",
-			"requirement": "optional"
+			"requirement": "recommended"
 		},
 		"actor": {
 			"group": "primary",

--- a/events/application/web_resources_activity.json
+++ b/events/application/web_resources_activity.json
@@ -83,7 +83,7 @@
         },
         "web_resources_result": {
             "group": "primary",
-            "requirement": "optional"
+            "requirement": "recommended"
         }
     }
 }

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -28,7 +28,7 @@
     },
     "observables": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "raw_data": {
       "group": "context",
@@ -44,15 +44,15 @@
     },
     "status": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "status_code": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "status_detail": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "status_id": {
       "group": "primary",

--- a/events/discovery/network_connection_info.json
+++ b/events/discovery/network_connection_info.json
@@ -16,8 +16,8 @@
     },
     "state": {
       "description": "The state of the socket, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the event source.",
-      "requirement": "optional",
-      "group":"primary"
+      "requirement": "recommended",
+      "group": "primary"
     },
     "state_id": {
       "description": "The state of the socket.",

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -51,7 +51,7 @@
     "device": {
       "description": "Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "end_time": {
       "description": "The time of the most recent event included in the finding.",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -73,7 +73,7 @@
     },
     "impact": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "impact_id": {
       "group": "primary",
@@ -81,7 +81,7 @@
     },
     "impact_score": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "priority": {
       "group": "context",
@@ -103,7 +103,7 @@
     "status": {
       "description": "The normalized status of the Incident normalized to the caption of the status_id value. In the case of 'Other', it is defined by the source.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "status_id": {
       "description": "The normalized status identifier of the Incident.",
@@ -138,7 +138,7 @@
     },
     "verdict": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "verdict_id": {
       "group": "primary",

--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -45,7 +45,7 @@
     },
     "confidence": {
       "group": "primary",
-      "requirement":"optional"
+      "requirement":"recommended"
     },
     "confidence_id": {
       "group": "primary",
@@ -54,7 +54,7 @@
     },
      "confidence_score": {
       "group": "primary",
-      "requirement":"optional"
+      "requirement":"recommended"
     },
     "data_sources": {
       "group": "context",
@@ -70,7 +70,7 @@
     },
     "impact": {
       "group": "primary",
-      "requirement":"optional"
+      "requirement":"recommended"
     },
     "impact_id": {
       "group": "primary",
@@ -79,7 +79,7 @@
     },
     "impact_score": {
       "group": "primary",
-      "requirement":"optional"
+      "requirement":"recommended"
     },
     "kill_chain": {
       "group": "context",
@@ -103,16 +103,16 @@
     },
     "risk_level": {
       "group": "primary",
-      "requirement":"optional"
+      "requirement":"recommended"
     },
     "risk_level_id": {
       "group": "primary",
-      "requirement": "optional",
+      "requirement": "recommended",
       "sibling": "risk_level"
     },
     "risk_score": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "state": {
       "description": "The normalized state of a security finding.",

--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -80,7 +80,7 @@
     },
     "user_result": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -40,7 +40,7 @@
     },
     "auth_protocol": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "auth_protocol_id": {
       "group": "primary",
@@ -49,7 +49,7 @@
     "certificate": {
       "description": "The certificate associated with the authentication or pre-authentication (Kerberos).",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "dst_endpoint": {
       "description": "The endpoint to which the authentication was targeted.",
@@ -67,7 +67,7 @@
     },
     "is_mfa": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "is_new_logon": {
       "group": "context",
@@ -83,7 +83,7 @@
     },
     "logon_type": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "logon_type_id": {
       "group": "primary",
@@ -96,12 +96,12 @@
     },
     "session": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "src_endpoint": {
       "description": "The Endpoint from which the authentication was requested.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "status_detail": {
       "description": "The details about the authentication request. For example, possible details for Windows logon or logoff events are:<ul><li>Success</li><ul><li>LOGOFF_USER_INITIATED</li><li>LOGOFF_OTHER</li></ul><li>Failure</li><ul><li>USER_DOES_NOT_EXIST</li><li>INVALID_CREDENTIALS</li><li>ACCOUNT_DISABLED</li><li>ACCOUNT_LOCKED_OUT</li><li>PASSWORD_EXPIRED</li></ul></ul>"

--- a/events/iam/entity_management.json
+++ b/events/iam/entity_management.json
@@ -28,7 +28,7 @@
     "comment": {
       "description": "The user provided comment about why the entity was changed.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "entity": {
       "group": "primary",
@@ -36,7 +36,7 @@
     },
     "entity_result": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -46,7 +46,7 @@
     "resource": {
       "description": "Resource that the privileges give access to.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "user": {
       "description": "A user that was added to or removed from the group.",

--- a/events/iam/user_access.json
+++ b/events/iam/user_access.json
@@ -25,7 +25,7 @@
     "resource": {
       "description": "Resource that the privileges give access to.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "user": {
       "description": "User to which privileges were assigned.",

--- a/events/network/dhcp.json
+++ b/events/network/dhcp.json
@@ -61,11 +61,11 @@
     },
     "is_renewal": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "lease_dur": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "src_endpoint": {
       "description": "The initiator (client) of the DHCP connection.",
@@ -74,12 +74,12 @@
     },
     "relay": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "transaction_uid": {
       "description": "The unique identifier of the transaction. This is typically a random number generated from the client to associate a dhcp request/response pair.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/network/dns.json
+++ b/events/network/dns.json
@@ -43,13 +43,13 @@
     "rcode": {
       "description": "The DNS server response code, normalized to the caption of the rcode_id value. In the case of 'Other', it is defined by the event source.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "rcode_id": {
       "caption": "Response Code ID",
       "description": "The normalized identifier of the DNS server response code. See <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc6895'>RFC-6895</a>.",
       "group": "primary",
-      "requirement": "optional",
+      "requirement": "recommended",
       "enum": {
         "0": {
           "caption": "NoError",

--- a/events/network/email.json
+++ b/events/network/email.json
@@ -71,7 +71,7 @@
     },
     "dst_endpoint": {
       "description": "The responder (server) receiving the email.",
-      "requirement": "optional",
+      "requirement": "recommended",
       "group": "primary"
     },
     "email": {
@@ -84,7 +84,7 @@
     },
     "src_endpoint": {
       "description": "The initiator (client) sending the email.",
-      "requirement": "optional",
+      "requirement": "recommended",
       "group": "primary"
     },
     "smtp_hello": {

--- a/events/network/email_url.json
+++ b/events/network/email_url.json
@@ -15,7 +15,7 @@
       "profiles/security_control.json"
     ],
     "activity_id": {
-      "requirement": "recommended",
+      "requirement": "optional",
       "enum": {
         "1": {
           "caption": "Send"

--- a/events/network/email_url.json
+++ b/events/network/email_url.json
@@ -15,7 +15,7 @@
       "profiles/security_control.json"
     ],
     "activity_id": {
-      "requirement": "optional",
+      "requirement": "recommended",
       "enum": {
         "1": {
           "caption": "Send"

--- a/events/network/http.json
+++ b/events/network/http.json
@@ -44,7 +44,7 @@
     },
     "http_cookies": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "http_request": {
       "group": "primary",

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -32,7 +32,7 @@
     },
     "proxy": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "src_endpoint": {
       "description": "The initiator (client) of the network connection.",
@@ -44,7 +44,7 @@
     },
     "traffic": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -12,7 +12,7 @@
     "url": {
       "description": "The URL details relevant to the network traffic.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/network/ntp.json
+++ b/events/network/ntp.json
@@ -47,11 +47,11 @@
     },
     "delay": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "dispersion": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "precision": {
       "description": "The NTP precision quantifies a clock's accuracy and stability in log2 seconds, as defined in RFC-5905.",
@@ -60,7 +60,7 @@
     },
     "stratum": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "stratum_id": {
       "group": "primary",

--- a/events/network/rdp.json
+++ b/events/network/rdp.json
@@ -39,7 +39,7 @@
     "certificate_chain": {
       "description": "The list of observed certificates in an RDP TLS connection.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "device": {
       "description": "The device instigating the RDP connection.",

--- a/events/network/smb.json
+++ b/events/network/smb.json
@@ -67,11 +67,11 @@
     },
     "share": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "share_type": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "share_type_id": {
       "group": "primary",
@@ -79,7 +79,7 @@
     },
     "tree_uid": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/network/ssh.json
+++ b/events/network/ssh.json
@@ -11,7 +11,7 @@
     "auth_type": {
       "description": "The SSH authentication type, normalized to the caption of 'auth_type_id'. In the case of 'Other', it is defined by the event source.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "auth_type_id": {
       "description": "The normalized identifier of the SSH authentication type.",

--- a/events/system/filesystem.json
+++ b/events/system/filesystem.json
@@ -75,7 +75,7 @@
     },
     "component": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "connection_uid": {
       "group": "context",
@@ -83,7 +83,7 @@
     },
     "create_mask": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "file": {
       "description": "The file that is the target of the activity.",
@@ -92,12 +92,12 @@
     },
     "file_diff": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "file_result": {
       "description": "The resulting file object when the activity was allowed and successful.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -39,7 +39,7 @@
     },
     "actual_permissions": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "base_address": {
       "description": "The memory address that was access or requested.",
@@ -48,7 +48,7 @@
     },
     "requested_permissions": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "size": {
       "description": "The memory size that was access or requested.",

--- a/events/system/process.json
+++ b/events/system/process.json
@@ -29,24 +29,24 @@
     },
     "actual_permissions": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "exit_code": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "injection_type": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "injection_type_id": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "module": {
       "description": "The module that was injected by the actor process.",
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "process": {
       "description": "The process that was launched, injected into, opened, or terminated.",
@@ -55,7 +55,7 @@
     },
     "requested_permissions": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/extensions/windows/events/registry_key.json
+++ b/extensions/windows/events/registry_key.json
@@ -7,7 +7,7 @@
   "attributes": {
     "access_mask": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "activity_id": {
       "enum": {
@@ -46,11 +46,11 @@
     },
     "create_mask": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "open_mask": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "reg_key": {
       "group": "primary",
@@ -58,7 +58,7 @@
     },
     "prev_reg_key": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/extensions/windows/events/registry_value.json
+++ b/extensions/windows/events/registry_value.json
@@ -29,7 +29,7 @@
       "requirement": "required"
     },
     "prev_reg_value": {
-      "requirement": "recommended"
+      "requirement": "optional"
     }
   }
 }

--- a/extensions/windows/events/registry_value.json
+++ b/extensions/windows/events/registry_value.json
@@ -29,7 +29,7 @@
       "requirement": "required"
     },
     "prev_reg_value": {
-      "requirement": "optional"
+      "requirement": "recommended"
     }
   }
 }

--- a/metaschema/attribute.schema.json
+++ b/metaschema/attribute.schema.json
@@ -43,12 +43,31 @@
         },
         "requirement": {
             "type": "string",
-            "description": "The requirement placed on the attribute for inclusion in the schema.",
-            "enum": ["optional", "recommended", "required"]
+            "description": "The requirement placed on the attribute for inclusion in the schema."
         },
         "sibling": {
             "type": "string",
             "description": "Sibling attributes are string attributes paired with a source enum id attribute. If the source attribute maps to a defined enumeration value, the sibling attribute should be populated with the label of the enum. In the case that the source attribute is `Other`, the sibling attribute is populated with a custom label."
+        }
+    },
+    "if": {
+        "required": ["group"],
+        "properties": {
+            "group": { "const": "primary" }
+        }
+    },
+    "then": {
+        "properties": {
+            "requirement": {
+                "enum": ["recommended", "required"]
+            }
+        }
+    },
+    "else": {
+        "properties": {
+            "requirement": {
+                "enum": ["optional", "recommended", "required"]
+            }
         }
     }
 }


### PR DESCRIPTION
#### Related Issue: 
Fixes #664 

#### Description of changes:
This PR makes two changes:

* Updates the metaschema to enforce that attributes labeled with `group: primary` may not be labeled with `requirement: optional`
* Updates existing violations of that new rule so that all existing `primary` / `optional` attributes are made `primary` / `recommended`
