### PR TITLE
Fix grammar in status_detail desc/caption

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3765,8 +3765,8 @@
       "type": "string_t"
     },
     "status_detail": {
-      "caption": "Status Details",
-      "description": "The status details contains additional information about the event/finding outcome.",
+      "caption": "Status Detail",
+      "description": "The status detail contains additional information about the event/finding outcome.",
       "type": "string_t"
     },
     "status_id": {


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:

Grammar fix in Dictionary. There is inconsistent use of singular & plural.

Is:

<img width="933" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/dc3d4be8-87b6-491e-8ce1-22a5dfd35fe3">


Changes To:

<img width="938" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/2e0d978f-8f15-4e10-a646-97bd4454a598">

On the flip side - If we want plural + consistency, changing the attribute name to `status_details` would be breaking. Keeping it singular ensures this is non-breaking and provides grammar consistency in the Caption, Name, and Description.