### PR TITLE
Added reg_key and reg_value attributes to Evidence Artifacts object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Thankyou! -->
     3. Added `state_id`, `state` to `Digital Signature` object. #1069
     4. Added `ticket` to `Incident Finding` object. ticket. #1068
     5. Added `domain` to `Uniform Resource Locator` object. #1096
+    6. Added `reg_key` and `reg_value` to `Evidence Artifacts` object. #1078
+
 * #### Platform Extensions
 
 ### Bugfixes

--- a/extensions/windows/objects/evidences.json
+++ b/extensions/windows/objects/evidences.json
@@ -1,0 +1,36 @@
+{
+  "caption": "Windows Evidence Artifacts",
+  "description": "Extends the evidences object to add Windows specific fields",
+  "extends": "evidences",
+  "attributes": {
+    "reg_key": {
+      "description": "Describes details about the registry key that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "reg_value": {
+      "description": "Describes details about the registry value that triggered the detection.",
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "actor",
+      "api",
+      "connection_info",
+      "data",
+      "database",
+      "databucket",
+      "device",
+      "dst_endpoint",
+      "email",
+      "file",
+      "process",
+      "query",
+      "src_endpoint",
+      "url",
+      "user",
+      "reg_key",
+      "reg_value"
+    ]
+  }
+}


### PR DESCRIPTION
#### Related Issue: 

https://github.com/ocsf/ocsf-schema/issues/1077

#### Description of changes:

The requirement simply stated in the issue linked above was to add the pre-existing `reg_key` and `reg_value` attributes to the `Evidence Artifacts` object.

However, because these attributes are Windows extension attributes rather than core attributes, it is necessary to extend the `Evidence Artifacts` object as `Windows Evidence Artifacts` and then add the attributes to this object.

Note that this approach follows the pattern that was previously used to add Linux-specific attributes to the `Process` object.