### PR TITLE
Add new ways to define observables to metaschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thankyou! -->
 
 ### Misc
 1. New Extension registration for Sedara. #951
+2. Add new ways to define observables to metaschema. #982
 
 <!-- All available sections in the Changelog:
 

--- a/metaschema/dictionary-attribute.schema.json
+++ b/metaschema/dictionary-attribute.schema.json
@@ -52,6 +52,9 @@
         "is_array": {
             "type": "boolean",
             "description": "A flag used when the attribute represents an array of values rather than a single value."
+        },
+        "observable": {
+            "$ref": "observable.schema.json"
         }
     },
     "additionalProperties": false

--- a/metaschema/event.schema.json
+++ b/metaschema/event.schema.json
@@ -37,6 +37,16 @@
                     "description": "A unique identifier for this event, must be unique within the category.",
                     "minimum": 0,
                     "maximum": 999
+                },
+                "observables": {
+                    "type": "object",
+                    "description": "Defines class-specific observables by attribute path.",
+                    "patternProperties": {
+                        "^[a-z0-9_]+(\\.[a-z0-9_]+)*$": {
+                            "$ref": "observable.schema.json"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
**NOTE:** This PR is waiting on the `ocsf-validator` PR below to be published and then version updated in the GitHub action. No further changes are needed in this repo, however I will hold off merging this change until an updated validator is published.

#### Related Issues: 
* https://github.com/ocsf/ocsf-schema/issues/960
* https://github.com/ocsf/ocsf-schema/issues/964

#### Related PRs: 
* https://github.com/ocsf/ocsf-server/pull/77
* https://github.com/ocsf/ocsf-validator/pull/9

#### Description of changes:
This change adds the ability to define observables in dictionary attributes and in classes as class-specific observables by attribute path.

This change also validates all observable `type_id` definitions. This is enabled by an update to the `ocsf-validator` tool.