### PR TITLE
[Draft] Add ability to embed non-finding events inside of Related Event

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -40,6 +40,11 @@
       "description": "The account object describes details about the account that was the source or target of the activity.",
       "type": "account"
     },
+    "account_change": {
+      "caption": "Embedded Account Change [3001]",
+      "description": "The content of an Account Change [3001] event.",
+      "type": "account_change"
+    },
     "ack_reason": {
       "caption": "Acknowledgement Reason",
       "description": "An integer that provides a reason code or additional information about the acknowledgment result.",
@@ -110,6 +115,11 @@
       "description": "The permissions that were granted to the in a platform-native format.",
       "type": "integer_t"
     },
+    "admin_group_query": {
+      "caption": "Embedded Admin Group Query [5009]",
+      "description": "The content of an Admin Group Query [5009] event.",
+      "type": "admin_group_query"
+    },
     "affected_code": {
       "caption": "Affected Code",
       "description": "List of Affected Code objects that describe details about code blocks identified as vulnerable.",
@@ -175,10 +185,20 @@
       "description": "Describes details about a typical API (Application Programming Interface) call.",
       "type": "api"
     },
+    "api_activity": {
+      "caption": "Embedded API Activity [6003]",
+      "description": "The content of an API Activity [6003] event.",
+      "type": "api_activity"
+    },
     "app": {
       "caption": "Application",
       "description": "The application that reported the event.",
       "type": "product"
+    },
+    "application_lifecycle": {
+      "caption": "Embedded Application Lifecycle [6002]",
+      "description": "The content of an Application Lifecycle [6002] event.",
+      "type": "application_lifecycle"
     },
     "app_name": {
       "caption": "Application Name",
@@ -297,6 +317,16 @@
       },
       "sibling": "auth_type",
       "type": "integer_t"
+    },
+    "authentication": {
+      "caption": "Embedded Authentication [3002]",
+      "description": "The content of an Authentication [3002] event.",
+      "type": "authentication"
+    },
+    "authorize_session": {
+      "caption": "Embedded Authorize Session [3003]",
+      "description": "The content of an Authorize Session [3003] event.",
+      "type": "authorize_session"
     },
     "authorizations": {
       "caption": "Authorization Information",
@@ -1005,6 +1035,11 @@
       "sibling": "confidentiality",
       "type": "integer_t"
     },
+    "config_state": {
+      "caption": "Embedded Device Config State [5002]",
+      "description": "The content of a Device Config State [5002] event.",
+      "type": "config_state"
+    },
     "connection_info": {
       "caption": "Connection Info",
       "description": "The network connection information.",
@@ -1224,6 +1259,11 @@
       "caption": "Databucket",
       "description": "The data bucket object is a basic container that holds data, typically organized through the use of data partitions.",
       "type": "databucket"
+    },
+    "datastore_activity": {
+      "caption": "Embedded Web Resource Access Activity [6004]",
+      "description": "The content of a Web Resource Access Activity [6004] event.",
+      "type": "datastore_activity"
     },
     "data_type": {
       "caption": "Data Type",
@@ -1455,11 +1495,21 @@
       "description": "An addressable device, computer system or host.",
       "type": "device"
     },
+    "device_config_state_change": {
+      "caption": "Embedded Device Config State Change [5019]",
+      "description": "The content of a Device Config State Change [5019] event.",
+      "type": "device_config_state_change"
+    },
     "devices": {
       "caption": "Devices",
       "description": "The object describes details related to the list of devices.",
       "is_array": true,
       "type": "device"
+    },
+    "dhcp_activity": {
+      "caption": "Embedded DHCP Activity [4004]",
+      "description": "The content of a DHCP Activity [4004] event.",
+      "type": "dhcp_activity"
     },
     "dialect": {
       "caption": "Dialect",
@@ -1560,6 +1610,11 @@
       "description": "The Domain-based Message Authentication, Reporting and Conformance (DMARC) policy status.",
       "type": "string_t"
     },
+    "dns_activity": {
+      "caption": "Embedded DNS Activity [4003]",
+      "description": "The content of a DNS Activity [4003] event.",
+      "type": "dns_activity"
+    },
     "domain": {
       "caption": "Domain",
       "description": "The name of the domain.",
@@ -1590,6 +1645,11 @@
       "description": "The email object.",
       "type": "email"
     },
+    "email_activity": {
+      "caption": "Embedded Email Activity [4009]",
+      "description": "The content of an Email Activity [4009] event.",
+      "type": "email_activity"
+    },
     "email_addr": {
       "caption": "Email Address",
       "description": "The user's primary email address.",
@@ -1606,10 +1666,25 @@
       "description": "The SPF, DKIM and DMARC attributes of an email.",
       "type": "email_auth"
     },
+    "email_file_activity": {
+      "caption": "Embedded Email File Activity [4011]",
+      "description": "The content of an Email File Activity [4011] event.",
+      "type": "email_file_activity"
+    },
     "email_uid": {
       "caption": "Email UID",
       "description": "The unique identifier of the email, used to correlate related email alert and activity events.",
       "type": "string_t"
+    },
+    "email_url_activity": {
+      "caption": "Embedded Email URL Activity [4012]",
+      "description": "The content of an Email URL Activity [4012] event.",
+      "type": "email_url_activity"
+    },
+    "embedded_event":{
+      "caption": "Embedded Event",
+      "description": "A container for an embedded event/",
+      "type": "embedded_event"
     },
     "employee_uid": {
       "caption": "Employee ID",
@@ -1642,6 +1717,11 @@
       "caption": "Entity",
       "description": "The managed entity that is being acted upon.",
       "type": "managed_entity"
+    },
+    "entity_management": {
+      "caption": "Embedded Entity Management [3004]",
+      "description": "The content of an Entity Management [3004] event.",
+      "type": "entity_management"
     },
     "entity_result": {
       "caption": "Entity Result",
@@ -1801,10 +1881,25 @@
       "description": "The file that pertains to the event or object. See specific usage.",
       "type": "file"
     },
+    "file_activity": {
+      "caption": "Embedded File System Activity [1001]",
+      "description": "The content of a File System Activity [1001] event.",
+      "type": "file_activity"
+    },
     "file_diff": {
       "caption": "File Diff",
       "description": "File content differences used for change detection. For example, a common use case is to identify itemized changes within INI or configuration/property setting values.",
       "type": "string_t"
+    },
+    "file_hosting": {
+      "caption": "Embedded File Hosting Activity [6006]",
+      "description": "The content of a File Hosting Activity [6006] event.",
+      "type": "file_hosting"
+    },
+    "file_query": {
+      "caption": "Embedded File Query [5007]",
+      "description": "The content of a File Query [5007] event.",
+      "type": "file_query"
     },
     "file_result": {
       "caption": "File Result",
@@ -1881,10 +1976,20 @@
       "description": "The folder that pertains to the event.",
       "type": "file"
     },
+    "folder_query": {
+      "caption": "Embedded Folder Query [5008]",
+      "description": "The content of a Folder Query [5008] event.",
+      "type": "folder_query"
+    },
     "from": {
       "caption": "From",
       "description": "The email header From values, as defined by RFC 5322.",
       "type": "email_t"
+    },
+    "ftp_activity": {
+      "caption": "Embedded FTP Activity [4008]",
+      "description": "The content of an FTP Activity [4008] event.",
+      "type": "ftp_activity"
     },
     "full_name": {
       "caption": "Full Name",
@@ -1915,6 +2020,11 @@
       "caption": "Group",
       "description": "The group object associated with an entity such as user, policy, or rule.",
       "type": "group"
+    },
+    "group_management": {
+      "caption": "Embedded Group Management [3006]",
+      "description": "The content of a Group Management [3006] event.",
+      "type": "group_management"
     },
     "group_name": {
       "@deprecated": {
@@ -1956,6 +2066,11 @@
       "caption": "Hostname",
       "description": "The hostname of an endpoint or a device.",
       "type": "hostname_t"
+    },
+    "http_activity": {
+      "caption": "Embedded HTTP Activity [4002]",
+      "description": "The content of an HTTP Activity [4002] event.",
+      "type": "http_activity"
     },
     "http_cookies": {
       "caption": "HTTP Cookies",
@@ -2135,6 +2250,11 @@
       "is_array": true,
       "type": "ip_t"
     },
+    "inventory_info": {
+      "caption": "Embedded Device Inventory Info [5001]",
+      "description": "The content of a Device Inventory Info [5001] event.",
+      "type": "inventory_info"
+    },
     "invoked_by": {
       "caption": "Invoked by",
       "description": "The name of the service that invoked the activity as described in the event.",
@@ -2280,6 +2400,11 @@
       "description": "The user's job title.",
       "type": "string_t"
     },
+    "job_query": {
+      "caption": "Embedded Job Query [5010]",
+      "description": "The content of a Job Query [5010] event.",
+      "type": "job_query"
+    },
     "kb_articles": {
       "caption": "Knowledgebase Articles",
       "@deprecated": {
@@ -2300,6 +2425,21 @@
       "caption": "Kernel",
       "description": "The kernel resource object that pertains to the event.",
       "type": "kernel"
+    },
+    "kernel_activity": {
+      "caption": "Embedded Kernel Activity [1003]",
+      "description": "The content of a Kernel Activity [1003] event.",
+      "type": "kernel_activity"
+    },
+    "kernel_extension": {
+      "caption": "Embedded Kernel Extension Activity [1002]",
+      "description": "The content of a Kernel Extension Activity [1002] event.",
+      "type": "kernel_extension"
+    },
+    "kernel_object_query": {
+      "caption": "Embedded Kernel Object Query [5006]",
+      "description": "The content of a Kernel Object Query [5006] event.",
+      "type": "kernel_object_query"
     },
     "key_length": {
       "caption": "Key Length",
@@ -2559,6 +2699,11 @@
       "description": "The user's manager. This helps in understanding an org hierarchy. This should only ever be populated once in an event. I.e. there should not be a manager's manager in an event.",
       "type": "user"
     },
+    "memory_activity": {
+      "caption": "Embedded Memory Activity [1004]",
+      "description": "The content of a Memory Activity [1004] event.",
+      "type": "memory_activity"
+    },
     "message": {
       "caption": "Message",
       "description": "The description of the event/finding, as defined by the source.",
@@ -2605,6 +2750,16 @@
       "description": "The module that pertains to the event.",
       "type": "module"
     },
+    "module_activity": {
+      "caption": "Embedded Module Activity [1005]",
+      "description": "The content of a Module Activity [1005] event.",
+      "type": "module_activity"
+    },
+    "module_query": {
+      "caption": "Embedded Module Query [5011]",
+      "description": "The content of a Module Query [5011] event.",
+      "type": "module_query"
+    },
     "name": {
       "caption": "Name",
       "description": "The name of the entity. See specific usage.",
@@ -2619,6 +2774,16 @@
       "caption": "Namespace PID",
       "description": "If running under a process namespace (such as in a container), the process identifier within that process namespace.",
       "type": "integer_t"
+    },
+    "network_activity": {
+      "caption": "Embedded Network Activity [4001]",
+      "description": "The content of a Network Activity [4001] event.",
+      "type": "network_activity"
+    },
+    "network_connection_query": {
+      "caption": "Embedded Network Connection Query [5012]",
+      "description": "The content of a Network Connection Query [5012] event.",
+      "type": "network_connection_query"
     },
     "network_driver": {
       "caption": "Network Driver",
@@ -2636,6 +2801,11 @@
       "is_array": true,
       "type": "network_interface"
     },
+    "networks_query": {
+      "caption": "Embedded Networks Query [5013]",
+      "description": "The content of a Networks Query [5013] event.",
+      "type": "networks_query"
+    },
     "next_run_time": {
       "caption": "Next Run",
       "description": "The next run time. See specific usage.",
@@ -2646,6 +2816,11 @@
       "description": "The NIST Cybersecurity Framework recommendations for managing the cybersecurity risk.",
       "is_array": true,
       "type": "string_t"
+    },
+    "ntp_activity": {
+      "caption": "Embedded NTP Activity [4013]",
+      "description": "The content of an NTP Activity [4013] event.",
+      "type": "ntp_activity"
     },
     "num_detections": {
       "caption": "Detections",
@@ -2863,6 +3038,11 @@
       "description": "The parent process of this process object. It is recommended to only populate this field for the first process object, to prevent deep nesting.",
       "type": "process"
     },
+    "patch_state": {
+      "caption": "Embedded Operating System Patch State [5004]",
+      "description": "The content of an Operating System Patch State [5004] event.",
+      "type": "patch_state"
+    },
     "path": {
       "caption": "Path",
       "description": "The path that pertains to the event or object. See specific usage.",
@@ -2882,6 +3062,11 @@
       "caption": "Peripheral Device",
       "description": "The peripheral device that triggered the event.",
       "type": "peripheral_device"
+    },
+    "peripheral_device_query": {
+      "caption": "Embedded Peripheral Device Query [5014]",
+      "description": "The content of a Peripheral Device Query [5014] event.",
+      "type": "peripheral_device_query"
     },
     "permission": {
       "caption": "Permission",
@@ -3082,6 +3267,16 @@
       "description": "The process object.",
       "type": "process"
     },
+    "process_activity": {
+      "caption": "Embedded Process Activity [1007]",
+      "description": "The content of a Process Activity [1007] event.",
+      "type": "process_activity"
+    },
+    "process_query": {
+      "caption": "Embedded Process Query [5015]",
+      "description": "The content of a Process Query [5015] event.",
+      "type": "process_query"
+    },
     "processed_time": {
       "caption": "Processed Time",
       "description": "The event processed time, such as an ETL operation.",
@@ -3276,6 +3471,11 @@
       "caption": "DNS RData",
       "description": "The data describing the DNS resource. The meaning of this data depends on the type and class of the resource record.",
       "type": "string_t"
+    },
+    "rdp_activity": {
+      "caption": "Embedded RDP Activity [4005]",
+      "description": "The content of a RDP Activity [4005] event.",
+      "type": "rdp_activity"
     },
     "references": {
       "caption": "References",
@@ -3480,10 +3680,20 @@
       "description": "The Scan object describes characteristics of a scan.  See specific usage.",
       "type": "scan"
     },
+    "scan_activity": {
+      "caption": "Embedded Scan Activity [6007]",
+      "description": "The content of a Scan Activity [6007] event.",
+      "type": "scan_activity"
+    },
     "schedule_uid": {
       "caption": "Schedule UID",
       "description": "The unique identifier of the schedule associated with a scan job.",
       "type": "string_t"
+    },
+    "scheduled_job_activity": {
+      "caption": "Embedded Scheduled Job Activity [1006]",
+      "description": "The content of a Scheduled Job Activity [1006] event.",
+      "type": "scheduled_job_activity"
     },
     "scheme": {
       "caption": "Scheme",
@@ -3597,10 +3807,20 @@
       "description": "The service that pertains to the event.",
       "type": "service"
     },
+    "service_query": {
+      "caption": "Embedded Service Query [5016]",
+      "description": "The content of a Service Query [5016] event.",
+      "type": "service_query"
+    },
     "session": {
       "caption": "Session",
       "description": "The authenticated user or service session.",
       "type": "session"
+    },
+    "session_query": {
+      "caption": "Embedded User Session Query [5017]",
+      "description": "The content of a User Session Query [5017] event.",
+      "type": "session_query"
     },
     "severity": {
       "caption": "Severity",
@@ -3692,6 +3912,11 @@
       "description": "The size of data, in bytes.",
       "type": "long_t"
     },
+    "smb_activity": {
+      "caption": "Embedded SMB Activity [4006]",
+      "description": "The content of an SMB Activity [4006] event.",
+      "type": "smb_activity"
+    },
     "smtp_from": {
       "caption": "SMTP From",
       "description": "The value of the SMTP MAIL FROM command.",
@@ -3737,6 +3962,11 @@
       "caption": "Source URL",
       "description": "The URL pointing towards the source of an entity. See specific usage.",
       "type": "url_t"
+    },
+    "ssh_activity": {
+      "caption": "Embedded SSH Activity [4007]",
+      "description": "The content of an SSH Activity [4007] event.",
+      "type": "ssh_activity"
     },
     "standards": {
       "caption": "Security Standards",
@@ -4099,10 +4329,25 @@
       "is_array": true,
       "type": "user"
     },
+    "user_access": {
+      "caption": "Embedded User Access Management [3005]",
+      "description": "The content of a User Access Management [3005] event.",
+      "type": "user_access"
+    },
     "user_agent": {
       "caption": "HTTP User-Agent",
       "description": "The request header that identifies the operating system and web browser.",
       "type": "string_t"
+    },
+    "user_inventory": {
+      "caption": "Embedded User Inventory Info [5003]",
+      "description": "The content of a User Inventory Info [5003] event.",
+      "type": "user_inventory"
+    },
+    "user_query": {
+      "caption": "Embedded User Query [5018]",
+      "description": "The content of a User Query [5018] event.",
+      "type": "user_query"
     },
     "user_result": {
       "caption": "User Result",
@@ -4275,6 +4520,11 @@
       "caption": "Rate Limit",
       "description": "The rate limit for a rate-based rule.",
       "type": "integer_t"
+    },
+    "web_resources_activity": {
+      "caption": "Embedded Web Resources Activity [6001]",
+      "description": "The content of a Web Resources Activity [6001] event.",
+      "type": "web_resources_activity"
     }
   },
   "types": {

--- a/extensions/macos/dictionary.json
+++ b/extensions/macos/dictionary.json
@@ -68,6 +68,11 @@
       "description": "The startup application that pertains to the event.",
       "type": "startup_app"
     },
+    "startup_app_query": {
+      "caption": "Embedded Startup Application Query [305019]",
+      "description": "The content of a Startup Application Query [305019] event.",
+      "type": "startup_app_query"
+    },
     "startup_app_types": {
       "caption": "Startup App Types",
       "description": "The startup app service types.",

--- a/extensions/macos/objects/embedded_event.json
+++ b/extensions/macos/objects/embedded_event.json
@@ -1,0 +1,15 @@
+{
+  "caption": "MacOS Embedded Event",
+  "description": "Extends the Embedded Event object to add MacOS specific events.",
+  "extends": "embedded_event", 
+  "attributes": {
+    "startup_app_query": {
+      "requirement": "optional"
+    }
+  },
+  "constraints": {
+    "just_one": [
+      "startup_app_query"
+    ]
+  }
+}

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -8,10 +8,40 @@
       "description": "The registry key.",
       "type": "reg_key"
     },
+    "prefetch_query": {
+      "caption": "Embedded Startup Prefetch Query [205019]",
+      "description": "The content of a Prefetch Query [205019] event.",
+      "type": "prefetch_query"
+    },
     "prev_reg_key": {
       "caption": "Previous Registry Key",
       "description": "The registry key before the mutation",
       "type": "reg_key"
+    },
+    "registry_key_activity": {
+      "caption": "Embedded Registry Key Activity [201001]",
+      "description": "The content of a Registry Key Activity [201001] event.",
+      "type": "registry_key_activity"
+    },
+    "registry_key_query": {
+      "caption": "Embedded Registry Key Query [205004]",
+      "description": "The content of a Registry Key Query [205004] event.",
+      "type": "registry_key_query"
+    },
+    "registry_value_activity": {
+      "caption": "Embedded Registry Value Activity [201002]",
+      "description": "The content of a Registry Value Activity [201002] event.",
+      "type": "registry_value_activity"
+    },
+    "registry_value_query": {
+      "caption": "Embedded Registry Value Query [205005]",
+      "description": "The content of a Registry Value Query [205005] event.",
+      "type": "registry_value_query"
+    },
+    "resource_activity": {
+      "caption": "Embedded Windows Resource Activity [201003]",
+      "description": "The content of a Windows Resource Activity [201003] event.",
+      "type": "resource_activity"
     },
     "reg_value": {
       "caption": "Registry Value",

--- a/extensions/windows/objects/embedded_event.json
+++ b/extensions/windows/objects/embedded_event.json
@@ -1,0 +1,35 @@
+{
+  "caption": "Windows Embedded Event",
+  "description": "Extends the Embedded Event object to add Windows specific events.",
+  "extends": "embedded_event",
+  "attributes": {
+    "registry_key_activity": {
+      "requirement": "optional"
+    },
+    "registry_value_activity": {
+      "requirement": "optional"
+    },
+    "resource_activity": {
+      "requirement": "optional"
+    },
+    "registry_key_query": {
+      "requirement": "optional"
+    },
+    "registry_value_query": {
+      "requirement": "optional"
+    },
+    "prefetch_query": {
+      "requirement": "optional"
+    }
+  },
+  "constraints": {
+    "just_one": [
+      "registry_key_activity",
+      "registry_value_activity",
+      "resource_activity",
+      "registry_key_query",
+      "registry_value_query",
+      "prefetch_query"
+    ]
+  }
+}

--- a/objects/embedded_event.json
+++ b/objects/embedded_event.json
@@ -1,0 +1,206 @@
+{
+  "caption": "Embedded Event",
+  "description": "The full content of an event. Supported events are limited to non-Finding event types. The event content is present in the attribute corresponding to the event type name.",
+  "extends": "object",
+  "name": "embedded_event",
+  "attributes": {
+    "file_activity": {
+      "requirement": "optional"
+    },
+    "kernel_extension": {
+      "requirement": "optional"
+    },
+    "kernel_activity": {
+      "requirement": "optional"
+    },
+    "memory_activity": {
+      "requirement": "optional"
+    },
+    "module_activity": {
+      "requirement": "optional"
+    },
+    "scheduled_job_activity": {
+      "requirement": "optional"
+    },
+    "process_activity": {
+      "requirement": "optional"
+    },
+    "account_change": {
+      "requirement": "optional"
+    },
+    "authentication": {
+      "requirement": "optional"
+    },
+    "authorize_session": {
+      "requirement": "optional"
+    },
+    "entity_management": {
+      "requirement": "optional"
+    },
+    "user_access": {
+      "requirement": "optional"
+    },
+    "group_management": {
+      "requirement": "optional"
+    },
+    "network_activity": {
+      "requirement": "optional"
+    },
+    "http_activity": {
+      "requirement": "optional"
+    },
+    "dns_activity": {
+      "requirement": "optional"
+    },
+    "dhcp_activity": {
+      "requirement": "optional"
+    },
+    "rdp_activity": {
+      "requirement": "optional"
+    },
+    "smb_activity": {
+      "requirement": "optional"
+    },
+    "ssh_activity": {
+      "requirement": "optional"
+    },
+    "ftp_activity": {
+      "requirement": "optional"
+    },
+    "email_activity": {
+      "requirement": "optional"
+    },
+    "email_file_activity": {
+      "requirement": "optional"
+    },
+    "email_url_activity": {
+      "requirement": "optional"
+    },
+    "ntp_activity": {
+      "requirement": "optional"
+    },
+    "inventory_info": {
+      "requirement": "optional"
+    },
+    "config_state": {
+      "requirement": "optional"
+    },
+    "user_inventory": {
+      "requirement": "optional"
+    },
+    "patch_state": {
+      "requirement": "optional"
+    },
+    "kernel_object_query": {
+      "requirement": "optional"
+    },
+    "file_query": {
+      "requirement": "optional"
+    },
+    "folder_query": {
+      "requirement": "optional"
+    },
+    "admin_group_query": {
+      "requirement": "optional"
+    },
+    "job_query": {
+      "requirement": "optional"
+    },
+    "module_query": {
+      "requirement": "optional"
+    },
+    "network_connection_query": {
+      "requirement": "optional"
+    },
+    "networks_query": {
+      "requirement": "optional"
+    },
+    "peripheral_device_query": {
+      "requirement": "optional"
+    },
+    "process_query": {
+      "requirement": "optional"
+    },
+    "service_query": {
+      "requirement": "optional"
+    },
+    "session_query": {
+      "requirement": "optional"
+    },
+    "user_query": {
+      "requirement": "optional"
+    },
+    "device_config_state_change": {
+      "requirement": "optional"
+    },
+    "web_resources_activity": {
+      "requirement": "optional"
+    },
+    "application_lifecycle": {
+      "requirement": "optional"
+    },
+    "api_activity": {
+      "requirement": "optional"
+    },
+    "datastore_activity": {
+      "requirement": "optional"
+    },
+    "file_hosting": {
+      "requirement": "optional"
+    },
+    "scan_activity": {}
+  },
+  "constraints": {
+    "just_one": [
+      "file_activity",
+      "kernel_extension",
+      "kernel_activity",
+      "memory_activity",
+      "module_activity",
+      "scheduled_job_activity",
+      "process_activity",
+      "account_change",
+      "authentication",
+      "authorize_session",
+      "entity_management",
+      "user_access",
+      "group_management",
+      "network_activity",
+      "http_activity",
+      "dns_activity",
+      "dhcp_activity",
+      "rdp_activity",
+      "smb_activity",
+      "ssh_activity",
+      "ftp_activity",
+      "email_activity",
+      "email_file_activity",
+      "email_url_activity",
+      "ntp_activity",
+      "inventory_info",
+      "config_state",
+      "user_inventory",
+      "patch_state",
+      "kernel_object_query",
+      "file_query",
+      "folder_query",
+      "admin_group_query",
+      "job_query",
+      "module_query",
+      "network_connection_query",
+      "networks_query",
+      "peripheral_device_query",
+      "process_query",
+      "service_query",
+      "session_query",
+      "user_query",
+      "device_config_state_change",
+      "web_resources_activity",
+      "application_lifecycle",
+      "api_activity",
+      "datastore_activity",
+      "file_hosting",
+      "scan_activity"
+    ]
+  }
+} 

--- a/objects/related_event.json
+++ b/objects/related_event.json
@@ -7,6 +7,10 @@
     "attacks": {
       "requirement": "optional"
     },
+    "embedded_event": {
+      "description": "The full embedded content of the related event with type matching <code>type</code> and <code>type_uid</code>.",
+      "requirement": "optional"
+    },
     "kill_chain": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/995

#### Description of changes:
New object "Embedded Event" created
Embedded Event added as a field to Related Event
Attributes created for Embedded Event corresponding to event types
Embedded Event extended in MacOS and Windows extensions

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
4. Have you assigned appropriate labels to the PR?
5. Is your PR title in sync with the description?
