### PR TITLE
Adjust Entity Management class (3004) to be aligned with Windows event 4662

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ Thankyou! -->
     7. Added a `Preauth` `activity_id` to the `Authentication` class. #1018
     8. Added the `Security Control` profile to the `Datastore Activity` class. #1030
     9. Added `risk_details` to Detection Finding. #1032
+   10. Added `access_mask` to Entity Management class. #1090
+   11. Added `access_list` to Entity Management class. #1090
 
 * #### Profiles
     n/a

--- a/events/iam/entity_management.json
+++ b/events/iam/entity_management.json
@@ -37,6 +37,14 @@
     "entity_result": {
       "group": "primary",
       "requirement": "recommended"
+    },
+    "access_mask": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "access_list": {
+      "group": "context",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
Adjust Entity Management class (3004) to be aligned with fields exist in Windows event 4662 - “An operation was performed on an object”.
https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4662

#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1090

#### Description of changes:
We add the attributes access_list, access_mask.
![Screenshot 2024-06-04 at 15 50 27](https://github.com/ocsf/ocsf-schema/assets/100218904/5417d9a9-5956-441c-b173-437183875f49)


Signed-off-by: Eliraz Levi [eliraz.levi@hunters.ai](mailto:eliraz.levi@hunters.ai)