### PR TITLE
Add a `body_length` field to `http_request` and `http_response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ Thankyou! -->
     12. Added `avg_timespan` to the `kb_article` object. #1125
     13. Added `created_time`,`desc`, `short_desc`, `reputation`, `src_url` to `enrichment` object. #1149
     14. Added `compliance_references`, `compliance_standards` to the `compliance` object. #1110
+   15. Added `body_length` to `http_request` and `http_response`. #1141
+* #### Platform Extensions
+    n/a
 
 ### Bugfixes
 1. Fixed the host profile construction in `patch_state` event class. #1087

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -56,7 +56,7 @@
     },
     "body_length": {
       "caption": "Request Body Length",
-      "description": "The length of the HTTP request body, in number of bytes.",
+      "description": "The actual length of the HTTP request body, in number of bytes, independent of a potentially existing Content-Length header.",
       "requirement": "optional"
     },
     "referrer": {

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -51,7 +51,12 @@
     },
     "length": {
       "caption": "Request Length",
-      "description": "The HTTP request length, in number of bytes.",
+      "description": "The length of the entire HTTP request, in number of bytes.",
+      "requirement": "optional"
+    },
+    "body_length": {
+      "caption": "Request Body Length",
+      "description": "The length of the HTTP request body, in number of bytes.",
       "requirement": "optional"
     },
     "referrer": {

--- a/objects/http_response.json
+++ b/objects/http_response.json
@@ -18,6 +18,13 @@
       "requirement": "optional"
     },
     "length": {
+      "caption": "Response Length",
+      "description": "The length of the entire HTTP response, in number of bytes.",
+      "requirement": "optional"
+    },
+    "body_length": {
+      "caption": "Response Body Length",
+      "description": "The length of the HTTP response body, in number of bytes.",
       "requirement": "optional"
     },
     "message": {

--- a/objects/http_response.json
+++ b/objects/http_response.json
@@ -24,7 +24,7 @@
     },
     "body_length": {
       "caption": "Response Body Length",
-      "description": "The length of the HTTP response body, in number of bytes.",
+      "description": "The actual length of the HTTP response body, in number of bytes, independent of a potentially existing Content-Length header.",
       "requirement": "optional"
     },
     "message": {


### PR DESCRIPTION
This PR adds a new field to the `http_[request|response]` objects called `body_length` that captures the length of the HTTP request body. The existing field `length` describes the *entire* length of the HTTP request, including headers.

### Delete once you have confirmed the following: 
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
