### PR TITLE
Increasing ocsf-validator dependency to 0.2.x

### DIFF
--- a/.github/workflows/deep-validate.yml
+++ b/.github/workflows/deep-validate.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: '3.11'
 
     - name: Install validator
-      run: python -m pip install 'ocsf-validator>=0.1.1,<0.2'
+      run: python -m pip install 'ocsf-validator>=0.2,<0.3'
 
     - name: Run validator
       shell: bash


### PR DESCRIPTION
This PR bumps the version of the `ocsf-validator` in the GitHub workflow from 0.1.x to 0.2.x, to allow work by @dkolbly on  #1063 to pass validation.
