### PR TITLE
Added new activity `Listen` to `Network Activity` and relax requirement of `src_endpoint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Thankyou! -->
     4. Added `ja4_fingerprint_list` to base network event class. #834
     5. Added `ticket` to `Incident Finding` event class. #1068
     6. Added new activities `Enroll`, `Activate`, `Deactivate`, `Suspend`, and `Resume` to the `Entity Management` class. #1095
+    7. Added new activity `Listen` to `Network Activity` and relax requirement of `src_endpoint`. #1147
 * #### Profiles
 * #### Objects
     1. Added `ext` to `File` object. #1046

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -41,7 +41,7 @@
     "src_endpoint": {
       "description": "The initiator (client) of the network connection.",
       "group": "primary",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "tls": {
       "group": "context",

--- a/includes/network/network_activities.json
+++ b/includes/network/network_activities.json
@@ -27,6 +27,10 @@
         "6": {
           "caption": "Traffic",
           "description": "Network traffic report."
+        },
+        "7": {
+          "caption": "Listen",
+          "description": "A network endpoint began listening for new network connections."
         }
       }
     }


### PR DESCRIPTION
This adds support for representing a network endpoint listening for new network connections on a network.

The listening network endpoint will always be the `dst_endpoint`, and there is no `src_endpoint` because no network connection has been established yet. Therefore `src_endpoint` is changed from required to recommended.

The rational behind using `Network Activity` is that when a data consumer asks their data set for `Network Activity`, they will probably be interested in things that are listening on the network even if there wasn't a connection established yet.
This is in contrast to needing to ask the data set for a different event type.