### PR TITLE
1131 k8s basic

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -1,18 +1,19 @@
 # OCSF Extensions Registry
 The purpose of this file is to keep track of and avoid collisions in Extension `names` & `uid`s.
 
-| Caption     | Name     | UID | Notes |
-|-------------|----------|-----|-------|
-| Cisco       | cisco    | **991** | The Cisco schema extension |
-| Sedara      | sedara   | **992** | The Sedara schema extension |
-| Sciber      | sciber   | **993** | The Sciber schema extension |
-| DataBee     | databee  | **994** | The Comcast DataBee schema extension |
-| Symantec    | symantec | **995** | The Symantec schema extension |
-| SentinelOne | s1       | **996** | The SentinelOne schema extension |
-| Splunk      | splunk   | **997** | The Splunk schema extension |
-| AWS         | aws      | **998** | The Amazon Web Services schema extension |
-| Development | dev      | **999** | The development (TODO) schema extensions |
+| Caption                             | Name       | UID     | Notes                                                                          |
+|-------------------------------------|------------|---------|--------------------------------------------------------------------------------|
+| Cisco                               | cisco      | **991** | The Cisco schema extension                                                     |
+| Sedara                              | sedara     | **992** | The Sedara schema extension                                                    |
+| Sciber                              | sciber     | **993** | The Sciber schema extension                                                    |
+| DataBee                             | databee    | **994** | The Comcast DataBee schema extension                                           |
+| Symantec                            | symantec   | **995** | The Symantec schema extension                                                  |
+| SentinelOne                         | s1         | **996** | The SentinelOne schema extension                                               |
+| Splunk                              | splunk     | **997** | The Splunk schema extension                                                    |
+| AWS                                 | aws        | **998** | The Amazon Web Services schema extension                                       |
+| Development                         | dev        | **999** | The development (TODO) schema extensions                                       |
 | _Native Extensions defined in OCSF_ |
-| Linux       | linux    | **1** | The Linux extension defines Linux specific attributes, objects and classes |
-| Windows     | win      | **2** | The Windows extension defines Windows specific attributes, objects and classes |
-| macOS       | macos    | **3** | The macOS extension defines macOS specific attributes, objects and classes |
+| Linux                               | linux      | **1**   | The Linux extension defines Linux specific attributes, objects and classes     |
+| Windows                             | win        | **2**   | The Windows extension defines Windows specific attributes, objects and classes |
+| macOS                               | macos      | **3**   | The macOS extension defines macOS specific attributes, objects and classes     |
+| Kubernetes                          | kuberentes | **4**   | The Kubernetes schema extension                                                |

--- a/extensions/kubernetes/dictionary.json
+++ b/extensions/kubernetes/dictionary.json
@@ -3,6 +3,12 @@
   "description": "The Attribute Dictionary defines schema attributes and includes references to the events and objects in which they are used.",
   "name": "dictionary",
   "attributes": {
+    "allocated_ips": {
+      "type": "ip_t",
+      "caption": "Allocated IPs",
+      "description": "The list of reserved ip addresses.",
+      "is_array": true
+    },
     "cluster_uid": {
       "caption": "Cluster UID",
       "type": "string_t",
@@ -134,6 +140,11 @@
       "type": "selector_label",
       "description": "The selectorKLabels associated with the k8s resource.",
       "is_array": true
+    },
+    "used_ip": {
+      "type": "ip_t",
+      "caption": "Used IP",
+      "description": "IP address used by item."
     },
     "value": {
       "caption": "Key Value of a Key-value pair",

--- a/extensions/kubernetes/dictionary.json
+++ b/extensions/kubernetes/dictionary.json
@@ -1,0 +1,65 @@
+{
+  "caption": "Attribute Dictionary",
+  "description": "The Attribute Dictionary defines schema attributes and includes references to the events and objects in which they are used.",
+  "name": "dictionary",
+  "attributes": {
+    "cluster_uid": {
+      "caption": "Cluster UID",
+      "type": "string_t",
+      "description": "The unique identifier of a cluster."
+    },
+    "generation_name": {
+      "caption": "Generation Name",
+      "type": "string_t",
+      "description": "Generation name prefix for object name."
+    },
+    "k8s_annotations": {
+      "caption": "K8s annotations",
+      "type": "selector_label",
+      "description": "The annotation array of the k8s resource.",
+      "is_array": true
+    },
+    "k8s_cluster": {
+      "caption": "Kubernetes Cluster",
+      "type": "k8s_cluster",
+      "description": "The Kubernetes cluster root object."
+    },
+    "k8s_metadata": {
+      "caption": "Kubernetes metadata",
+      "type": "k8s_metadata",
+      "description": "The Kubernetes metadata describes Kubernetes items."
+    },
+    "key": {
+      "caption": "Key Name of a key-value pair",
+      "type": "string_t",
+      "description": "The name of the key."
+    },
+    "selector_label": {
+      "caption": "SelectorLabel",
+      "type": "selector_label",
+      "description": "The selectorLabel format used as K8s labels, selectors, ownerReferences etc."
+    },
+    "owner_references": {
+      "caption": "Owner references",
+      "type": "selector_label",
+      "description": "The owner associated with the k8s resource.",
+      "is_array": true
+    },
+    "resource_version": {
+      "caption": "Resource Version",
+      "type": "string_t",
+      "description": "The version of the resource."
+    },
+    "selector_labels": {
+      "caption": "SelectorLabels",
+      "type": "selector_label",
+      "description": "The selectorKLabels associated with the k8s resource.",
+      "is_array": true
+    },
+    "value": {
+      "caption": "Key Value of a Key-value pair",
+      "type": "string_t",
+      "description": "The value of the object."
+    }
+  }
+}

--- a/extensions/kubernetes/dictionary.json
+++ b/extensions/kubernetes/dictionary.json
@@ -8,6 +8,12 @@
       "type": "string_t",
       "description": "The unique identifier of a cluster."
     },
+    "commands": {
+      "caption": "Commands",
+      "description": "The list of commands to be executed.",
+      "type": "string_t",
+      "is_array": true
+    },
     "generation_name": {
       "caption": "Generation Name",
       "type": "string_t",
@@ -34,10 +40,31 @@
       "type": "k8s_cluster_resource",
       "description": "The Kubernetes cluster resource item."
     },
+    "k8s_container": {
+      "caption": "Kubernetes container",
+      "type": "k8s_container",
+      "description": "The Kubernetes container data holder."
+    },
+    "k8s_image": {
+      "caption": "Image",
+      "type": "string_t",
+      "description": "The image name of the container."
+    },
     "k8s_metadata": {
       "caption": "Kubernetes metadata",
       "type": "k8s_metadata",
       "description": "The Kubernetes metadata describes Kubernetes items."
+    },
+    "k8s_port": {
+      "caption": "Kubernetes Port",
+      "type": "k8s_port",
+      "description": "The Kubernetes port item."
+    },
+    "k8s_ports": {
+      "caption": "Kubernetes Ports",
+      "type": "k8s_port",
+      "description": "The List of assigned ports.",
+      "is_array": true
     },
     "k8s_spec": {
       "caption": "K8s specs",
@@ -50,16 +77,31 @@
       "type": "k8s_status",
       "description": "The Kubernetes status describes the current state of k8s item."
     },
+    "k8s_workload": {
+      "caption": "Kubernetes Workload",
+      "type": "k8s_workload",
+      "description": "The Kubernetes workload item."
+    },
     "key": {
       "caption": "Key Name of a key-value pair",
       "type": "string_t",
       "description": "The name of the key."
+    },
+    "namespace_uid":{
+      "caption": "Namespace UID",
+      "description": "The unique identifier of a Kubernetes namespace.",
+      "type": "string_t"
     },
     "node_info": {
       "caption": "Node Info",
       "description": "Node labels.",
       "type": "selector_label",
       "is_array": true
+    },
+    "node_uid":{
+      "caption": "Node UID",
+      "description": "The unique identifier of a Kubernetes node.",
+      "type": "string_t"
     },
     "selector_label": {
       "caption": "SelectorLabel",
@@ -76,6 +118,11 @@
       "caption": "Pod IP Info",
       "description": "Pod IP and a pool of reserved ip addresses for it.",
       "type": "ip_usage_info"
+    },
+    "pod_uid":{
+      "caption": "POD UID",
+      "description": "The unique identifier of a Kubernetes pod.",
+      "type": "string_t"
     },
     "resource_version": {
       "caption": "Resource Version",

--- a/extensions/kubernetes/dictionary.json
+++ b/extensions/kubernetes/dictionary.json
@@ -13,6 +13,11 @@
       "type": "string_t",
       "description": "Generation name prefix for object name."
     },
+    "host_ip_info": {
+      "caption": "Host IP Info",
+      "description": "Host IP and a pool of reserved ip addresses for it.",
+      "type": "ip_usage_info"
+    },
     "k8s_annotations": {
       "caption": "K8s annotations",
       "type": "selector_label",
@@ -24,15 +29,37 @@
       "type": "k8s_cluster",
       "description": "The Kubernetes cluster root object."
     },
+    "k8s_cluster_resource": {
+      "caption": "Kubernetes Cluster resource",
+      "type": "k8s_cluster_resource",
+      "description": "The Kubernetes cluster resource item."
+    },
     "k8s_metadata": {
       "caption": "Kubernetes metadata",
       "type": "k8s_metadata",
       "description": "The Kubernetes metadata describes Kubernetes items."
     },
+    "k8s_spec": {
+      "caption": "K8s specs",
+      "type": "selector_label",
+      "description": "The spec array of the k8s resource.",
+      "is_array": true
+    },
+    "k8s_status": {
+      "caption": "Kubernetes Status",
+      "type": "k8s_status",
+      "description": "The Kubernetes status describes the current state of k8s item."
+    },
     "key": {
       "caption": "Key Name of a key-value pair",
       "type": "string_t",
       "description": "The name of the key."
+    },
+    "node_info": {
+      "caption": "Node Info",
+      "description": "Node labels.",
+      "type": "selector_label",
+      "is_array": true
     },
     "selector_label": {
       "caption": "SelectorLabel",
@@ -44,6 +71,11 @@
       "type": "selector_label",
       "description": "The owner associated with the k8s resource.",
       "is_array": true
+    },
+    "pod_ip_info": {
+      "caption": "Pod IP Info",
+      "description": "Pod IP and a pool of reserved ip addresses for it.",
+      "type": "ip_usage_info"
     },
     "resource_version": {
       "caption": "Resource Version",

--- a/extensions/kubernetes/events/k8s_cluster_inventory_info.json
+++ b/extensions/kubernetes/events/k8s_cluster_inventory_info.json
@@ -1,0 +1,14 @@
+{
+  "caption": "K8s Cluster Inventory Info",
+  "category": "discovery",
+  "description": "K8s Cluster info as the root of topology.",
+  "extends": "discovery",
+  "name": "k8s_cluster_inventory_info",
+  "uid": 1,
+  "attributes": {
+    "k8s_cluster":{
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/kubernetes/events/k8s_cluster_resource_inventory_info.json
+++ b/extensions/kubernetes/events/k8s_cluster_resource_inventory_info.json
@@ -1,0 +1,14 @@
+{
+  "caption": "K8s Cluster resource Inventory Info",
+  "category": "discovery",
+  "description": "K8s item inventory info used for cluster resource structures of k8s.",
+  "extends": "discovery",
+  "name": "k8s_cluster_resource_inventory_info",
+  "uid": 2,
+  "attributes": {
+    "k8s_cluster_resource":{
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/kubernetes/events/k8s_container_inventory_info.json
+++ b/extensions/kubernetes/events/k8s_container_inventory_info.json
@@ -1,0 +1,14 @@
+{
+  "caption": "K8s Container Inventory Info",
+  "category": "discovery",
+  "description": "K8s Container info - data represents container inventory information for a k8s cluster",
+  "extends": "discovery",
+  "name": "k8s_container_inventory_info",
+  "uid": 3,
+  "attributes": {
+    "k8s_container":{
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/kubernetes/events/k8s_workload_inventory_info.json
+++ b/extensions/kubernetes/events/k8s_workload_inventory_info.json
@@ -1,0 +1,14 @@
+{
+  "caption": "K8s Workload Inventory Info",
+  "category": "discovery",
+  "description": "K8s item inventory info used for workload structures of k8s.",
+  "extends": "discovery",
+  "name": "k8s_workload_inventory_info",
+  "uid": 4,
+  "attributes": {
+    "k8s_workload":{
+      "group": "primary",
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/kubernetes/extension.json
+++ b/extensions/kubernetes/extension.json
@@ -1,0 +1,7 @@
+{
+  "caption": "Kubernetes",
+  "description": "The Kubernetes extension defines Kubernetes specific attributes, objects and classes.",
+  "name": "kubernetes",
+  "uid": 4,
+  "version": "1.3.0-dev"
+}

--- a/extensions/kubernetes/objects/ip_usage_info.json
+++ b/extensions/kubernetes/objects/ip_usage_info.json
@@ -1,0 +1,16 @@
+{
+  "caption": "The IP usage information for the item.",
+  "description": "Used Ip address and the list of reserved ip addresses.",
+  "name": "ip_usage_info",
+  "attributes": {
+    "used_ip": {
+      "type": "ip_t",
+      "description": "IP address used by item."
+    },
+    "allocated_ips": {
+      "type": "ip_t",
+      "description": "The list of reserved ip addresses.",
+      "is_array": true
+    }
+  }
+}

--- a/extensions/kubernetes/objects/ip_usage_info.json
+++ b/extensions/kubernetes/objects/ip_usage_info.json
@@ -4,15 +4,10 @@
   "name": "ip_usage_info",
   "attributes": {
     "used_ip": {
-      "type": "ip_t",
-      "caption": "Used IP",
-      "description": "IP address used by item."
+      "requirement": "optional"
     },
     "allocated_ips": {
-      "type": "ip_t",
-      "caption": "Allocated IPs",
-      "description": "The list of reserved ip addresses.",
-      "is_array": true
+      "requirement": "optional"
     }
   }
 }

--- a/extensions/kubernetes/objects/ip_usage_info.json
+++ b/extensions/kubernetes/objects/ip_usage_info.json
@@ -5,10 +5,12 @@
   "attributes": {
     "used_ip": {
       "type": "ip_t",
+      "caption": "Used IP",
       "description": "IP address used by item."
     },
     "allocated_ips": {
       "type": "ip_t",
+      "caption": "Allocated IPs",
       "description": "The list of reserved ip addresses.",
       "is_array": true
     }

--- a/extensions/kubernetes/objects/k8s_cluster.json
+++ b/extensions/kubernetes/objects/k8s_cluster.json
@@ -1,0 +1,14 @@
+{
+    "caption": "K8s Cluster",
+    "description": "K8s Cluster root object.",
+    "name": "k8s_cluster",
+    "attributes": {
+        "cluster_uid": {
+            "requirement": "required"
+        },
+        "k8s_metadata": {
+            "caption": "Kubernetes metadata.",
+            "requirement": "required"
+        }
+    }
+}

--- a/extensions/kubernetes/objects/k8s_cluster_resource.json
+++ b/extensions/kubernetes/objects/k8s_cluster_resource.json
@@ -1,0 +1,67 @@
+{
+    "caption": "K8s Cluster resource",
+    "description": "Used for Kubernetes structures Node, Namespace, Event, ApiService etc. - https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/",
+    "name": "k8s_cluster_resource",
+    "attributes": {
+        "cluster_uid": {
+            "requirement": "required"
+        },
+        "k8s_metadata": {
+            "caption": "Kubernetes metadata.",
+            "requirement": "required"
+        },
+        "k8s_status": {
+            "caption": "Cluster resource's status.",
+            "requirement": "optional"
+        },
+        "k8s_spec": {
+            "caption": "Cluster resource spec.",
+            "requirement": "optional"
+        },
+        "type": {
+            "caption": "Cluster Resource Type",
+            "description": "The type of the cluster resource.",
+            "requirement": "optional"
+        },
+        "type_id": {
+            "caption": "Cluster Resource Type ID",
+            "description": "The normalized identifier for the cluster resource.",
+            "enum": {
+                "1": {
+                    "caption": "Node"
+                },
+                "2": {
+                    "caption": "Namespace"
+                },
+                "3": {
+                    "caption": "Event"
+                },
+                "4": {
+                    "caption": "APIService"
+                },
+                "5": {
+                    "caption": "Lease"
+                },
+                "6": {
+                    "caption": "RuntimeClass"
+                },
+                "7": {
+                    "caption": "FlowSchema v1beta3"
+                },
+                "8": {
+                    "caption": "PriorityLevelConfiguration v1beta3"
+                },
+                "9": {
+                    "caption": "Binding"
+                },
+                "10": {
+                    "caption": "ComponentStatus"
+                },
+                "11": {
+                    "caption": "ClusterCIDR v1alpha1"
+                }
+            },
+            "requirement": "required"
+        }
+    }
+}

--- a/extensions/kubernetes/objects/k8s_container.json
+++ b/extensions/kubernetes/objects/k8s_container.json
@@ -1,0 +1,31 @@
+{
+    "caption": "K8s Container",
+    "description": "K8s Container data holder object.",
+    "name": "k8s_container",
+    "attributes": {
+        "cluster_uid": {
+            "requirement": "required"
+        },
+        "commands": {
+            "requirement": "optional"
+        },
+        "k8s_image": {
+            "requirement": "recommended"
+        },
+        "namespace_uid": {
+            "requirement": "required"
+        },
+        "name": {
+            "requirement": "recommended"
+        },
+        "node_uid": {
+            "requirement": "required"
+        },
+        "pod_uid": {
+            "requirement": "optional"
+        },
+        "k8s_ports": {
+            "requirement": "optional"
+        }
+    }
+}

--- a/extensions/kubernetes/objects/k8s_metadata.json
+++ b/extensions/kubernetes/objects/k8s_metadata.json
@@ -1,0 +1,37 @@
+{
+    "caption": "K8s metadata",
+    "description": "K8s metadata",
+    "name": "k8s_metadata",
+    "attributes": {
+        "k8s_annotations": {
+            "requirement": "optional"
+        },
+        "created_time": {
+            "requirement": "optional"
+        },
+        "generation_name": {
+            "requirement": "optional"
+        },
+        "selector_labels": {
+            "requirement": "optional"
+        },
+        "name": {
+            "requirement": "optional",
+            "description": "The name of the workload."
+        },
+        "namespace": {
+            "requirement": "optional",
+            "description": "The namespace of the workload."
+        },
+        "owner_references": {
+            "requirement": "optional"
+        },
+        "resource_version": {
+            "requirement": "optional"
+        },
+        "uid": {
+            "requirement": "required",
+            "description": "The unique identifier of the workload."
+        }
+    }
+}

--- a/extensions/kubernetes/objects/k8s_port.json
+++ b/extensions/kubernetes/objects/k8s_port.json
@@ -1,0 +1,36 @@
+{
+  "caption": "K8s port",
+  "description": "K8s port",
+  "name": "k8s_port",
+  "attributes": {
+    "name": {
+      "requirement": "optional"
+    },
+    "port": {
+      "caption": "Port",
+      "description": "The port number.",
+      "requirement": "required"
+    },
+    "type": {
+      "caption": "Port Type",
+      "description": "The type of the port.",
+      "requirement": "optional"
+    },
+    "type_id": {
+      "caption": "Port Type ID",
+      "description": "The normalized identifier for the port type.",
+      "enum": {
+        "0": {
+          "caption": "Unknown"
+        },
+        "1": {
+          "caption": "TCP"
+        },
+        "2": {
+          "caption": "UDP"
+        }
+      },
+      "requirement": "required"
+    }
+  }
+}

--- a/extensions/kubernetes/objects/k8s_status.json
+++ b/extensions/kubernetes/objects/k8s_status.json
@@ -1,0 +1,48 @@
+{
+  "caption": "K8s status",
+  "description": "K8s status",
+  "name": "k8s_status",
+  "attributes": {
+    "host_ip_info": {
+      "requirement": "optional"
+    },
+    "pod_ip_info": {
+      "requirement": "optional"
+    },
+    "status": {
+      "requirement": "optional",
+      "description": "The event status, normalized to the caption of the status_id value. In the case of 'Other', it is defined by the event source."
+    },
+    "status_id": {
+      "requirement": "optional",
+      "enum": {
+        "1": {
+          "caption": "Pending",
+          "description": "The Pod has been accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. This includes time a Pod spends waiting to be scheduled as well as the time spent downloading container images over the network."
+        },
+        "2": {
+          "caption": "Running",
+          "description": "The Pod has been bound to a node, and all of the containers have been created. At least one container is still running, or is in the process of starting or restarting."
+        },
+        "3": {
+          "caption": "Succeeded",
+          "description": "All containers in the Pod have terminated in success, and will not be restarted."
+        },
+        "4": {
+          "caption": "Failed",
+            "description": "All containers in the Pod have terminated, and at least one container has terminated in failure. That is, the container either exited with non-zero status or was terminated by the system, and is not set for automatic restarting."
+        },
+        "5": {
+          "caption": "Terminating",
+          "description": "When a Pod is being deleted, it is shown as Terminating by some kubectl commands. This Terminating status is not one of the Pod phases. A Pod is granted a term to terminate gracefully, which defaults to 30 seconds."
+        }
+      }
+    },
+    "node_info": {
+      "requirement": "optional"
+    },
+    "start_time": {
+      "requirement": "optional"
+    }
+  }
+}

--- a/extensions/kubernetes/objects/k8s_workload.json
+++ b/extensions/kubernetes/objects/k8s_workload.json
@@ -1,0 +1,94 @@
+{
+    "caption": "K8s Workload",
+    "description": "Used for Kubernetes structures Pod, PodTemplate, ReplicationController, ReplicaSet, Deployment, StatefulSet, etc. by the Kubernetes API - Workload Resources - https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/.",
+    "name": "k8s_workload",
+    "attributes": {
+        "cluster_uid": {
+            "requirement": "required"
+        },
+        "namespace_uid": {
+            "requirement": "recommended"
+        },
+        "node_uid": {
+            "requirement": "recommended"
+        },
+        "k8s_metadata": {
+            "caption": "Kubernetes metadata.",
+            "requirement": "required"
+        },
+        "k8s_status": {
+            "caption": "Workload's status.",
+            "requirement": "optional"
+        },
+        "k8s_spec": {
+            "caption": "Workload's spec.",
+            "requirement": "optional"
+        },
+        "type": {
+            "caption": "Workload Type",
+            "description": "The type of the workload.",
+            "requirement": "optional"
+        },
+        "type_id": {
+            "caption": "Workload Type ID",
+            "description": "The normalized identifier for the workload.",
+            "enum": {
+                "0": {
+                    "caption": "Unknown"
+                },
+                "1": {
+                    "caption": "Pod"
+                },
+                "2": {
+                    "caption": "PodTemplate"
+                },
+                "3": {
+                    "caption": "ReplicationController"
+                },
+                "4": {
+                    "caption": "ReplicaSet"
+                },
+                "5": {
+                    "caption": "Deployment"
+                },
+                "6": {
+                    "caption": "StatefulSet"
+                },
+                "7": {
+                    "caption": "ControllerRevision"
+                },
+                "8": {
+                    "caption": "DaemonSet"
+                },
+                "9": {
+                    "caption": "Job"
+                },
+                "10": {
+                    "caption": "CronJob"
+                },
+                "11": {
+                    "caption": "HorizontalPodAutoscaler"
+                },
+                "12": {
+                    "caption": "PriorityClass"
+                },
+                "13": {
+                    "caption": "PodSchedulingContext v1alpha2"
+                },
+                "14": {
+                    "caption": "ResourceClaim v1alpha2"
+                },
+                "15": {
+                    "caption": "ResourceClaimTemplate v1alpha2"
+                },
+                "16": {
+                    "caption": "ResourceClass v1alpha2"
+                },
+                "99": {
+                    "caption": "Other"
+                }
+            },
+            "requirement": "required"
+        }
+    }
+}

--- a/extensions/kubernetes/objects/selector_label.json
+++ b/extensions/kubernetes/objects/selector_label.json
@@ -1,0 +1,15 @@
+{
+  "caption": "K8s selectorLabel",
+  "description": "Kubernetes labels, etc. -  used for storing data like \"beta.kubernetes.io/arch\": \"amd64\".",
+  "name": "selector_label",
+  "attributes": {
+    "key": {
+      "caption": "Key part of k8s selectorLabel object.",
+      "requirement": "required"
+    },
+    "value": {
+      "caption": "Value part of k8s selectorLabel object.",
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1131

#### Description of changes:
This issue is about to extend OCSF schema by Kubernetes mapping. The extension should be provided as a separated extension like the current Windows and Linux.

After data analyses the topology copies K8s API - the objects are split by type (workload, cluster resources etc.) with common shared object. Each objects leads to asset and usage is via discovery classes. The hierarchy is defined as bottom-up.

The basic elements defined by this issue:

Cluster - the root element object k8s_cluster - used by **K8s Cluster Inventory Info **
Workload - object of type k8s_workload - used by - K8s Workload Inventory Info
Cluster resource - k8s_cluster_resource used by K8s Cluster resource Inventory Info
Container - k8s_container used by K8s Container Inventory Info

### Delete once you have confirmed the following: 
TBD
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
4. Is your PR title in sync with the description?
