### PR TITLE
Make Network Interface an observable object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Thankyou! -->
     3. Added `risk_score`, `risk_level_id`, `risk_level` to `user` object. Issue #972.
     4. Added `app_name`, `app_uid` to `actor` object.  Issue #966, PR #979.
     5. Added `container`, `database`, `databucket` to the `evidences` object. #984
-    6. Added `network_interface` object as observable type `31`. #997
+    6. Made `network_interface` object an `observable` with `type_id` `31`. #997
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Thankyou! -->
     3. Added `risk_score`, `risk_level_id`, `risk_level` to `user` object. Issue #972.
     4. Added `app_name`, `app_uid` to `actor` object.  Issue #966, PR #979.
     5. Added `container`, `database`, `databucket` to the `evidences` object. #984
+    6. Added `network_interface` object as observable type `31`. #997
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,12 @@ Thankyou! -->
     3. Added `risk_score`, `risk_level_id`, `risk_level` to `user` object. Issue #972.
     4. Added `app_name`, `app_uid` to `actor` object.  Issue #966, PR #979.
     5. Added `container`, `database`, `databucket` to the `evidences` object. #984
-    6. Made `network_interface` object an `observable` with `type_id` `31`. #997
+    6. Added `owner` to `endpoint` object. #987
+    7. Added `is_applied` Boolean attribute to `policy` object. #987
+    8. Added `agent_list` as an array of `agent` objects. #987
+    9. Added `policies` object as an array of `policy` objects. #987
+    10. Added `agent_list` to `endpoint` object. #987 
+    11. Made `network_interface` object an `observable` with `type_id` `31`. #997
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,12 +45,7 @@ Thankyou! -->
     3. Added `risk_score`, `risk_level_id`, `risk_level` to `user` object. Issue #972.
     4. Added `app_name`, `app_uid` to `actor` object.  Issue #966, PR #979.
     5. Added `container`, `database`, `databucket` to the `evidences` object. #984
-    6. Added `owner` to `endpoint` object. #987
-    7. Added `is_applied` Boolean attribute to `policy` object. #987
-    8. Added `agent_list` as an array of `agent` objects. #987
-    9. Added `policies` object as an array of `policy` objects. #987
-    10. Added `agent_list` to `endpoint` object. #987 
-    11. Made `network_interface` object an `observable` with `type_id` `31`. #997
+    6. Made `network_interface` object an `observable` with `type_id` `31`. #997
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -30,7 +30,7 @@
             "requirement": "recommended"
         },
         "transmit_time": {
-            "description": "The time when the event was transmitted from the logging device to it's next destination",
+            "description": "The time when the event was transmitted from the logging device to it's next destination.",
             "requirement": "optional"
         },
         "uid": {

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -3,6 +3,7 @@
   "description": "The Network Interface object describes the type and associated attributes of a network interface.",
   "extends": "_entity",
   "name": "network_interface",
+  "observable": 31,
   "attributes": {
     "hostname": {
       "description": "The hostname associated with the network interface.",


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:
This PR makes the Network Interface object an observable type for use with analytics.

<img width="291" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/f5796bb5-36ae-4e12-bdf3-ea0721135bf9">
