### PR TITLE
Moved the x_query classes from the 1.1.0 section to the (1.2.0) Unreleased section.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Thankyou! -->
 * #### Categories
 * #### Event Classes
     1. Added `Data Security Finding` event class. #953
+    2. Added `File Query` event class. #967
+    3. Added `Folder Query` event class. #967
+    4. Added `Group Query` event class. #967
+    5. Added `Job Query` event class. #967
+    6. Added `Kernel Object Query` event class. #967
+    7. Added `Module Query` event class. #967
+    8. Added `Network Connection Query` event class. #967
+    9. Added `Networks Query` event class. #967
+    10. Added `Peripheral Device Query` event class. #967
+    11. Added `Prefetch Query` event class. #967
+    12. Added `Process Query` event class. #967
+    13. Added `Registry Key Query` event class. #967
+    14. Added `Registry Value Query` event class. #967
+    15. Added `Service Query` event class. #967
+    16. Added `Session Query` event class. #967
+    17. Added `Startup Application Query` event class. #967
+    18. Added `User Query` event class. #967
+
 * #### Profiles
 * #### Objects
     1. Added `auth_factor` object. #949
@@ -48,17 +66,17 @@ Thankyou! -->
 * #### Platform Extensions
 
 ### Bugfixes
-1. Changed datatype of `priority` attribute, from `integer_t` to `string_t` #959
+    1. Changed datatype of `priority` attribute, from `integer_t` to `string_t` #959
 
 ### Deprecated
-1. Deprecated `coordinates` attribute in favor of specific `lat`, `long` attributes. #971
-2. Deprecated `invoked_by` attribute in the `Actor` object in favor of `app_name`. #979.
+    1. Deprecated `coordinates` attribute in favor of specific `lat`, `long` attributes. #971
+    2. Deprecated `invoked_by` attribute in the `Actor` object in favor of `app_name`. #979.
 
 ### Breaking changes
 
 ### Misc
-1. New Extension registration for Sedara. #951
-2. Add new ways to define observables to metaschema. #982
+    1. New Extension registration for Sedara. #951
+    2. Add new ways to define observables to metaschema. #982
 
 <!-- All available sections in the Changelog:
 
@@ -102,24 +120,7 @@ Thankyou! -->
     7. Added `Device Config Sate Change` event class. #914
     8. Added `Scan Activity` event class. #915
     9. Added `File Hosting Activity` event class. #917
-    10. Added `File Query` event class. #967
-    11. Added `Folder Query` event class. #967
-    12. Added `Group Query` event class. #967
-    13. Added `Job Query` event class. #967
-    14. Added `Kernel Object Query` event class. #967
-    15. Added `Module Query` event class. #967
-    16. Added `Network Connection Query` event class. #967
-    17. Added `Networks Query` event class. #967
-    18. Added `Peripheral Device Query` event class. #967
-    19. Added `Prefetch Query` event class. #967
-    20. Added `Process Query` event class. #967
-    21. Added `Registry Key Query` event class. #967
-    22. Added `Registry Value Query` event class. #967
-    23. Added `Service Query` event class. #967
-    24. Added `Session Query` event class. #967
-    25. Added `Startup Application Query` event class. #967
-    26. Added `User Query` event class. #967
-
+   
 * #### Profiles
 	1. Added `Network Proxy` Profile for the `Network Activity` and `Application Activity` classes. #705 
     2. Added `Load Balancer` Profile for the Network Activity classes. #897 


### PR DESCRIPTION

#### Related Issue: 

#### Description of changes:
The _query Discovery classes were in the 1.1.0 section, but they were not released with 1.1.0 at which time they were _info classes.  These classes were moved to the Added Classes section of Unreleased.
