### PR TITLE
Adding profile metadata in the resource_details object definition

### DIFF
--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -3,6 +3,7 @@
   "description": "The Resource Details object describes details about resources that were affected by the activity/event.",
   "extends": "_resource",
   "name": "resource_details",
+  "profiles": ["cloud"],
   "attributes": {
     "agent_list": {
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/1003

#### Description of changes:

This is a non-schema-affecting change. I am adding a profile metadata tag in the resource_details object to allow the OCSF to properly present references when viewing a profile.
