### PR TITLE
Fix punctuation for transmit_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Thankyou! -->
 ### Misc
     1. New Extension registration for Sedara. #951
     2. Add new ways to define observables to metaschema. #982
+    3. Corrected punctuation for the `transmit_time` attribute. #1001
 
 <!-- All available sections in the Changelog:
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -4012,7 +4012,7 @@
     },
     "transmit_time": {
       "caption": "Transmission Time",
-      "description": "The event transmission time from one device to another.  See specific usage",
+      "description": "The event transmission time from one device to another.  See specific usage.",
       "type": "timestamp_t"
     },
     "tree_uid": {

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -30,7 +30,7 @@
             "requirement": "recommended"
         },
         "transmit_time": {
-            "description": "The time when the event was transmitted from the logging device to it's next destination",
+            "description": "The time when the event was transmitted from the logging device to it's next destination.",
             "requirement": "optional"
         },
         "uid": {


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:

Simple punctuation fix to for the `transmit_time` description.
