### PR TITLE
[bugfix]: Adding unknown enum value to query_result_id

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3132,6 +3132,10 @@
       "caption": "Query Result ID",
       "description": "The normalized identifier of the query result.",
       "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The query result is unknown."
+        },
         "1": {
           "caption": "Exists",
           "description": "The target was found."


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/1044

#### Description of changes:
1. Adding unknown/0 item in the enum for `query_result_id`
