### PR TITLE
Adjust Windows Resource Activity class (201003) to be aligned with Windows event 4662

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Thankyou! -->
 ### Added
 * #### Categories
     1. Added `Remediation` category. #1066
+* #### Dictionary
+    1. Added `win_resources` as an array of win_resource objects. #1090
 * #### Event Classes
     1. Added `Event Log Activity` event class. #1014
     2. Added `Remediation Activity` `File Remediation Activity` `Process Remediation Activity` `Network Remediation Activity` event classes. #1066
@@ -67,7 +69,10 @@ Thankyou! -->
     3. Added `state_id`, `state` to `Digital Signature` object. #1069
     4. Added `ticket` to `Incident Finding` object. ticket. #1068
 * #### Platform Extensions
-
+    1. Removed `win_resource` object from Windows Resource Activity class. #1090   
+    2. Added `win_resources` to Windows Resource Activity class. #1090   
+    3. Added `access_mask` to Windows Resource Activity class. #1090   
+    4. Added `access_list` to Windows Resource Activity class. #1090
 ### Bugfixes
 
 ### Deprecated

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -32,6 +32,12 @@
       "caption": "Windows Resource",
       "description": "The Windows resource object that was accessed, such as a mutant or timer.",
       "type": "win_resource"
+    },
+    "win_resources": {
+      "caption": "Windows Resource Array",
+      "description": "List of Windows resources that were accessed.",
+      "type": "win_resource",
+      "is_array": true
     }
   }
 }

--- a/extensions/windows/events/resource.json
+++ b/extensions/windows/events/resource.json
@@ -12,9 +12,17 @@
         }
       }
     },
-    "win_resource": {
+    "win_resources": {
       "group": "primary",
       "requirement": "required"
+    },
+    "access_mask": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "access_list": {
+      "group": "context",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: 
[#1090 ](https://github.com/ocsf/ocsf-schema/issues/1090)

#### Description of changes:
1. We add the attributes `access_list`, `access_mask`.
2.  We create a new attribute called `win_resources` that is an array of `win_resource` objects. The new `win_resources` replaces the `win_resource` attribute under the Windows Resource Activity class.

Windows Resource Activity (201003) Class:
![Screenshot 2024-05-21 at 16 08 51](https://github.com/ocsf/ocsf-schema/assets/100218904/dc87ee11-0365-45ed-ac72-e448230333b1)
![Screenshot 2024-05-21 at 16 09 15](https://github.com/ocsf/ocsf-schema/assets/100218904/2aa89acd-3b75-4832-8209-e1f3011aa717)
 

Dictionary:
![Screenshot 2024-05-21 at 16 06 58](https://github.com/ocsf/ocsf-schema/assets/100218904/44dd5e71-467f-4c35-af3c-d259c9013a46)

Signed-off-by: Eliraz Levi [eliraz.levi@hunters.ai](mailto:eliraz.levi@hunters.ai)
