### PR TITLE
[nonbreaking] Minor indentation fix for readability

### DIFF
--- a/events/network/tunnel_activity.json
+++ b/events/network/tunnel_activity.json
@@ -113,9 +113,9 @@
       "user"
     ]
   },
-	"constraints": {
-		"at_least_one": [
-			"connection_info",
+  "constraints": {
+    "at_least_one": [
+      "connection_info",
       "session",
       "src_endpoint",
       "traffic",


### PR DESCRIPTION
#### Related Issue: 

N/A

#### Description of changes:

Just a minor indentation fix for code readability/consistency.

Validated the constraints are not impacted, and the server runs without error:

<img width="553" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/cd49004c-36a2-45eb-820e-77534628e383">

