### PR TITLE
Fixing event class names, file names for the new remediation events

### DIFF
--- a/events/remediation/file_remediation_activity.json
+++ b/events/remediation/file_remediation_activity.json
@@ -1,8 +1,8 @@
 {
     "caption": "File Remediation Activity",
     "description": "File Remediation Activity events report on attempts at remediating files. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Sub-techniques will include File, such as File Removal or Restore File.",
-    "extends": "remediation",
-    "name": "file_remediation",
+    "extends": "remediation_activity",
+    "name": "file_remediation_activity",
     "uid": 2,
     "attributes": {
       "file": {

--- a/events/remediation/network_remediation_activity.json
+++ b/events/remediation/network_remediation_activity.json
@@ -1,8 +1,8 @@
 {
     "caption": "Network Remediation Activity",
     "description": "Network Remediation Activity events report on attempts at remediating computer networks. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Techniques and Sub-techniques will include Network, such as Network Isolation or Network Traffic Filtering.",
-    "extends": "remediation",
-    "name": "network_remediation",
+    "extends": "remediation_activity",
+    "name": "network_remediation_activity",
     "uid": 4,
     "attributes": {
       "connection_info": {

--- a/events/remediation/process_remediation_activity.json
+++ b/events/remediation/process_remediation_activity.json
@@ -1,8 +1,8 @@
 {
     "caption": "Process Remediation Activity",
     "description": "Process Remediation Activity events report on attempts at remediating processes. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Sub-techniques will include Process, such as Process Termination or Kernel-based Process Isolation.",
-    "extends": "remediation",
-    "name": "process_remediation",
+    "extends": "remediation_activity",
+    "name": "process_remediation_activity",
     "uid": 3,
     "attributes": {
       "process": {

--- a/events/remediation/remediation_activity.json
+++ b/events/remediation/remediation_activity.json
@@ -1,7 +1,7 @@
 {
     "caption": "Remediation Activity",
     "description": "Remediation Activity events report on attempts at remediating a compromised device or computer network. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>.",
-    "name": "remediation",
+    "name": "remediation_activity",
     "category": "remediation",
     "extends": "base_event",
     "uid": 1,


### PR DESCRIPTION
#### Related Issue: surfaced by @dkolbly in slack

#### Description of changes:
1. Fixing event class names in the Remediation category to avoid name collision within the framework
2. No need for a changelog entry, this is fixing a new item added in 1.3.0-dev

