### PR TITLE
Added 'Windows Service Activity' event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Thankyou! -->
 * #### Event Classes
     1. Added `Event Log Activity` event class. #1014
     2. Added `Remediation Activity` `File Remediation Activity` `Process Remediation Activity` `Network Remediation Activity` event classes. #1066
+    3. Added `Windows Service Activity` event class to the Windows extension. #1103
 * #### Profiles
     1. Added `osint` Profile based on `osint` object. #992
 * #### Objects
@@ -56,6 +57,7 @@ Thankyou! -->
     6. Added `signatures` object, an array of `signature` objects. #992
     7. Added `whois` object. #992
     8. Added `domain_contact` and array-typed `domain_contacts` object for use with `whois` object. #992
+    9. Added `Windows Service` object to the Windows extension. #1103
 
 * #### Platform Extensions
 

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -32,6 +32,171 @@
       "caption": "Windows Resource",
       "description": "The Windows resource object that was accessed, such as a mutant or timer.",
       "type": "win_resource"
+    },
+    "load_order_group": {
+      "caption": "Load Order Group",
+      "description": "The name of the load ordering group of which this service is a member.",
+      "type": "string_t"
+    },
+    "service_category": {
+      "caption": "Service Category",
+      "description": "The service category, normalized to the caption of the service_category_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "service_category_id": {
+      "caption": "Service Category ID",
+      "description": "The normalized identifier of the service category.",
+      "sibling": "service_category",
+      "type": "integer_t",
+      "enum":{
+        "0": {
+          "caption": "Unknown",
+          "description": "The service category is unknown."
+        },
+        "1": {
+          "caption": "Kernel Mode",
+          "description": "A kernel mode driver."
+        },
+        "2": {
+          "caption": "User Mode",
+          "description": "A user mode service."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The service category is not mapped. See the <code>service_category</code> attribute, which contains an event source specific value."
+        }
+      }
+    },
+    "service_dependencies": {
+      "caption": "Service Dependencies",
+      "description": "The names of other services upon which this service has a dependency.",
+      "type": "string_t",
+      "is_array": true
+    },
+    "service_error_control": {
+      "caption": "Service Error Control",
+      "description": "The service error control, normalized to the caption of the <code>service_error_control_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "service_error_control_id": {
+      "caption": "Service Error Control ID",
+      "description": "The normalized identifier of the service error control.",
+      "sibling": "service_error_control",
+      "type": "integer_t",
+      "enum":{
+        "0": {
+          "caption": "Unknown",
+          "description": "The service error control is unknown."
+        },
+        "1": {
+          "caption": "Ignore",
+          "description": "The startup program ignores the error and continues the startup operation."
+        },
+        "2": {
+          "caption": "Normal",
+          "description": "The startup program logs the error in the event log but continues the startup operation."
+        },
+        "3": {
+          "caption": "Severe",
+          "description": "The startup program logs the error in the event log. If the last-known-good configuration is being started, the startup operation continues. Otherwise, the system is restarted with the last-known-good configuration."
+        },
+        "4": {
+          "caption": "Critical",
+          "description": "The startup program logs the error in the event log, if possible. If the last-known-good configuration is being started, the startup operation fails. Otherwise, the system is restarted with the last-known good configuration."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The service error control is not mapped. See the <code>service_error_control</code> attribute, which contains an event source specific value."
+        }
+      }
+    },
+    "service_start_type": {
+      "caption": "Service Start Type",
+      "description": "The service start type, normalized to the caption of the <code>service_start_type_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "service_start_type_id": {
+      "caption": "Service Start Type ID",
+      "description": "The normalized identifier of the service start type.",
+      "sibling": "service_start_type",
+      "type": "integer_t",
+      "enum":{
+        "0": {
+          "caption": "Unknown",
+          "description": "The service start type is unknown."
+        },
+        "1": {
+          "caption": "Boot",
+          "description": "A kernel mode driver loaded at boot."
+        },
+        "2": {
+          "caption": "System",
+          "description": "A kernel mode driver loaded during system startup."
+        },
+        "3": {
+          "caption": "Auto",
+          "description": "A user mode service started automatically during system startup."
+        },
+        "4": {
+          "caption": "Demand",
+          "description": "A user mode service started on demand when a process calls <code>StartService</code>."
+        },
+        "5": {
+          "caption": "Disabled",
+          "description": "A driver or service that cannot be started."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The service start type is not mapped. See the <code>service_start_type</code> attribute, which contains an event source specific value."
+        }
+      }
+    },
+    "service_start_name": {
+      "caption": "Service Start Name",
+      "description": "For a user mode service, this attribute represents the name of the account under which the service is run. For a kernel mode driver, this attribute represents the object name used to load the driver.",
+      "type": "string_t"
+    },
+    "service_type": {
+      "caption": "Service Type",
+      "description": "The service type, normalized to the caption of the service_type_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "service_type_id": {
+      "caption": "Service Type ID",
+      "description": "The normalized identifier of the service type.",
+      "sibling": "service_type",
+      "type": "integer_t",
+      "enum":{
+        "0": {
+          "caption": "Unknown",
+          "description": "The service type is unknown."
+        },
+        "1": {
+          "caption": "Kernel Driver",
+          "description": "A kernel mode driver."
+        },
+        "2": {
+          "caption": "File System Driver",
+          "description": "A kernel mode file system minifilter."
+        },
+        "3": {
+          "caption": "Own Process",
+          "description": "A user mode service that runs in its own process."
+        },
+        "4": {
+          "caption": "Share Process",
+          "description": "A user mode service that shares a process with other services."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The service type is not mapped. See the <code>service_type</code> attribute, which contains an event source specific value."
+        }
+      }
+    },
+    "win_service": {
+      "caption": "Windows Service",
+      "description": "The Windows service.",
+      "type": "win_service"
     }
   }
 }

--- a/extensions/windows/events/win_service.json
+++ b/extensions/windows/events/win_service.json
@@ -1,0 +1,44 @@
+{
+  "caption": "Windows Service Activity",
+  "description": "Windows Service Activity events report when a process interacts with the Service Control Manager.",
+  "extends": "system",
+  "name": "win_service_activity",
+  "uid": 4,
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Create",
+          "description": "A service is created, for example by calling <code>CreateService</code>. Refer to the <code>win_service</code> attribute for details."
+        },
+        "2": {
+          "caption": "Reconfigure",
+          "description": "A service is reconfigured, for example by calling <code>ChangeServiceConfig</code> or <code>ChangeServiceConfig2</code>. Refer to the <code>win_service</code> attribute for details."
+        },
+        "3": {
+          "caption": "Start",
+          "description": "A stopped service is started, for example by calling <code>StartService</code>. Refer to the <code>service</code> attribute for details."
+        },
+        "4": {
+          "caption": "Stop",
+          "description": "A running or paused service is stopped, for example by calling <code>ControlService</code> or <code>ControlServiceEx</code>. Refer to the <code>win_service</code> attribute for details."
+        },
+        "5": {
+          "caption": "Pause",
+          "description": "A running service is paused, for example by calling <code>ControlService</code> or <code>ControlServiceEx</code>. Refer to the <code>win_service</code> attribute for details."
+        },
+        "6": {
+          "caption": "Continue",
+          "description": "A paused service is continued, for example by calling <code>ControlService</code> or <code>ControlServiceEx</code>. Refer to the <code>win_service</code> attribute for details."
+        },
+        "7": {
+          "caption": "Delete",
+          "description": "A service is deleted, for example by calling <code>DeleteService</code>. Refer to the <code>win_service</code> attribute for details."
+        }
+      }
+    },
+    "win_service": {
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/windows/objects/evidences.json
+++ b/extensions/windows/objects/evidences.json
@@ -10,6 +10,10 @@
     "reg_value": {
       "description": "Describes details about the registry value that triggered the detection.",
       "requirement": "recommended"
+    },
+    "win_service": {
+      "description": "Describes details about the Windows service that triggered the detection.",
+      "requirement": "recommended"
     }
   },
   "constraints": {
@@ -30,7 +34,8 @@
       "url",
       "user",
       "reg_key",
-      "reg_value"
+      "reg_value",
+      "win_service"
     ]
   }
 }

--- a/extensions/windows/objects/win_service.json
+++ b/extensions/windows/objects/win_service.json
@@ -1,0 +1,61 @@
+{
+  "caption": "Windows Service",
+  "description": "The Windows Service object describes a Windows service.",
+  "extends": "service",
+  "name": "win_service",
+  "attributes": {
+    "name": {
+      "description": "The unique name of the service.",
+      "requirement": "required"
+    },
+    "cmd_line": {
+      "description": "The full command line used to launch the service.",
+      "requirement": "recommended"
+    },
+    "load_order_group": {
+        "requirement": "recommended"
+    },
+    "service_category": {
+      "requirement": "optional"
+    },
+    "service_category_id": {
+      "requirement": "recommended"
+    },
+    "service_dependencies": {
+      "requirement": "recommended"
+    },
+    "service_error_control": {
+      "requirement": "optional"
+    },
+    "service_error_control_id": {
+      "requirement": "recommended"
+    },
+    "service_start_name": {
+      "requirement": "recommended"
+    },
+    "service_start_type": {
+      "requirement": "optional"
+    },
+    "service_start_type_id": {
+      "requirement": "recommended"
+    },
+    "service_type": {
+      "requirement": "optional"
+    },
+    "service_type_id": {
+      "requirement": "recommended"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+        "cmd_line",
+        "service_category_id",
+        "service_dependencies",
+        "service_error_control_id",
+        "service_start_name",
+        "service_start_type_id",
+        "service_type_id"
+    ]
+  }
+}
+


### PR DESCRIPTION
#### Related Issue: 

[1020](https://github.com/ocsf/ocsf-schema/issues/1020)

#### Description of changes:

This schema change introduces a new `Windows Service Activity` event to the Windows extension in the `System Activity` category. The new event extends the `System Activity` event only minimally:
* Enumerants are added to the `activity_id` attribute, corresponding to the various actions that a process may perform on a service.
* The new `win_service` attribute is a `Windows Service` object.

The `Windows Service` object extends the pre-existing `Service` object in some important ways:
* The pre-existing `name` attribute is made `required` so as to reflect the mandatory nature of this attribute when describing behaviour pertaining to a Windows service.
* The new `service_type_id` attribute and its `service_type` sibling correspond to the `dwServiceType` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `service_start_type_id` attribute and its `service_start_type` sibling correspond to the `dwStartType` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `cmd_line` attribute corresponds to the `lpBinaryPathName` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `load_order_group` attribute corresponds to the `lpLoadOrderGroup` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `service_dependencies` attribute corresponds to the `lpDependencies` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `service_start_name` attribute corresponds to the `lpServiceStartName` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `service_error_control` attribute corresponds to the `dwErrorControl` field in the Win32 `QUERY_SERVICE_CONFIG` structure.
* The new `service_category_id` attribute and its `service_category` sibling do not directly correspond to any field in the Win32 `QUERY_SERVICE_CONFIG` structure but instead represent a more coarse-grained categorisation of the information in the `service_type_id` and `service_type` attributes. This is useful in contexts where the precise type of service is unknown and a security product knows only if the activity relates to a kernel mode driver or a user mode service.

Because behaviour relating to Windows services is a common trigger for detections, this PR also adds the `win_service` attribute to the `Windows Evidence Artifacts` object.