### PR TITLE
Evidences object update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Thankyou! -->
 -->
 
 ## [Unreleased]
+* #### Added account, device, email, url, user to evidences in detection finding.
 
 ### Added
 * #### Categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Thankyou! -->
     1. Added `file_result` to File Hosting Activity. #1045
 * #### Profiles
 * #### Objects
-    1. Added account, device, email, url, user to evidences in detection finding.
+    2. Added account, device, email, url, user to evidences in detection finding. #1000
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Thankyou! -->
 * #### Profiles
 * #### Objects
     1. Added account, device, email, url, user to evidences in detection finding.
-
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Thankyou! -->
 -->
 
 ## [Unreleased]
-* #### Added account, device, email, url, user to evidences in detection finding.
 
 ### Added
 * #### Categories
@@ -53,6 +52,8 @@ Thankyou! -->
     1. Added `file_result` to File Hosting Activity. #1045
 * #### Profiles
 * #### Objects
+    1. Added account, device, email, url, user to evidences in detection finding.
+
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -4,10 +4,6 @@
   "extends": "object",
   "name": "evidences",
   "attributes": {
-    "account": {
-      "description": "The account object describes details about the account that was the source or target of the activity that triggered the detection.",
-      "requirement": "recommended"
-    },
     "actor": {
       "description": "Describes details about the user/role/process that was the source of the activity that triggered the detection.",
       "requirement": "recommended"
@@ -69,7 +65,7 @@
       "requirement": "recommended"
     },
     "user": {
-      "description": "The user that pertains to the event or object associated to the activity that triggered the detection.",
+      "description": "Describes details about the user that was the target or somehow else associated with the activity that triggered the detection.",
       "requirement": "recommended"
     }
   },
@@ -81,11 +77,15 @@
       "data",
       "database",
       "databucket",
+      "device",
       "dst_endpoint",
+      "email",
       "file",
       "process",
       "query",
-      "src_endpoint"
+      "src_endpoint",
+      "url",
+      "user"
     ]
   }
 }

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "evidences",
   "attributes": {
+    "account": {
+      "description": "The account object describes details about the account that was the source or target of the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
     "actor": {
       "description": "Describes details about the user/role/process that was the source of the activity that triggered the detection.",
       "requirement": "recommended"
@@ -32,8 +36,16 @@
       "description": "Describes details about the databucket associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
+    "device": {
+      "description": "An addressable device, computer system or host associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
     "dst_endpoint": {
       "description": "Describes details about the destination of the network activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "email": {
+      "description": "The email object associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
     "file": {
@@ -50,6 +62,14 @@
     },
     "src_endpoint": {
       "description": "Describes details about the source of the network activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "url": {
+      "description": "The URL object that pertains to the event or object associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "user": {
+      "description": "The user that pertains to the event or object associated to the activity that triggered the detection.",
       "requirement": "recommended"
     }
   },


### PR DESCRIPTION
Related Issue: https://github.com/ocsf/ocsf-schema/issues/1000

Description of changes:

Adding account, device, email, url, user to evidences in detection finding.

Signed-off-by: Anton Fishman anton.fishman@hunters.ai