### PR TITLE
Enhance email_t regex to allow all characters from RFC5322

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Thankyou! -->
 
 ### Bugfixes
     1. Changed datatype of `priority` attribute, from `integer_t` to `string_t` #959
+    2. Extended `email_t` regexp to allow characters from RFC5322 before @.
 
 ### Deprecated
     1. Deprecated `coordinates` attribute in favor of specific `lat`, `long` attributes. #971

--- a/dictionary.json
+++ b/dictionary.json
@@ -4306,7 +4306,7 @@
         "caption": "Email Address",
         "description": "Email address. For example: <code>john_doe@example.com</code>.",
         "observable": 5,
-        "regex": "^[a-zA-Z0-9!#$%&\"*+-/=?^_'{|}~.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+        "regex": "^[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -4306,7 +4306,7 @@
         "caption": "Email Address",
         "description": "Email address. For example: <code>john_doe@example.com</code>.",
         "observable": 5,
-        "regex": "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
+        "regex": "^[a-zA-Z0-9!#$%&\"*+-/=?^_'{|}~.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
         "type": "string_t",
         "type_name": "String"
       },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1015

#### Description of changes: 
The [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322) allows much more characters in e-mail part before @ than the current regex. This PR adds the characters allowed in RFC `atext`.


Commits have the sign-offs and were verified using the local ocsf-server.

