### PR TITLE
Improve and fix enum declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Thankyou! -->
 ### Bugfixes
     1. Fixed the host profile construction in `patch_state` event class. #1087
     2. Removed the optional requirement overrides for `name` and `uid` in `_resource` as they are part of a constraint. #1087
+    3. Fixed declarations of `data_lifecycle_state_id`, `integrity`, `opcode_id`, `risk_level`, and `analytic.type_id`. #1111
 
 ### Deprecated
 
@@ -97,6 +98,7 @@ Thankyou! -->
     3. Added a `gitignore` file. #1071
     4. New Extension registration for Cisco #1074
     5. Cleaned up MITRE trademarks and registrations for captions and descriptions.
+    6. Declared enums in dictionary.json have sane "0" (Unknown) and "99" (Other) declarations and descriptions where appropriate #1111
 
 ## [v1.2.0] - April 23rd, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -845,7 +845,16 @@
       "description": "The list of normalized identifiers of the malware classifications. Reference: <a target='_blank' href='https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_oxlc4df65spl'>STIX Malware Types</a> ",
       "sibling": "classifications",
       "type": "integer_t",
-      "enum": {},
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The malware classification is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The malware classification is not mapped. See the <code>classifications</code> array, which contains a data source specific value."
+        }
+      },
       "is_array": true
     },
     "classifications": {
@@ -1232,7 +1241,7 @@
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The type is not mapped. See the <code>data_lifecycle_state</code> attribute, which contains a data source specific value."
+          "description": "The data lifecycle state is unknown."
         },
         "1": {
           "caption": "Data at-Rest",
@@ -1245,6 +1254,10 @@
         "3": {
           "caption": "Data in-Use",
           "description": "The data was being processed, accessed, or read by a system, making it active in memory or CPU. E.g., sensitive data in a Business Intelligence tool, ePHI being processed in an EHR application or a user viewing data stored in a spreadsheet or PDF."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The data lifecycle state is not mapped. See the <code>data_lifecycle_state</code> attribute, which contains a data source specific value."
         }
       }
     },
@@ -1911,7 +1924,16 @@
       "description": "The list of normalized identifiers of the communication flag IDs.",
       "sibling": "flags",
       "type": "integer_t",
-      "enum": {},
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The flag is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The flag is not mapped. See the <code>flags</code> attribute, which contains a data source specific value."
+        }
+      },
       "is_array": true
     },
     "flags": {
@@ -2189,7 +2211,7 @@
     },
     "integrity": {
       "caption": "Integrity",
-      "description": "The process integrity level, normalized to the caption of the direction_id value. In the case of 'Other', it is defined by the event source (Windows only).",
+      "description": "The process integrity level, normalized to the caption of the integrity_id value. In the case of 'Other', it is defined by the event source (Windows only).",
       "type": "string_t"
     },
     "integrity_id": {
@@ -2197,7 +2219,16 @@
       "description": "The normalized identifier of the process integrity level (Windows only).",
       "sibling": "integrity",
       "type": "integer_t",
-      "enum": {}
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The integrity level is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The integrity level is not mapped. See the <code>integrity</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "interface_name": {
       "caption": "Network Interface Name",
@@ -2520,7 +2551,16 @@
       "description": "The normalized identifier of the load type. It identifies how the module was loaded in memory.",
       "sibling": "load_type",
       "type": "integer_t",
-      "enum": {}
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The load type is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The load type is not mapped. See the <code>load_type</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "loaded_modules": {
       "caption": "Loaded Modules",
@@ -2866,7 +2906,7 @@
     },
     "opcode_id": {
       "caption": "DNS Opcode ID",
-      "description": "The DNS opcode ID specifies the normalized query message type.",
+      "description": "The DNS opcode ID specifies the normalized query message type as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc5395.html'>RFC-5395</a>.",
       "type": "integer_t",
       "enum": {
         "0": {
@@ -2896,6 +2936,10 @@
         "6": {
           "caption": "DSO Message",
           "description": "DNS Stateful Operations (DSO)"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The DNS Opcode is not defined by the RFC. See the <code>opcode</code> attribute, which contains a data source specific value."
         }
       }
     },
@@ -3275,7 +3319,16 @@
       "description": "The normalized identifier of the Protocol version.",
       "sibling": "protocol_ver",
       "type": "integer_t",
-      "enum": {}
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The protocol version is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The protocol version is not mapped. See the <code>protocol_ver</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "provider": {
       "caption": "Provider",
@@ -3557,7 +3610,7 @@
     },
     "risk_level": {
       "caption": "Risk Level",
-      "description": "The risk level, normalized to the caption of the risk_level_id value. In the case of 'Other', it is defined by the event source.",
+      "description": "The risk level, normalized to the caption of the risk_level_id value.",
       "type": "string_t"
     },
     "risk_level_id": {
@@ -3580,6 +3633,10 @@
         },
         "4": {
           "caption": "Critical"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The risk level is not mapped. See the <code>risk_level</code> attribute, which contains a data source specific value."
         }
       }
     },
@@ -3608,7 +3665,16 @@
       "description": "The normalized identifier of the state of the job or service. See specific usage.",
       "sibling": "run_state",
       "type": "integer_t",
-      "enum": {}
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The run state is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The run state is not mapped. See the <code>run_state</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "runtime": {
       "caption": "Runtime",

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -46,6 +46,10 @@
             "caption": "Statistical",
             "description": "Statistical analytics pertains to analyzing data patterns and anomalies using statistical models to predict, detect, and respond to potential threats, enhancing overall security posture through informed decision-making."
           },
+          "4": {
+            "caption": "Learning (ML/DL)",
+            "description": "Learning (ML/DL) encompasses techniques that can \"learn\" from known data to create analytics that generalize to new data. There may be a statistical component to these techniques, but it is not a requirement."
+          },
           "5": {
             "caption": "Fingerprinting",
             "description": "Fingerprinting is the technique of collecting detailed system data, including software versions and configurations, to enhance threat detection, data loss prevention (DLP), and endpoint detection and response (EDR) capabilities."


### PR DESCRIPTION
Changes were tested on a local OCSF server and are error free.

#### Description of changes:

`classification_ids` now declared in dictionary with default "0" and "99" values and descriptions
"0" and "99" already existed without description through override in its only use (objects/malware.json)

`data_lifecycle_state_id` mistakenly had the "Other" description applied to "0"/"Unknown"
A "99"/"Other" value was missing

`flag_ids` now declared in dictionary with default "0" and "99" values and descriptions
 "0" and "99" already existed without description through override in its only use (objects/dns_answer.json)

`integrity` mistakenly referenced the `direction_id` enum in its description

`integrity_id` now declared in dictionary with default "0" and "99" values and descriptions
"0" and "99" already existed without description through override in its only use (objects/process.json)

`load_type_id` now declared in dictionary with default "0" and "99" values and decsriptions
"0" and "99" already existed without description through override in its only use (objects/module.json)

`opcode_id` now points to RFC5395 to explain why "0" does not correspond to "Unknown"
A "99"/"Unmapped" value is added to match other RFC based enums

`protocol_ver_id` now declared in dictionary with default "0" and "99" values and descriptions
"0" and "99" already existed without description through override in its only use (objects/network_connection_info.json)

`run_state_id` now declared in dictionary with default "0" and "99" values and descriptions
"0" and "99" already existed without description through override in its only use (objects/job.json)