### PR TITLE
Update attributes with default groups in order to prevent validator errors

### DIFF
--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -80,6 +80,7 @@
       "requirement": "required"
     },
     "connection_info": {
+      "group": "context",
       "requirement": "optional"
     },
     "dst_endpoint": {

--- a/events/network/file_activity.json
+++ b/events/network/file_activity.json
@@ -84,6 +84,7 @@
       "requirement": "required"
     },
     "connection_info": {
+      "group": "context",
       "requirement": "optional"
     },
     "dst_endpoint": {

--- a/events/system/scheduled_job.json
+++ b/events/system/scheduled_job.json
@@ -29,6 +29,7 @@
     },
     "actor": {
       "description": "The actor that performed the activity on the <code>job</code> object.",
+      "group": "context",
       "requirement": "optional"
     },
     "job": {


### PR DESCRIPTION
#### Related Issue: 
#1008 

#### Description of changes:
- Update group for network_connection object in `network_file_activity` and `file_activity` event classes
- Update group for actor object in the `scheduled_job` event class
