### PR TITLE
Added the security_control profile and attributes to the Datastore Activity class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Thankyou! -->
     5. Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. #989 
     6. Added `file` attribute to `http`, `rdp`, `ssh`, and `ftp` event classes. #985
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
+    8. Added the `Security Control` profile to the `Datastore Activity` class.
 
 * #### Profiles
 * #### Objects 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Thankyou! -->
     5. Added `List`, `Encrypt` and `Decrypt` activities to `datastore` event class. #989 
     6. Added `file` attribute to `http`, `rdp`, `ssh`, and `ftp` event classes. #985
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
-    8. Added the `Security Control` profile to the `Datastore Activity` class.
+    8. Added the `Security Control` profile to the `Datastore Activity` class. #1030
 
 * #### Profiles
 * #### Objects 

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -4,7 +4,13 @@
 	"extends": "application",
 	"caption": "Datastore Activity",
 	"name": "datastore_activity",
+    "profiles": [
+		"security_control"
+	],
 	"attributes": {
+		"$include": [
+			"profiles/security_control.json"
+		  ],
 		"activity_id": {
 			"enum": {
 				"1": {


### PR DESCRIPTION
#### Related Issue: 1029

#### Description of changes:
Added the `Security Control` profile to the `Datastore Activity` class to give it the authorization semantics of `Allowed` and `Denied` for its access activities.

Updated the `CHANGELOG.md`