### PR TITLE
Updated metaschema to improve error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ Thankyou! -->
     4. Metaschema improvements. #993 
         * Detect unexpected top-level properties in object and event class definitions. This was added at this point to detect invalid observable definitions: invalid `observable` property in event classes, and invalid `observables` property in objects.
         * Remove hard-coded list of categories from `metaschema/categories.schema.json`, leaving this to the `ocsf-validator`. This change makes testing with alternate schemas that may add extra categories easier, as well as making it possible to validate private extensions that contain new categories.
+    5. Metaschema error reporting #1027
+        * Updated the definition of `object` and `event` so that metaschema errors reported by the validator with nested properties correctly attribute the error to the property with the error, rather than the top-level class.
 <!-- All available sections in the Changelog:
 
 ### Added

--- a/metaschema/event.schema.json
+++ b/metaschema/event.schema.json
@@ -3,13 +3,21 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Event",
     "description": "Event classes are particular sets of attributes and objects representing a log line or telemetry submission at a point in time. Event classes have semantics that describe what happened: either a particular activity, disposition or both.",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "common-event-object.schema.json"
         },
         {
             "type": "object",
             "properties": {
+                "@deprecated": true,
+                "description": true,
+                "caption": true,
+                "name": true,
+                "extends": true,
+                "constraints": true,
+                "profiles": true,
+                "attributes": true,
                 "associations": {
                     "type": "object",
                     "description": "Associations indicate attributes in a schema which 'go together'. For example, if a schema has multiple users and multiple endpoints, associations can indicate which user attribute goes with which endpoint.",
@@ -40,8 +48,8 @@
                     },
                     "additionalProperties": false
                 }
-            }
+            },
+            "additionalProperties": false
         }
-    ],
-    "unevaluatedProperties": false
+    ]
 }

--- a/metaschema/object.schema.json
+++ b/metaschema/object.schema.json
@@ -3,18 +3,26 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "Object",
     "description": "An object is a collection of contextually related attributes, usually representing an entity, and may include other objects. Each object is also a data type in OCSF. Examples of object data types are Process, Device, User, Malware and File.",
-    "anyOf": [
+    "allOf": [
         {
             "$ref": "common-event-object.schema.json"
         },
         {
             "type": "object",
             "properties": {
+                "@deprecated": true,
+                "description": true,
+                "caption": true,
+                "name": true,
+                "extends": true,
+                "constraints": true,
+                "profiles": true,
+                "attributes": true,
                 "observable": {
                     "$ref": "observable.schema.json"
-                }            
-            }
+                }
+            },
+            "additionalProperties": false
         }
-    ],
-    "unevaluatedProperties": false
+    ]
 }


### PR DESCRIPTION
#### Related Issue: 
Fixes #1021 

#### Description of changes:
This PR updates the `event` and `object` metaschemas to address the issue described in #1021, where reporting from the metaschema validation does not point to the location of the error.  The strategy used is shown here: https://json-schema.org/understanding-json-schema/reference/object#extending

> Because additionalProperties only recognizes properties declared in the same subschema, it considers anything other than "street_address", "city", and "state" to be additional. Combining the schemas with [allOf](https://json-schema.org/understanding-json-schema/reference/combining#allof) doesn't change that. A workaround you can use is to move additionalProperties to the extending schema and redeclare the properties from the extended schema.
