### PR TITLE
Address gaps in Process Activity and Memory Activity wrt process injection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Thankyou! -->
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
     8. Added the `Security Control` profile to the `Datastore Activity` class. #1030
     9. Added `risk_details` to Detection Finding. #1032
+    10. Added entries to `injection_type_id` enum (`Process Activity`) and `activity_id` enum (`Memory Activity`). #1060
 
 * #### Profiles
     n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Thankyou! -->
 * #### Categories
 * #### Event Classes
     1. Added `file_result` to File Hosting Activity. #1045
+    2. Added entries to `injection_type_id` enum (`Process Activity`) and `activity_id` enum (`Memory Activity`). #1060
 * #### Profiles
 * #### Objects
 * #### Platform Extensions
@@ -120,7 +121,6 @@ Thankyou! -->
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
     8. Added the `Security Control` profile to the `Datastore Activity` class. #1030
     9. Added `risk_details` to Detection Finding. #1032
-    10. Added entries to `injection_type_id` enum (`Process Activity`) and `activity_id` enum (`Memory Activity`). #1060
 
 * #### Profiles
     n/a

--- a/dictionary.json
+++ b/dictionary.json
@@ -2030,6 +2030,9 @@
         },
         "2": {
           "caption": "Load Library"
+        },
+        "3": {
+          "caption": "Queue APC"
         }
       },
       "sibling": "injection_type",

--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -34,6 +34,10 @@
         "8": {
           "description": "Write (Example: <code>WriteProcessMemory</code>)",
           "caption": "Write"
+        },
+        "9": {
+          "description": "Map View (Example: <code>MapViewOfFile2</code>)",
+          "caption": "Map View"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: 

[#1041: Process Activity and Memory Activity cannot adequately describe common injection-related behaviours](https://github.com/ocsf/ocsf-schema/issues/1041)

#### Description of changes:

* Added entry to `injection_type_id` enum in dictionary.json to cover queueing of an asynchronous procedure call (APC).
* Added entry to `activity_id` enum in events/system/memory.json to cover mapping of shared memory object.