### PR TITLE
Fix  `category_ids` typo

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -464,7 +464,7 @@
     },
     "category_ids": {
       "caption": "Website Categorization IDs",
-      "description": "The Website categorization identifies.",
+      "description": "The Website categorization identifiers.",
       "enum": {
         "99": {
           "caption": "Other",


### PR DESCRIPTION
Fix typo in `category_ids` description