### PR TITLE
Broaden Desc of Share Attributes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3649,17 +3649,17 @@
     },
     "share": {
       "caption": "Share",
-      "description": "The SMB share name.",
+      "description": "The share name. See specific usage.",
       "type": "string_t"
     },
     "share_type": {
       "caption": "Share Type",
-      "description": "The SMB share type, normalized to the caption of the share_type_id value. In the case of 'Other', it is defined by the event source.",
+      "description": "The share type, normalized to the caption of the share_type_id value. In the case of 'Other', it is defined by the event source.",
       "type": "string_t"
     },
     "share_type_id": {
       "caption": "Share Type Id",
-      "description": "The normalized identifier of the SMB share type.",
+      "description": "The normalized identifier of the share type.",
       "enum": {
         "99": {
           "caption": "Other",

--- a/events/network/smb.json
+++ b/events/network/smb.json
@@ -66,14 +66,17 @@
       "requirement": "recommended"
     },
     "share": {
+      "description": "The SMB share name.",
       "group": "primary",
       "requirement": "recommended"
     },
     "share_type": {
+      "description": "The SMB share type, normalized to the caption of the share_type_id value. In the case of 'Other', it is defined by the event source.",
       "group": "primary",
       "requirement": "recommended"
     },
     "share_type_id": {
+      "description": "The normalized identifier of the SMB share type.",
       "group": "primary",
       "requirement": "recommended"
     },


### PR DESCRIPTION
#### Related Issue: 
#1022

#### Description of changes:

Removes 'SMB' from the base dictionary description of the `share` attributes:

<img width="861" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/dc6f72bd-561c-4cf5-b2ae-d4370c696d62">

Retains 'SMB' in the descriptions within the SMB class:

<img width="853" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/a5d9e2d0-ed4c-4618-b20a-898abd029dd6">
