### PR TITLE
Fix Minor Typo: make 'class' lowercase in class description

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -820,7 +820,7 @@
     },
     "class_uid": {
       "caption": "Class ID",
-      "description": "The unique identifier of a class. A Class describes the attributes available in an event.",
+      "description": "The unique identifier of a class. A class describes the attributes available in an event.",
       "sibling": "class_name",
       "type": "integer_t"
     },


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:

Fix a minor typo in the description of `class_uid` where `class` was uppercased.

From: `A Class describes the attributes available in an event.`
To: `A class describes the attributes available in an event.`

<img width="823" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/48375336-7b16-40d9-bee4-4c5e132d16c3">
