### PR TITLE
Improvements to Operating System Patch State 5004

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -2149,7 +2149,7 @@
     },
     "is_installed": {
       "caption": "Installed",
-      "description": "The object is installed or not installed.",
+      "description": "The object is installed or not installed. See specific usage.",
       "type": "boolean_t"
     }, 
     "is_managed": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2228,10 +2228,35 @@
       "type": "boolean_t"
     },
     "is_installed": {
-      "caption": "Installed",
-      "description": "The object is installed or not installed. See specific usage.",
-      "type": "boolean_t"
-    }, 
+      "caption": "Installation State",
+      "description": "The installation state, normalized to the caption of is_installed_id. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "is_installed_id": {
+      "caption": "Installation State ID",
+      "description": "The normalized state of the installation.",
+      "sibling": "is_installed",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The normalized installation state is unknown."
+        },
+        "1": {
+          "caption": "Installed"
+        },
+        "2": {
+          "caption": "Not Installed"
+        },
+        "3": {
+          "caption": "Installed Pending Reboot"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The state is not mapped. See the <code>is_installed</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "is_managed": {
       "caption": "Managed Device",
       "description": "The event occurred on a managed device.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2243,13 +2243,16 @@
           "description": "The normalized installation state is unknown."
         },
         "1": {
-          "caption": "Installed"
+          "caption": "Installed",
+          "description": "The item is installed."
         },
         "2": {
-          "caption": "Not Installed"
+          "caption": "Not Installed",
+          "description": "The item is not installed."
         },
         "3": {
-          "caption": "Installed Pending Reboot"
+          "caption": "Installed Pending Reboot",
+          "description": "The item is installed pending reboot operation."
         },
         "99": {
           "caption": "Other",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2583,8 +2583,8 @@
     },
     "mean_time": {
       "caption": "Mean Time",
-      "description": "The mean or average time of the activity as determined by the activity change.",
-      "type": "timestamp_t"
+      "description": "The average time of the activity as determined by the activity change.",
+      "type": "integer_t"
     },
     "message": {
       "caption": "Message",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2147,6 +2147,11 @@
       "description": "This attribute prevents the cookie from being accessed via JavaScript.",
       "type": "boolean_t"
     },
+    "is_installed": {
+      "caption": "Installed",
+      "description": "The object is installed or not installed.",
+      "type": "boolean_t"
+    }, 
     "is_managed": {
       "caption": "Managed Device",
       "description": "The event occurred on a managed device.",
@@ -2575,6 +2580,11 @@
       "caption": "Match Location",
       "description": "The location of the matched data in the source which resulted in the triggered firewall rule. For example: HEADER.",
       "type": "string_t"
+    },
+    "mean_time": {
+      "caption": "Mean Time",
+      "description": "The mean or average time.",
+      "type": "timestamp_t"
     },
     "message": {
       "caption": "Message",
@@ -3303,6 +3313,11 @@
       "caption": "DNS RData",
       "description": "The data describing the DNS resource. The meaning of this data depends on the type and class of the resource record.",
       "type": "string_t"
+    },
+    "reboot_time": {
+      "caption": "Reboot Time",
+      "description": "The time when the system was rebooted.",
+      "type": "timestamp_t"
     },
     "references": {
       "caption": "References",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2145,19 +2145,19 @@
       }
     },
     "installed_state": {
-      "caption": "Installation State",
-      "description": "The installation state, normalized to the caption of installed_state_id. In the case of 'Other', it is defined by the event source.",
+      "caption": "Installed State",
+      "description": "The installed state, normalized to the caption of installed_state_id. In the case of 'Other', it is defined by the event source.",
       "type": "string_t"
     },
     "installed_state_id": {
-      "caption": "Installation State ID",
-      "description": "The normalized state of the installation.",
+      "caption": "Installed State ID",
+      "description": "The normalized state of the install.",
       "sibling": "installed_state",
       "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The normalized installation state is unknown."
+          "description": "The normalized installed state is unknown."
         },
         "1": {
           "caption": "Installed",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1574,6 +1574,46 @@
       "description": "The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.",
       "type": "integer_t"
     },
+    "duration_avg_days": {
+      "caption": "Average Duration Days",
+      "description": "This represents the average duration of the activity in days. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_hours": {
+      "caption": "Average Duration Hours",
+      "description": "This represents the average duration of the activity in hours. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_mins": {
+      "caption": "Average Duration Minutes",
+      "description": "This represents the average duration of the activity in minutes. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_months": {
+      "caption": "Average Duration Months",
+      "description": "This represents the average duration of the activity in months. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_msecs": {
+      "caption": "Average Duration Milliseconds",
+      "description": "This represents the average duration of the activity in milliseconds. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_secs": {
+      "caption": "Average Duration Seconds",
+      "description": "This represents the average duration of the activity in seconds. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_weeks": {
+      "caption": "Average Duration Weeks",
+      "description": "This represents the average duration of the activity in weeks. See specific usage.",
+      "type": "integer_t"
+    },
+    "duration_avg_years": {
+      "caption": "Average Duration Years",
+      "description": "This represents the average duration of the activity in years. See specific usage.",
+      "type": "integer_t"
+    },
     "edition": {
       "caption": "OS Edition",
       "description": "The operating system edition. For example: <code>Professional</code>.",
@@ -2625,11 +2665,6 @@
       "caption": "Match Location",
       "description": "The location of the matched data in the source which resulted in the triggered firewall rule. For example: HEADER.",
       "type": "string_t"
-    },
-    "mean_time": {
-      "caption": "Mean Time",
-      "description": "The average time of the activity as determined by the activity change.",
-      "type": "integer_t"
     },
     "message": {
       "caption": "Message",

--- a/dictionary.json
+++ b/dictionary.json
@@ -344,6 +344,11 @@
       "description": "The BIOS version. For example: <code>LENOVO G5ETA2WW (2.62)</code>.",
       "type": "string_t"
     },
+    "boot_time": {
+      "caption": "Boot Time",
+      "description": "The time when the system was booted.",
+      "type": "timestamp_t"
+    },
     "boundary": {
       "caption": "Boundary",
       "description": "The boundary of the connection, normalized to the caption of 'boundary_id'. In the case of 'Other', it is defined by the event source. <p> For cloud connections, this translates to the traffic-boundary(same VPC, through IGW, etc.). For traditional networks, this is described as Local, Internal, or External.</p>",
@@ -2144,20 +2149,20 @@
         }
       }
     },
-    "installed_state": {
-      "caption": "Installed State",
-      "description": "The installed state, normalized to the caption of installed_state_id. In the case of 'Other', it is defined by the event source.",
+    "install_state": {
+      "caption": "Install State",
+      "description": "The install state, normalized to the caption of install_state_id. In the case of 'Other', it is defined by the event source.",
       "type": "string_t"
     },
-    "installed_state_id": {
-      "caption": "Installed State ID",
+    "install_state_id": {
+      "caption": "Install State ID",
       "description": "The normalized state of the install.",
-      "sibling": "installed_state",
+      "sibling": "install_state",
       "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The normalized installed state is unknown."
+          "description": "The normalized install state is unknown."
         },
         "1": {
           "caption": "Installed",
@@ -2173,7 +2178,7 @@
         },
         "99": {
           "caption": "Other",
-          "description": "The state is not mapped. See the <code>installed_state</code> attribute, which contains a data source specific value."
+          "description": "The install state is not mapped. See the <code>install_state</code> attribute, which contains a data source specific value."
         }
       }
     },
@@ -3427,11 +3432,6 @@
       "caption": "DNS RData",
       "description": "The data describing the DNS resource. The meaning of this data depends on the type and class of the resource record.",
       "type": "string_t"
-    },
-    "reboot_time": {
-      "caption": "Reboot Time",
-      "description": "The time when the system was rebooted.",
-      "type": "timestamp_t"
     },
     "references": {
       "caption": "References",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2144,6 +2144,39 @@
         }
       }
     },
+    "installed_state": {
+      "caption": "Installation State",
+      "description": "The installation state, normalized to the caption of installed_state_id. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "installed_state_id": {
+      "caption": "Installation State ID",
+      "description": "The normalized state of the installation.",
+      "sibling": "installed_state",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The normalized installation state is unknown."
+        },
+        "1": {
+          "caption": "Installed",
+          "description": "The item is installed."
+        },
+        "2": {
+          "caption": "Not Installed",
+          "description": "The item is not installed."
+        },
+        "3": {
+          "caption": "Installed Pending Reboot",
+          "description": "The item is installed pending reboot operation."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The state is not mapped. See the <code>installed_state</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "instance_uid": {
       "caption": "Instance ID",
       "description": "The unique identifier of a VM instance.",
@@ -2226,39 +2259,6 @@
       "caption": "HTTP Only",
       "description": "This attribute prevents the cookie from being accessed via JavaScript.",
       "type": "boolean_t"
-    },
-    "is_installed": {
-      "caption": "Installation State",
-      "description": "The installation state, normalized to the caption of is_installed_id. In the case of 'Other', it is defined by the event source.",
-      "type": "string_t"
-    },
-    "is_installed_id": {
-      "caption": "Installation State ID",
-      "description": "The normalized state of the installation.",
-      "sibling": "is_installed",
-      "type": "integer_t",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The normalized installation state is unknown."
-        },
-        "1": {
-          "caption": "Installed",
-          "description": "The item is installed."
-        },
-        "2": {
-          "caption": "Not Installed",
-          "description": "The item is not installed."
-        },
-        "3": {
-          "caption": "Installed Pending Reboot",
-          "description": "The item is installed pending reboot operation."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The state is not mapped. See the <code>is_installed</code> attribute, which contains a data source specific value."
-        }
-      }
     },
     "is_managed": {
       "caption": "Managed Device",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2583,7 +2583,7 @@
     },
     "mean_time": {
       "caption": "Mean Time",
-      "description": "The mean or average time.",
+      "description": "The mean or average time of the activity as determined by the activity change.",
       "type": "timestamp_t"
     },
     "message": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -81,6 +81,10 @@
       "description": "Organization and org unit related to the device.",
       "requirement": "optional"
     },
+    "reboot_time": {
+      "description": "The time the system was rebooted",
+      "requirement": "optional"
+    },
     "region": {
       "description": "The region where the virtual machine is located. For example, an AWS Region.",
       "requirement": "recommended"

--- a/objects/device.json
+++ b/objects/device.json
@@ -82,7 +82,7 @@
       "requirement": "optional"
     },
     "reboot_time": {
-      "description": "The time the system was rebooted",
+      "description": "The time the system was rebooted.",
       "requirement": "optional"
     },
     "region": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -7,6 +7,10 @@
     "autoscale_uid": {
       "requirement": "optional"
     },
+    "boot_time": {
+      "description": "The time the system was booted.",
+      "requirement": "optional"
+    },
     "created_time": {
       "description": "The time when the device was known to have been created.",
       "requirement": "optional"
@@ -79,10 +83,6 @@
     },
     "org": {
       "description": "Organization and org unit related to the device.",
-      "requirement": "optional"
-    },
-    "reboot_time": {
-      "description": "The time the system was rebooted.",
       "requirement": "optional"
     },
     "region": {

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -17,11 +17,11 @@
       "requirement": "optional"
     },
     "installed_state": {
-      "description": "The installation state of the kb article.",
+      "description": "The install state of the kb article.",
       "requirement": "recommended"
     },
     "installed_state_id": {
-      "description": "The normalized installation state ID of the kb article.",
+      "description": "The normalized install state ID of the kb article.",
       "requirement": "recommended"
     },
     "title": {

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -16,11 +16,11 @@
       "description": "The average time to patch in minutes.",
       "requirement": "optional"
     },
-    "installed_state": {
+    "install_state": {
       "description": "The install state of the kb article.",
       "requirement": "recommended"
     },
-    "installed_state_id": {
+    "install_state_id": {
       "description": "The normalized install state ID of the kb article.",
       "requirement": "recommended"
     },

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -4,13 +4,21 @@
   "extends": "object",
   "name": "kb_article",
   "attributes": {
+    "duration_avg_days": {
+      "description": "The average time to patch in days.",
+      "requirement": "optional"
+    },
+    "duration_avg_hours": {
+      "description": "The average time to patch in hours.",
+      "requirement": "optional"
+    },
+    "duration_avg_mins": {
+      "description": "The average time to patch in minutes.",
+      "requirement": "optional"
+    },
     "is_installed": {
       "description": "The KB Article is installed or not installed.",
       "requirement": "recommended"
-    },
-    "mean_time": {
-      "description": "The average time to patch.",
-      "requirement": "optional"
     },
     "title": {
       "description": "The title of the kb article.",

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -17,7 +17,11 @@
       "requirement": "optional"
     },
     "is_installed": {
-      "description": "The KB Article is installed or not installed.",
+      "description": "The installation state of the KB Article.",
+      "requirement": "recommended"
+    },
+    "is_installed_id": {
+      "description": "The normalized installation state ID of the KB Article.",
       "requirement": "recommended"
     },
     "title": {

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -17,11 +17,11 @@
       "requirement": "optional"
     },
     "is_installed": {
-      "description": "The installation state of the KB Article.",
+      "description": "The installation state of the kb article.",
       "requirement": "recommended"
     },
     "is_installed_id": {
-      "description": "The normalized installation state ID of the KB Article.",
+      "description": "The normalized installation state ID of the kb article.",
       "requirement": "recommended"
     },
     "title": {

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "kb_article",
   "attributes": {
+    "is_installed": {
+      "description": "The KB Article is installed or not installed.",
+      "requirement": "recommended"
+    },
     "title": {
       "description": "The title of the kb article.",
       "requirement": "recommended"

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -9,7 +9,7 @@
       "requirement": "recommended"
     },
     "mean_time": {
-      "description": "The mean or average time to patch.",
+      "description": "The average time to patch.",
       "requirement": "optional"
     },
     "title": {

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -16,11 +16,11 @@
       "description": "The average time to patch in minutes.",
       "requirement": "optional"
     },
-    "is_installed": {
+    "installed_state": {
       "description": "The installation state of the kb article.",
       "requirement": "recommended"
     },
-    "is_installed_id": {
+    "installed_state_id": {
       "description": "The normalized installation state ID of the kb article.",
       "requirement": "recommended"
     },

--- a/objects/kb_article.json
+++ b/objects/kb_article.json
@@ -8,6 +8,10 @@
       "description": "The KB Article is installed or not installed.",
       "requirement": "recommended"
     },
+    "mean_time": {
+      "description": "The mean or average time to patch.",
+      "requirement": "optional"
+    },
     "title": {
       "description": "The title of the kb article.",
       "requirement": "recommended"


### PR DESCRIPTION
###Updated 6/7
#### Description of changes: A number of attributes to improve Patch State. Mean time is a commonly used metric to evaluate patch efficacy and is captured in new attributes for duration_avg_<unit>, is_installed is a new attribute that describes the installation state, and is_installed_id the normalized installation state of the kb_article, and reboot_time to capture the reboot or true install time for reboot dependent patches.

New dictionary attributes
attributes: duration_avg_<unit> 
Examples: duration_avg_days, duration_avg_hours, duration_avg_msecs, duration_avg_mins, duration_avg_months, duration_avg_secs, duration_avg_weeks, and duration_avg_years
description: This captures the average time. This will be used for "mean time to patch" or MTTP.
Object: kb_article
Note: this could be set per kb_article or per kb_article array for a total "MTTP"

attribute: install_state
description: the installation state
Object: kb_article
Note: This could be for a single kb_article or array of many kb_articles.

attribute: install_state_id
description: the normalized installation state
Object: kb_article
Note: Includes installed, not installed, installed pending reboot, other, and unknown. This could be for a single kb_article or array of many kb_articles.

attribute: boot_time
description: This captures the boot time of the system.
Object: device
Note: This is a neat one and very related to patching.
