### PR TITLE
Fix typo in actor desc

### DIFF
--- a/events/iam/entity_management.json
+++ b/events/iam/entity_management.json
@@ -62,7 +62,7 @@
       }
     },
     "actor": {
-      "description": "Use for when the entity acting upon another entity is a process or user.",
+      "description": "Used for when the entity acting upon another entity is a process or user.",
       "group": "context"
     },
     "comment": {


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:

This PR fixes a minor typo in the `actor` description of the `Entity Management` class: ~~Use~~ vs Used.
Note: CHANGELOG update shouldn't be necessary for this one.

<img width="1029" alt="image" src="https://github.com/ocsf/ocsf-schema/assets/91983279/d8a89608-5268-48d4-a79d-9cf30732ec4c">
