### PR TITLE
1057 Update linux_users caption

### DIFF
--- a/extensions/linux/profiles/linux_users.json
+++ b/extensions/linux/profiles/linux_users.json
@@ -1,5 +1,5 @@
 {
-  "caption": "Linux",
+  "caption": "Linux Users",
   "description": "The attributes that Linux uses to identify user information.",
   "meta": "profile",
   "name": "linux_users",


### PR DESCRIPTION
#### Related Issue: 
#1057

#### Description of changes:

Updates the `linux_users` profile caption from just `Linux` to the more specific `Linux Users`. See issue #1057 for further details.
