### PR TITLE
Enhance Managed Entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,13 +66,10 @@ Thankyou! -->
     2. Added `account`, `device`, `email`, `url`, `user` to `evidences` in detection finding. #1000
     3. Added `state_id`, `state` to `Digital Signature` object. #1069
     4. Added `ticket` to `Incident Finding` object. ticket. #1068
-<<<<<<< HEAD
-    5. Added `type_id` and associated entity objects to `Managed Entity`. #1094
-=======
     5. Added `domain` to `Uniform Resource Locator` object. #1096
     6. Added `reg_key` and `reg_value` to `Evidence Artifacts` object. #1078
-
->>>>>>> c12527dee8ebd45df67db3ae46d4ab843b5d8ec0
+    7. Added `type_id` and associated entity objects to `Managed Entity`. #1094
+ 
 * #### Platform Extensions
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Thankyou! -->
     2. Added `account`, `device`, `email`, `url`, `user` to `evidences` in detection finding. #1000
     3. Added `state_id`, `state` to `Digital Signature` object. #1069
     4. Added `ticket` to `Incident Finding` object. ticket. #1068
+    5. Added `type_id` and associated entity objects to `Managed Entity`. #1094
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -1,6 +1,6 @@
 {
   "caption": "Managed Entity",
-  "description": "The Managed Entity object describes the type and version of an entity, such as a policy or configuration.",
+  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute and the <code>type</code> attribute should identify the entity.",
   "extends": "_entity",
   "name": "managed_entity",
   "attributes": {
@@ -15,12 +15,65 @@
       "description": "The managed entity type. For example: <code>policy</code>, <code>user</code>, <code>organizational unit</code>, <code>device</code>.",
       "requirement": "recommended"
     },
+    "type_id": {
+      "requirement": "recommended",
+      "description": "The type of the Managed Entity. It is recommended to also populate the <code>type</code> attribute with the associated label, or the source specific name if <code>Other</code>.",
+      "enum": {
+        "1": {
+          "caption": "Device",
+          "description": "A managed Device entity."
+        },
+        "2": {
+          "caption": "User",
+          "description": "A managed User entity."
+        },
+        "3": {
+          "caption": "Group",
+          "description": "A managed Group entity."
+        },
+        "4": {
+          "caption": "Organization",
+          "description": "A managed Organization entity."
+        },
+        "5": {
+          "caption": "Policy",
+          "description": "A managed Policy entity."
+        }
+      }
+    },
+    "device": {
+      "requirement": "recommended"
+    },
+    "group": {
+      "requirement": "recommended"
+    },
+    "org": {
+      "requirement": "recommended"
+    },
+    "policy": {
+      "requirement": "recommended",
+      "description": "Describes details of a managed policy."
+    },
     "uid": {
       "description": "The identifier of the managed entity."
+    },
+    "user": {
+      "requirement": "recommended"
     },
     "version": {
       "description": "The version of the managed entity. For example: <code>1.2.3</code>.",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "name",
+      "uid",  
+      "device",
+      "group",
+      "org",
+      "policy",
+      "user"
+    ]
   }
 }

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -1,6 +1,6 @@
 {
   "caption": "Managed Entity",
-  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute and the <code>type</code> attribute should identify the entity.",
+  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  For types in the <code>type_id</code> enum list, an associated attribute should be populated.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute and the <code>type</code> attribute should identify the entity.",
   "extends": "_entity",
   "name": "managed_entity",
   "attributes": {
@@ -21,27 +21,34 @@
       "enum": {
         "1": {
           "caption": "Device",
-          "description": "A managed Device entity."
+          "description": "A managed Device entity.  This item corresponds to population of the <code>device</code> attribute."
         },
         "2": {
           "caption": "User",
-          "description": "A managed User entity."
+          "description": "A managed User entity.  This item corresponds to population of the <code>user</code> attribute."
         },
         "3": {
           "caption": "Group",
-          "description": "A managed Group entity."
+          "description": "A managed Group entity.  This item corresponds to population of the <code>group</code> attribute."
         },
         "4": {
           "caption": "Organization",
-          "description": "A managed Organization entity."
+          "description": "A managed Organization entity.  This item corresponds to population of the <code>org</code> attribute."
         },
         "5": {
           "caption": "Policy",
-          "description": "A managed Policy entity."
+          "description": "A managed Policy entity.  This item corresponds to population of the <code>policy</code> attribute."
+        },
+        "6": {
+          "caption": "Email",
+          "description": "A managed Email entity.  This item corresponds to population of the <code>email</code> attribute."
         }
       }
     },
     "device": {
+      "requirement": "recommended"
+    },
+    "email": {
       "requirement": "recommended"
     },
     "group": {


### PR DESCRIPTION
#### Related Issue: N/A
Managed Entity was too open ended, without enough detail on the changes to an arbitrary entity as a string value in `type`.  This PR adds specific object entities.

#### Description of changes:
Added `type_id` (along with existing `type` as sibling) with an initial set of types: Device, User, Group, Organization, Policy.
Added to the constraints as `at_least_one`