### PR TITLE
feat: add file_result to File Hosting Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Thankyou! -->
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
     8. Added the `Security Control` profile to the `Datastore Activity` class. #1030
     9. Added `risk_details` to Detection Finding. #1032
+    10. Added `file_result` to File Hosting Activity. #1045
 
 * #### Profiles
 * #### Objects 

--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -97,6 +97,11 @@
       "group": "primary",
       "requirement": "required"
     },
+    "file_result": {
+      "description": "The resulting file object when the activity was allowed and successful.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "src_endpoint": {
       "description": "The endpoint that performed the activity on the target file.",
       "group": "primary",


### PR DESCRIPTION
#### Related Issue: 

Discussion in Slack [here](https://opencybersecu-lz97379.slack.com/archives/C05HLGHMKU2/p1713305012556869) and discussed during the Network meeting on 2024-04-17.

> The [file hosting activity](https://schema.ocsf.io/1.2.0-rc.1/classes/file_hosting?extensions=) class has the File object, which has an owner attribute, but this doesn't make it easy to model the change. Should this class get a [file_result](https://schema.ocsf.io/1.2.0-rc.1/classes/file_activity?extensions=) attribute so that both the old and new owner can be represented? That way it'd be file.owner for the old owner, and file_result.owner for the new/updated owner of a document

> Really good use case observation.  If there are more transfers besides owner, then a file_result of type File would make sense, but if it is only a change of owner it could be handled in a lighter way, given how rich of an object File is (e.g. new_owner - I don't really like that though, it's a bit too kludgy for one use case).  If the name could change, the size could change, its path changes, any of its extended attributes, its classification: having a file_result makes sense.  There is a Rename activity already, and so I think your suggestion is the right one.  I can imagine other activities in the future too.


#### Description of changes:

This addresses use-cases where the the activity was an Update but the changes were unable to be captured such as a new file.owner, file.size, file.name, etc.
