### PR TITLE
Clarify how to reference profiles in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,8 @@ Thankyou! -->
         * Remove hard-coded list of categories from `metaschema/categories.schema.json`, leaving this to the `ocsf-validator`. This change makes testing with alternate schemas that may add extra categories easier, as well as making it possible to validate private extensions that contain new categories.
     5. Metaschema error reporting #1027
         * Updated the definition of `object` and `event` so that metaschema errors reported by the validator with nested properties correctly attribute the error to the property with the error, rather than the top-level class.
+    6. Clarify how to reference profiles in metadata #1056
+        * Updated the description of `metadata.profiles` to clarify the correct way to reference a profile in that list.
 <!-- All available sections in the Changelog:
 
 ### Added

--- a/dictionary.json
+++ b/dictionary.json
@@ -3033,7 +3033,7 @@
     },
     "profiles": {
       "caption": "Profiles",
-      "description": "The list of profiles used to create the event.",
+      "description": "The list of profiles used to create the event.  Profiles should be referenced by their <code>name</code> attribute for core profiles, or <code>extension/name</code> for profiles from extensions.",
       "is_array": true,
       "type": "string_t"
     },


### PR DESCRIPTION
#### Related Issue: N/A

Recently, @dkolbly observed that an OCSF mapping example [here](https://github.com/ocsf/examples/blob/main/mappings/markdown/AWS/v1.1.0/Security%20Hub/Detection%20Finding/samples/sechub-guardduty.ocsf#L70) was referencing the Linux profile incorrectly, using `linux` as the profile name.  The example is for v1.1.0, and at that version the profile captioned "Linux" is defined as:

```py
{
  "name": "linux_users",
  "caption": "Linux",
  ...
}
```

... neither of which are the lowercase `linux` used in the example.  

As part of investigating that issue, I noticed that the description of `metadata.profiles` is not specific as to whether the `name` or `caption` should be used.  As the other examples are names, and we treat caption changes as non-breaking, my inference is that the `name` is the correct value to use.  Further, I noticed that profiles from extensions are referenced by `extension_name/profile_name`, such as [here](https://github.com/ocsf/ocsf-schema/blob/refs/tags/v1.1.0/extensions/linux/objects/process.json#L6).


#### Description of changes:

This PR aims to update the description of `metadata.profiles` to better describe how to properly reference a profile in the list.
