### PR TITLE
adding state_id IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Thankyou! -->
     7. Added `whois` object. #992
     8. Added `domain_contact` and array-typed `domain_contacts` object for use with `whois` object. #992
     9. Added `Windows Service` object to the Windows extension. #1103
+    10. Added `state` object to the Device Config State Change Event
+    11. Added `state_id` object to the Device Config State Change Event
 
 * #### Platform Extensions
 

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -1,47 +1,75 @@
 {
-  "uid": 19,
-  "caption": "Device Config State Change",
-  "description": "Device Config State Change events report state changes that impact the security of the device.",
-  "extends": "discovery",
-  "name": "device_config_state_change",
-  "attributes": {
-    "actor": {
-      "group": "context",
-      "requirement": "optional"
-    },
-    "device": {
-      "description": "The device that is impacted by the state change.",
-      "group": "primary",
-      "requirement": "required"
-    },
-    "prev_security_level": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "prev_security_level_id": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "prev_security_states": {
-      "description": "The previous security states of the device.",
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_level": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_level_id": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_states": {
-      "description": "The current security states of the device.",
-      "group": "primary",
-      "requirement": "recommended"
+    "uid": 19,
+    "caption": "Device Config State Change",
+    "description": "Device Config State Change events report state changes that impact the security of the device.",
+    "extends": "discovery",
+    "name": "device_config_state_change",
+    "attributes": {
+        "actor": {
+            "group": "context",
+            "requirement": "optional"
+        },
+        "device": {
+            "description": "The device that is impacted by the state change.",
+            "group": "primary",
+            "requirement": "required"
+        },
+        "prev_security_level": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "prev_security_level_id": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "prev_security_states": {
+            "description": "The previous security states of the device.",
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_level": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_level_id": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_states": {
+            "description": "The current security states of the device.",
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "state": {
+            "caption": "Config Change State",
+            "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
+            "requirement": "optional"
+        },
+        "state_id": {
+            "caption": "Config Change State ID",
+            "description": "The Config Change State of the managed entity.",
+            "requirement": "recommended",
+            "enum": {
+                "0": {
+                    "caption": "Unknown",
+                    "description": "The Config Change state is unknown."
+                },
+                "1": {
+                    "caption": "Disabled",
+                    "description": "Config State Changed to Disabled."
+                },
+                "2": {
+                    "caption": "Enabled",
+                    "description": "Config State Changed to Enabled."
+                },
+                "99": {
+                    "caption": "Other",
+                    "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+                }
+            }
+        },
+        "profiles": [
+            "host"
+        ]
     }
-  },
-  "profiles": [
-    "host"
-  ]
 }

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -41,21 +41,21 @@
       "requirement": "recommended"
     }
       "state": {
-      "caption": "Application Lifecycle State",
-      "description": "The Application Lifecycle State, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
+      "caption": "Config Change State",
+      "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
       "requirement": "optional"
     },
     "state_id": {
-      "caption": "Application Lifecycle ID",
-      "description": "The security state of the managed entity.",
+      "caption": "Config Change State ID",
+      "description": "The Config Change State of the managed entity.",
       "enum": {
         "99": {
           "caption": "Other",
-          "description": "The Application Lifecycle is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+          "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
         },
         "0": {
           "caption": "Unknown",
-          "description": "The Application Lifecycle state is unknown."
+          "description": "The Config Change state is unknown."
         },
         "1": {
           "caption": "Disabled",
@@ -63,7 +63,7 @@
         },
         "2": {
           "caption": "Enabled",
-          "description": "Config State Change to Enabled."
+          "description": "Config State Changed to Enabled."
         },
   },
   "profiles": [

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -39,7 +39,7 @@
       "description": "The current security states of the device.",
       "group": "primary",
       "requirement": "recommended"
-    }
+    },
       "state": {
       "caption": "Config Change State",
       "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -40,6 +40,31 @@
       "group": "primary",
       "requirement": "recommended"
     }
+      "state": {
+      "caption": "Application Lifecycle State",
+      "description": "The Application Lifecycle State, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
+      "requirement": "optional"
+    },
+    "state_id": {
+      "caption": "Application Lifecycle ID",
+      "description": "The security state of the managed entity.",
+      "enum": {
+        "99": {
+          "caption": "Other",
+          "description": "The Application Lifecycle is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+        },
+        "0": {
+          "caption": "Unknown",
+          "description": "The Application Lifecycle state is unknown."
+        },
+        "1": {
+          "caption": "Disabled",
+          "description": "Config State Changed to Disabled."
+        },
+        "2": {
+          "caption": "Enabled",
+          "description": "Config State Change to Enabled."
+        },
   },
   "profiles": [
     "host"

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -1,72 +1,74 @@
 {
-  "uid": 19,
-  "caption": "Device Config State Change",
-  "description": "Device Config State Change events report state changes that impact the security of the device.",
-  "extends": "discovery",
-  "name": "device_config_state_change",
-  "attributes": {
-    "actor": {
-      "group": "context",
-      "requirement": "optional"
-    },
-    "device": {
-      "description": "The device that is impacted by the state change.",
-      "group": "primary",
-      "requirement": "required"
-    },
-    "prev_security_level": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "prev_security_level_id": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "prev_security_states": {
-      "description": "The previous security states of the device.",
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_level": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_level_id": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "security_states": {
-      "description": "The current security states of the device.",
-      "group": "primary",
-      "requirement": "recommended"
-    },
-      "state": {
-      "caption": "Config Change State",
-      "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
-      "requirement": "optional"
-    },
-    "state_id": {
-      "caption": "Config Change State ID",
-      "description": "The Config Change State of the managed entity.",
-      "enum": {
-        "99": {
-          "caption": "Other",
-          "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+    "uid": 19,
+    "caption": "Device Config State Change",
+    "description": "Device Config State Change events report state changes that impact the security of the device.",
+    "extends": "discovery",
+    "name": "device_config_state_change",
+    "attributes": {
+        "actor": {
+            "group": "context",
+            "requirement": "optional"
         },
-        "0": {
-          "caption": "Unknown",
-          "description": "The Config Change state is unknown."
+        "device": {
+            "description": "The device that is impacted by the state change.",
+            "group": "primary",
+            "requirement": "required"
         },
-        "1": {
-          "caption": "Disabled",
-          "description": "Config State Changed to Disabled."
+        "prev_security_level": {
+            "group": "primary",
+            "requirement": "recommended"
         },
-        "2": {
-          "caption": "Enabled",
-          "description": "Config State Changed to Enabled."
+        "prev_security_level_id": {
+            "group": "primary",
+            "requirement": "recommended"
         },
-  },
-  "profiles": [
-    "host"
-  ]
+        "prev_security_states": {
+            "description": "The previous security states of the device.",
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_level": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_level_id": {
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "security_states": {
+            "description": "The current security states of the device.",
+            "group": "primary",
+            "requirement": "recommended"
+        },
+        "state": {
+            "caption": "Config Change State",
+            "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
+            "requirement": "optional"
+        },
+        "state_id": {
+            "caption": "Config Change State ID",
+            "description": "The Config Change State of the managed entity.",
+            "enum": {
+                "0": {
+                    "caption": "Unknown",
+                    "description": "The Config Change state is unknown."
+                },
+                "1": {
+                    "caption": "Disabled",
+                    "description": "Config State Changed to Disabled."
+                },
+                "2": {
+                    "caption": "Enabled",
+                    "description": "Config State Changed to Enabled."
+                },
+                "99": {
+                    "caption": "Other",
+                    "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+                }
+            }
+        },
+        "profiles": [
+            "host"
+        ]
+    }
 }

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -1,74 +1,47 @@
 {
-    "uid": 19,
-    "caption": "Device Config State Change",
-    "description": "Device Config State Change events report state changes that impact the security of the device.",
-    "extends": "discovery",
-    "name": "device_config_state_change",
-    "attributes": {
-        "actor": {
-            "group": "context",
-            "requirement": "optional"
-        },
-        "device": {
-            "description": "The device that is impacted by the state change.",
-            "group": "primary",
-            "requirement": "required"
-        },
-        "prev_security_level": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "prev_security_level_id": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "prev_security_states": {
-            "description": "The previous security states of the device.",
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "security_level": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "security_level_id": {
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "security_states": {
-            "description": "The current security states of the device.",
-            "group": "primary",
-            "requirement": "recommended"
-        },
-        "state": {
-            "caption": "Config Change State",
-            "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
-            "requirement": "optional"
-        },
-        "state_id": {
-            "caption": "Config Change State ID",
-            "description": "The Config Change State of the managed entity.",
-            "enum": {
-                "0": {
-                    "caption": "Unknown",
-                    "description": "The Config Change state is unknown."
-                },
-                "1": {
-                    "caption": "Disabled",
-                    "description": "Config State Changed to Disabled."
-                },
-                "2": {
-                    "caption": "Enabled",
-                    "description": "Config State Changed to Enabled."
-                },
-                "99": {
-                    "caption": "Other",
-                    "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
-                }
-            }
-        },
-        "profiles": [
-            "host"
-        ]
+  "uid": 19,
+  "caption": "Device Config State Change",
+  "description": "Device Config State Change events report state changes that impact the security of the device.",
+  "extends": "discovery",
+  "name": "device_config_state_change",
+  "attributes": {
+    "actor": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "device": {
+      "description": "The device that is impacted by the state change.",
+      "group": "primary",
+      "requirement": "required"
+    },
+    "prev_security_level": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "prev_security_level_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "prev_security_states": {
+      "description": "The previous security states of the device.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "security_level": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "security_level_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "security_states": {
+      "description": "The current security states of the device.",
+      "group": "primary",
+      "requirement": "recommended"
     }
+  },
+  "profiles": [
+    "host"
+  ]
 }

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -67,9 +67,6 @@
                     "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
                 }
             }
-        },
-        "profiles": [
-            "host"
-        ]
+        }
     }
 }

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -44,7 +44,7 @@
             "caption": "Config Change State",
             "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
             "requirement": "optional"
-         },
+        },
         "state_id": {
             "caption": "Config Change State ID",
             "description": "The Config Change State of the managed entity.",
@@ -64,10 +64,11 @@
                 "99": {
                     "caption": "Other",
                     "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
+                }
+            }
+        },
+        "profiles": [
+            "host"
+        ]
     }
-  }
-}
-  "profiles": [
-    "host"
-  ]
 }

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -44,7 +44,7 @@
             "caption": "Config Change State",
             "description": "The Config Change Stat, normalized to the caption of the state_id value. In the case of 'Other', it is defined by the source.",
             "requirement": "optional"
-        },
+         },
         "state_id": {
             "caption": "Config Change State ID",
             "description": "The Config Change State of the managed entity.",
@@ -64,11 +64,10 @@
                 "99": {
                     "caption": "Other",
                     "description": "The Config Change is not mapped. See the <code>state</code> attribute, which contains data source specific values."
-                }
-            }
-        },
-        "profiles": [
-            "host"
-        ]
     }
+  }
+}
+  "profiles": [
+    "host"
+  ]
 }


### PR DESCRIPTION
Related Issue:
Missing enable/disable state Ids

Description of changes:
added state id's to Device Config State Change Class.

Signed-off-by: Sasha Selin (Cyrebro) ([sasha.selin@cyrebro.io](mailto:sasha.selin@cyrebro.io))

Following closed PR #1076 (https://github.com/ocsf/ocsf-schema/pull/1076), Ive created new PR to create disable/enable state to "device_config_state_change" class.

state “disable/enable” is very common when it comes to FortiGate logs, especially where the subtype=”system” and action=”add”.
The “status” field on this type of logs are represent the “cfgattr” (Configuration value changed) status.

Raw log for example:

<118>date=2024-05-01 time=11:43:38 devname="Test for OCSF" devid="FG11256985563" eventtime=1714553018203018280 tz="+0300" logid="0100044547" type="event" subtype="system" level="information" vd="North" logdesc="Object attribute configured" user="SashaS" ui="GUI(192.168.190.54)" action="Add" cfgtid=10691505 cfgpath="firewall.policy" cfgobj="136" cfgattr="status[disable]srcintf[OCSF-Test]dstintf[OCSF-Test]srcaddr[Sasha-selin-ocsf-test]dstaddr[Sasha-selin]srcaddr6[]dstaddr6[]src-vendor-mac[]action[accept]schedule[always]service[RDP]groups[]users[]fsso-groups[]comments[ (Copy of 148)]custom-log-fields[]" msg="Add firewall.policy 136"


![image](https://github.com/ocsf/ocsf-schema/assets/145011693/b3ef9592-5a02-47d7-baa2-4a2e1f2af0ea)
