### PR TITLE
Fixed patch_state profile construction; Removed requirement overrides from _resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ Thankyou! -->
 * #### Platform Extensions
 
 ### Bugfixes
+    1. Fixed the host profile construction in `patch_state` event class.
+    2. Removed the optional requirement overrides for `name` and `uid` in `_resource` as they are part of a constraint.
 
 ### Deprecated
 

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -8,7 +8,11 @@
     "host"
   ],
   "attributes": {
+    "$include": [
+      "profiles/host.json"
+  ],
     "device": {
+      "profile": null,
       "group": "primary",
       "requirement": "required"
     },

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -19,16 +19,14 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The name of the resource.",
-      "requirement": "optional"
+      "description": "The name of the resource."
     },
     "type": {
       "description": "The resource type as defined by the event source.",
       "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier of the resource.",
-      "requirement": "optional"
+      "description": "The unique identifier of the resource."
     }
   }
 }


### PR DESCRIPTION
… from _resource (name, uid) - should not be optional if in a constraint.

#### Related Issue: #1086, #1075

#### Description of changes:
Attributes in a constraint should be recommended, not optional.  `_resource` was overriding the `_entity` requirements to optional.  This bug fix removes the override.

The `patch_state` Discovery event class was registered with the `Host` profile, but not including the `profiles/host.json` attributes.  The built-in `device` attribute needed a `"profile": null` statement in its clause.
