### PR TITLE
Fixes validation on latest OCSF validator

### DIFF
--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -84,7 +84,7 @@
       "requirement": "required"
     },
     "connection_info": {
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "dst_endpoint": {
       "description": "The endpoint that received the activity on the target file.",

--- a/events/system/scheduled_job.json
+++ b/events/system/scheduled_job.json
@@ -29,7 +29,7 @@
     },
     "actor": {
       "description": "The actor that performed the activity on the <code>job</code> object.",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "job": {
       "group": "primary",


### PR DESCRIPTION
#### Related Issue: N/A

The OCSF validator was recently updated.  In this latest update, the validator now applies to merged schemas, so that a couple more issues related to #664 are caught.

However, the validator version is not fully pinned in the OCSF schema repo.  That means version updates for the validator can cause the checks on the schema to go red by publishing a new validator.

I think we should consider fully pinning the validator version to avoid this situation.  However, we will also need to fix the issues the validator found, and that's what this PR aims to do.

#### Description of changes:

* Fixes a couple straggling issues related to #664 that are now caught by the OCSF validator.