### PR TITLE
Colorized output for OCSF validator

### DIFF
--- a/.github/workflows/deep-validate.yml
+++ b/.github/workflows/deep-validate.yml
@@ -23,4 +23,5 @@ jobs:
       run: python -m pip install 'ocsf-validator>=0.1.1,<0.2'
 
     - name: Run validator
-      run: python -m ocsf_validator .
+      shell: bash
+      run: echo "TERM=xterm" >> $GITHUB_ENV && python -m ocsf_validator .

--- a/.github/workflows/deep-validate.yml
+++ b/.github/workflows/deep-validate.yml
@@ -19,14 +19,9 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Set colorized output
-      shell: bash
-      run: echo "TERM=xterm" >> $GITHUB_ENV
-
     - name: Install validator
-      shell: bash
       run: python -m pip install 'ocsf-validator>=0.1.1,<0.2'
 
     - name: Run validator
       shell: bash
-      run: python -m ocsf_validator .
+      run: export TERM=xterm && python -m ocsf_validator .

--- a/.github/workflows/deep-validate.yml
+++ b/.github/workflows/deep-validate.yml
@@ -19,9 +19,14 @@ jobs:
       with:
         python-version: '3.11'
 
+    - name: Set colorized output
+      shell: bash
+      run: echo "TERM=xterm" >> $GITHUB_ENV
+
     - name: Install validator
+      shell: bash
       run: python -m pip install 'ocsf-validator>=0.1.1,<0.2'
 
     - name: Run validator
       shell: bash
-      run: echo "TERM=xterm" >> $GITHUB_ENV && python -m ocsf_validator .
+      run: python -m ocsf_validator .

--- a/.github/workflows/deep-validate.yml
+++ b/.github/workflows/deep-validate.yml
@@ -24,4 +24,4 @@ jobs:
 
     - name: Run validator
       shell: bash
-      run: export TERM=xterm && python -m ocsf_validator .
+      run: export FORCE_COLOR=1 && python -m ocsf_validator .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ Thankyou! -->
         * Remove hard-coded list of categories from `metaschema/categories.schema.json`, leaving this to the `ocsf-validator`. This change makes testing with alternate schemas that may add extra categories easier, as well as making it possible to validate private extensions that contain new categories.
     5. Metaschema error reporting #1027
         * Updated the definition of `object` and `event` so that metaschema errors reported by the validator with nested properties correctly attribute the error to the property with the error, rather than the top-level class.
+    6. Colorized validator output #1048
+        * Updated the GitHub workflow for the `ocsf-validator` to print colorized output.
 <!-- All available sections in the Changelog:
 
 ### Added


### PR DESCRIPTION
#### Related Issue: #1047 

#### Description of changes:

This PR enables colorized output for the GitHub action that runs the `ocsf-validator`.  This should help schema developers spot issues more easily while scanning through validator output in the GitHub web interface.

#### Before
![image](https://github.com/ocsf/ocsf-schema/assets/12620443/50aee580-4fdf-4ede-8c46-76f569bdc7b6)

#### After
![image](https://github.com/ocsf/ocsf-schema/assets/12620443/296038b4-e3be-4123-aa6d-5dade0580297)
