### PR TITLE
Add router, ids, and ips entries to type_id enum in the Endpoint object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Thankyou! -->
     6. Added `reg_key` and `reg_value` to `Evidence Artifacts` object. #1078  
     7. Added `type_id` and associated entity objects to `Managed Entity`. #1094
     8. Added `vendor_name`, `type`, `type_id` to object `package`. #1093
+    9. Added `router`, `ids`, and `ips` entries to `type_id` enum in the `Endpoint` object. #1121
 * #### Platform Extensions
 
 ### Bugfixes

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -94,7 +94,7 @@
         },
         "7": {
           "caption": "IOT",
-          "description": "A <a target='_blank' href='https://www.techtarget.com/iotagenda/definition/IoT-device'>IOT (Internet of Things) device</a>."
+          "description": "An <a target='_blank' href='https://www.techtarget.com/iotagenda/definition/IoT-device'>IOT (Internet of Things) device</a>."
         },
         "8": {
           "caption": "Browser",
@@ -111,6 +111,18 @@
         "11": {
           "caption": "Hub",
           "description": "A <a target='_blank' href='https://en.wikipedia.org/wiki/Ethernet_hub'>networking hub</a>."
+        },
+        "12": {
+          "caption": "Router",
+          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Router/'>networking router</a>."
+        },
+        "13": {
+          "caption": "IDS",
+          "description": "An <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:IntrusionDetectionSystem/'>intrusion detection system</a>."
+        },
+        "14": {
+          "caption": "IPS",
+          "description": "An <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:IntrusionPreventionSystem/'>intrusion prevention system</a>."
         }
       },
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: 
[1120](https://github.com/ocsf/ocsf-schema/issues/1120)

#### Description of changes:
Adds three enum type_id values to the Endpoint object:
- router
- ids
- ips

Miscellaneous: Updates grammar on the IOT entry.

I confirm that I have tested the changes, and the server run was error free.  New entries shown with server run:
![image](https://github.com/ocsf/ocsf-schema/assets/173811405/01ce99f7-2451-46ef-a8ac-cea3caf1192e)

