### PR TITLE
Create `OSINT Inventory Info` Discovery Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Event Classes
+    1. Added `OSINT Inventory Info` event class to the Discovery category.
+
 ## [v1.3.0] - August 1st, 2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Thankyou! -->
 
 ### Added
 * #### Event Classes
-    1. Added `OSINT Inventory Info` event class to the Discovery category.
+    1. Added `OSINT Inventory Info` event class to the Discovery category. #1154
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/events/discovery/osint_inventory_info.json
+++ b/events/discovery/osint_inventory_info.json
@@ -1,0 +1,19 @@
+{
+    "caption": "OSINT Inventory Info",
+    "description": "OSINT Inventory Info events report open source intelligence or threat intelligence inventory data that is either logged or proactively collected. For example, when collecting OSINT information from Threat Intelligence Platforms (TIPs) or Extended Detection and Response (XDR) platforms, or collecting data from OSINT or other generic threat intelligence and enrichment feeds such as APIs and datastores.",
+    "extends": "discovery",
+    "name": "osint_inventory_info",
+    "uid": 21,
+    "attributes": {
+        "actor": {
+            "description": "The actor describes the process that was the source of the inventory activity. In the case of OSINT inventory data, that could be a particular process or script that is run to scrape the OSINT or threat intelligence data. For example, it could be a Python process that runs to pull data from a MISP or Shodan API.",
+            "group": "context",
+            "requirement": "optional"
+        },
+        "osint": {
+            "group": "primary",
+            "requirement": "required",
+            "description": "The OSINT that is being discovered by an inventory process."
+        }
+    }
+}


### PR DESCRIPTION
Adds a `OSINT Inventory Info` event to the Discovery category to represent retrieval of OSINT, CTI, and other enrichment data from TIPs, XDRs, and other sources of OSINT/CTI
