### PR TITLE
Evidences object update, other minor fixes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Thankyou! -->
     2. Added `lat`, `long`, `geohash` attributes to `location` object. #971.
     3. Added `risk_score`, `risk_level_id`, `risk_level` to `user` object. Issue #972.
     4. Added `app_name`, `app_uid` to `actor` object.  Issue #966, PR #979.
+    5. Added `container`, `database`, `databucket` to the `evidences` object. #984
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/data_security.json
+++ b/objects/data_security.json
@@ -1,42 +1,42 @@
 {
-    "caption": "Data Security",
-    "description":"The Data Security object describes the characteristics, techniques and content of a Data Loss Prevention (DLP), Data Loss Detection (DLD), Data Classification, or similar tools' finding, alert, or detection mechanism(s).",
-    "extends": "object",
-    "name": "data_security",
-    "attributes": {
-      "policy": {
-        "requirement": "recommended"
-      },
-      "confidentiality": {
-        "requirement": "optional"
-      },
-      "confidentiality_id": {
-        "requirement": "optional"
-      },
-      "detection_pattern": {
-        "requirement": "recommended"
-      },
-      "pattern_match": {
-        "requirement": "optional"
-      },
-      "data_lifecycle_state_id": {
-        "requirement": "recommended"
-      },
-      "data_lifecycle_state": {
-        "requirement": "optional"
-      },
-      "detection_system_id": {
-        "requirement": "recommended"
-      },
-      "detection_system": {
-        "requirement": "optional"
-      },
-      "data_type_id": {
-        "requirement": "recommended"
-      },
-      "data_type": {
-        "caption":"Data Type",
-        "requirement": "optional"
-      }
+  "caption": "Data Security",
+  "description": "The Data Security object describes the characteristics, techniques and content of a Data Loss Prevention (DLP), Data Loss Detection (DLD), Data Classification, or similar tools' finding, alert, or detection mechanism(s).",
+  "extends": "object",
+  "name": "data_security",
+  "attributes": {
+    "confidentiality": {
+      "requirement": "optional"
+    },
+    "confidentiality_id": {
+      "requirement": "optional"
+    },
+    "data_lifecycle_state": {
+      "requirement": "optional"
+    },
+    "data_lifecycle_state_id": {
+      "requirement": "recommended"
+    },
+    "data_type": {
+      "requirement": "optional"
+    },
+    "data_type_id": {
+      "requirement": "recommended"
+    },
+    "detection_pattern": {
+      "requirement": "recommended"
+    },
+    "detection_system": {
+      "requirement": "optional"
+    },
+    "detection_system_id": {
+      "requirement": "recommended"
+    },
+    "pattern_match": {
+      "requirement": "optional"
+    },
+    "policy": {
+      "description": "Details about the policy that triggered the finding.",
+      "requirement": "recommended"
     }
   }
+}

--- a/objects/database.json
+++ b/objects/database.json
@@ -13,7 +13,7 @@
       "requirement": "optional"
     },
     "desc": {
-      "caption": "Description",
+      "description": "The description of the database.",
       "requirement": "optional"
     },
     "size": {
@@ -43,9 +43,6 @@
         },
         "3": {
           "caption": "Object Oriented"
-        },
-        "3": {
-          "caption": "Cloud"
         },
         "4": {
           "caption": "Centralized"

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -12,6 +12,10 @@
       "description": "Describes details about the API call associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
+    "container": {
+      "description": "Describes details about the container associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
     "connection_info": {
       "description": "Describes details about the network connection associated to the activity that triggered the detection.",
       "requirement": "recommended"
@@ -19,6 +23,14 @@
     "data": {
       "description": "Additional evidence data that is not accounted for in the specific evidence attributes.<code> Use only when absolutely necessary.</code>",
       "requirement": "optional"
+    },
+    "database": {
+      "description": "Describes details about the database associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "databucket": {
+      "description": "Describes details about the databucket associated to the activity that triggered the detection.",
+      "requirement": "recommended"
     },
     "dst_endpoint": {
       "description": "Describes details about the destination of the network activity that triggered the detection.",
@@ -47,6 +59,8 @@
       "api",
       "connection_info",
       "data",
+      "database",
+      "databucket",
       "dst_endpoint",
       "file",
       "process",


### PR DESCRIPTION
#### Related Issue: #983 

#### Description of changes:
1. Adding databucket, database & container to evidence artifacts
2. Bugfix: removing unused, duplicate item in the type_id enum of database
3. Bugfix: adding description for an overridden attribute in data_security