### PR TITLE
Add List, Encrypt, Decrypt activities to datastore class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Thankyou! -->
     2. Modified all classes such that primary attributes are at least recommended. #974
     3. Added `src_endpoint`, `http_request` attributes to all IAM category classes. #976
     4. Added `autonomous_system` to `network_endpoint` objects. #978
+    5. Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. #989 
 * #### Profiles
 * #### Objects 
     1. Expanded `type_id` enum in `analytic` object to account for more use-cases: #953

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -34,6 +34,18 @@
 				"7": {
 					"caption": "Delete",
 					"description": "The datastore activity in the event pertains to a 'Delete' operation."
+				},
+				"8": {
+					"caption": "List",
+					"description": "The datastore activity in the event pertains to a 'List' operation."
+				},
+				"9": {
+					"caption": "Encrypt",
+					"description": "The datastore activity in the event pertains to a 'Encrypt' operation."
+				},
+				"10": {
+					"caption": "Decrypt",
+					"description": "The datastore activity in the event pertains to a 'Decrypt' operation."
 				}
 			}
 		},

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -9,43 +9,43 @@
 			"enum": {
 				"1": {
 					"caption": "Read",
-					"description": "The datastore activity in the event pertains to a 'Read' operation."
+					"description": "The 'Read' activity involves accessing specific data record details."
 				},
 				"2": {
 					"caption": "Update",
-					"description": "The datastore activity in the event pertains to a 'Update' operation."
+					"description": "The 'Update' activity pertains to modifying specific data record details."
 				},
 				"3": {
 					"caption": "Connect",
-					"description": "The datastore activity in the event pertains to a 'Connect' operation."
+					"description": "The 'Connect' activity involves establishing a connection to the datastore."
 				},
 				"4": {
 					"caption": "Query",
-					"description": "The datastore activity in the event pertains to a 'Query' operation."
+					"description": "The 'Query' activity involves retrieving a filtered subset of data based on specific criteria."
 				},
 				"5": {
 					"caption": "Write",
-					"description": "The datastore activity in the event pertains to a 'Write' operation."
+					"description": "The 'Write' activity involves writing specific data record details."
 				},
 				"6": {
 					"caption": "Create",
-					"description": "The datastore activity in the event pertains to a 'Create' operation."
+					"description": "The 'Create' activity involves generating new data record details."
 				},
 				"7": {
 					"caption": "Delete",
-					"description": "The datastore activity in the event pertains to a 'Delete' operation."
+					"description": "The 'Delete' activity involves removing specific data record details."
 				},
 				"8": {
 					"caption": "List",
-					"description": "The datastore activity in the event pertains to a 'List' operation."
+					"description": "The 'List' activity provides an overview of existing data records."
 				},
 				"9": {
 					"caption": "Encrypt",
-					"description": "The datastore activity in the event pertains to a 'Encrypt' operation."
+					"description": "The 'Encrypt' activity involves securing data by encrypting a specific data record."
 				},
 				"10": {
 					"caption": "Decrypt",
-					"description": "The datastore activity in the event pertains to a 'Decrypt' operation."
+					"description": "The 'Decrypt' activity involves converting encrypted data back to its original format."
 				}
 			}
 		},


### PR DESCRIPTION
#### Related Issue: 
#989 
#### Description of changes:

- Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. 
- Update activity id descriptions
<img width="1336" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/6465263/d583652a-1e0f-4b8d-899b-f214d236d0d3">


