### PR TITLE
Add a 'Preauth' activity_id to Authentication Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thankyou! -->
     4. Added `autonomous_system` to `network_endpoint` objects. #978
     5. Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. #989 
     6. Added `file` attribute to `http`, `rdp`, `ssh`, and `ftp` event classes. #985
+    7. Added a `Preauth` `activity_id` to the `Authentication` class.
 
 * #### Profiles
 * #### Objects 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ Thankyou! -->
     4. Added `autonomous_system` to `network_endpoint` objects. #978
     5. Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. #989 
     6. Added `file` attribute to `http`, `rdp`, `ssh`, and `ftp` event classes. #985
-    7. Added a `Preauth` `activity_id` to the `Authentication` class.
+    7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
 
 * #### Profiles
 * #### Objects 

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -29,7 +29,7 @@
         },
         "6": {
           "caption": "Preauth",
-          "description": "A preauthentication stage"
+          "description": "A preauthentication stage was engaged."
         }
       }
     },

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -26,6 +26,10 @@
         "5": {
           "caption": "Service Ticket Renew",
           "description": "A Kerberos service ticket was renewed."
+        },
+        "6": {
+          "caption": "Preauth",
+          "description": "A preauthentication stage"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: 
Authentication Class lacks a Preauth Activity #1017

#### Description of changes:

This PR adds a `Preauth` activity_id to the `Authentication` class

<img width="802" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/07b6f7bf-a4d7-4625-a432-3691ee3b4b15">
