### PR TITLE
Add missing domain attribute to URL object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Thankyou! -->
     2. Added `account`, `device`, `email`, `url`, `user` to `evidences` in detection finding. #1000
     3. Added `state_id`, `state` to `Digital Signature` object. #1069
     4. Added `ticket` to `Incident Finding` object. ticket. #1068
+    5. Added `domain` to `Uniform Resource Locator` object. #1096
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/url.json
+++ b/objects/url.json
@@ -11,6 +11,10 @@
     "category_ids": {
       "requirement": "recommended"
     },
+    "domain": {
+      "description": "The domain portion of the URL. For example: <code>example.com</code> in <code>https://sub.example.com</code>.",
+      "requirement": "optional"
+    },
     "hostname": {
       "description": "The URL host as extracted from the URL. For example: <code>www.example.com</code> from <code>www.example.com/download/trouble</code>.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

We noticed that the `url` object has `subdomain`, but not `domain`. This PR adds the `domain` attribute to the existing `url` object:

<img width="992" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/7997c69a-8e1b-469e-b258-8785273fe665">

