### PR TITLE
Fix "See specific usage" warnings for `package.type_id` and `package.vendor_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Thankyou! -->
     * Updated several attributes that do not follow conventions to disable linting for them
 8. Added `credential_uid` as an Observable type - type_id: 19. #1137
 9. New Extension registration for US Gov #1140
+10. Fix "See specific usage" warnings for `package.type_id` and `package.vendor_name`. #1145
 
 ## [v1.2.0] - April 23rd, 2024
 

--- a/objects/package.json
+++ b/objects/package.json
@@ -25,6 +25,7 @@
       "requirement": "optional"
     },
     "vendor_name": {
+      "description": "The name of the software package's vendor.",
       "requirement": "optional"
     },
     "type": {
@@ -32,6 +33,7 @@
       "requirement": "optional"
     },
     "type_id": {
+      "description": "The normalized type identifier of the software package.",
       "enum": {
         "1": {
           "caption": "Application",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8ba6005b-acdd-406c-9b58-ff95e3719403)
OCSF server currently starts with these warnings.
This PR addresses these warnings by providing a specific usage description for `package.type_id` and `package.vendor_name`.
