### PR TITLE
change the duration attribute to long_t

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1577,7 +1577,7 @@
     "duration": {
       "caption": "Duration",
       "description": "The event duration or aggregate time, the amount of time the event covers from <code>start_time</code> to <code>end_time</code> in milliseconds.",
-      "type": "integer_t"
+      "type": "long_t"
     },
     "duration_avg_days": {
       "caption": "Average Duration Days",


### PR DESCRIPTION
This should be long_t if we keep this as an attribute.

#### Description of changes:
Several discussion's regarding the duration attribute. I believe this change is necessary if we keep this as an attribute.

There was some discussion of making this a new object.
