### PR TITLE
`user` Object expansion and related Observables creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Improved
+* #### Objects
+    1. Added `phone_number` to `user` and `ldap_person` objects.
+    2. Added `state_id` and `state` to `user` object to represent various user states such as active, suspended, locked out, etc.
+    3. Added `has_mfa` to `user` object.
+
+### Misc
+1. Added `user.uid` as an Observable type - `type_id: 31`.
+2. Added `group.name` and `group.uid` as Observable types - `type_id: 32` and `type_id: 33`, respectively.
+3. Added `account.name` and `account.uid` as Observable types - `type_id: 34` and `type_id: 35`, respectively.
+4. Added `has_mfa` boolean_t to Dictionary.
+
 ## [v1.3.0] - August 1st, 2024
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,7 @@ Thankyou! -->
 ### Improved
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
-    2. Added `state_id` and `state` to `user` object to represent various user states such as active, suspended, locked out, etc. #1155
-    3. Added `has_mfa` to `user` object. #1155
+    2. Added `has_mfa` to `user` object. #1155
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,15 @@ Thankyou! -->
 
 ### Improved
 * #### Objects
-    1. Added `phone_number` to `user` and `ldap_person` objects.
-    2. Added `state_id` and `state` to `user` object to represent various user states such as active, suspended, locked out, etc.
-    3. Added `has_mfa` to `user` object.
+    1. Added `phone_number` to `user` and `ldap_person` objects. #1155
+    2. Added `state_id` and `state` to `user` object to represent various user states such as active, suspended, locked out, etc. #1155
+    3. Added `has_mfa` to `user` object. #1155
 
 ### Misc
-1. Added `user.uid` as an Observable type - `type_id: 31`.
-2. Added `group.name` and `group.uid` as Observable types - `type_id: 32` and `type_id: 33`, respectively.
-3. Added `account.name` and `account.uid` as Observable types - `type_id: 34` and `type_id: 35`, respectively.
-4. Added `has_mfa` boolean_t to Dictionary.
+1. Added `user.uid` as an Observable type - `type_id: 31`. #1155
+2. Added `group.name` and `group.uid` as Observable types - `type_id: 32` and `type_id: 33`, respectively. #1155
+3. Added `account.name` and `account.uid` as Observable types - `type_id: 34` and `type_id: 35`, respectively. #1155
+4. Added `has_mfa` boolean_t to Dictionary. #1155
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -2124,6 +2124,11 @@
       "description": "The amount of total time for the TLS handshake to complete after the TCP connection is established, including client-side delays, in milliseconds.",
       "type": "integer_t"
     },
+    "has_mfa": {
+      "caption": "MFA Assigned",
+      "description": "The user has a multi-factor or secondary-factor device assigned.",
+      "type": "boolean_t"
+    },
     "hash": {
       "caption": "Hash",
       "description": "The hash attribute is the value of a digital fingerprint including information about its algorithm.",

--- a/objects/account.json
+++ b/objects/account.json
@@ -5,7 +5,8 @@
   "extends": "_entity",
   "attributes": {
     "name": {
-      "description": "The name of the account (e.g. GCP Account Name)."
+      "description": "The name of the account (e.g. GCP Account Name).",
+      "observable": 34
     },
     "type": {
       "caption": "Type",
@@ -58,7 +59,8 @@
       "requirement": "recommended"
     },
     "uid": {
-      "description": "The unique identifier of the account (e.g. AWS Account ID)."
+      "description": "The unique identifier of the account (e.g. AWS Account ID).",
+      "observable": 35
     },
     "labels": {
       "caption": "Labels",

--- a/objects/group.json
+++ b/objects/group.json
@@ -13,7 +13,8 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The group name."
+      "description": "The group name.",
+      "observable": 32
     },
     "privileges": {
       "description": "The group privileges.",
@@ -25,7 +26,8 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier of the group. For example, for Windows events this is the security identifier (SID) of the group."
+      "description": "The unique identifier of the group. For example, for Windows events this is the security identifier (SID) of the group.",
+      "observable": 33
     }
   }
 }

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -59,6 +59,11 @@
     "office_location": {
       "requirement": "optional"
     },
+    "phone_number": {
+      "caption": "Telephone Number",
+      "description": "The telephone number of the user. Corresponds to the LDAP <code>Telephone-Number</code> CN.",
+      "requirement": "optional"
+    },
     "surname": {
       "requirement": "optional"
     }

--- a/objects/user.json
+++ b/objects/user.json
@@ -56,60 +56,6 @@
     "risk_score": {
       "requirement": "optional"
     },
-    "state": {
-      "description": "The state of the user. For example, Active, Provisioned, Suspended, etc.",
-      "requirement": "optional"
-    },
-    "state_id": {
-      "description": "The user state identifier.",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The user state is unknown."
-        },
-        "1": {
-          "caption": "Active",
-          "description": "The user is active."
-        },
-        "2": {
-          "caption": "Deprovisioned",
-          "description": "The user has been deprovisioned or deactivated in the source system."
-        },
-        "3": {
-          "caption": "Locked Out",
-          "description": "The user is locked out. For example, due to too many failed logins or administrative action."
-        },
-        "4": {
-          "caption": "Password Expired",
-          "description": "The user has an expired password."
-        },
-        "5": {
-          "caption": "Provisioned",
-          "description": "The user is provisioned in the source system, but is not otherwise activated."
-        },
-        "6": {
-          "caption": "Recovery",
-          "description": "The user is in a recovery state in the source system. For example, the password was forgotten."
-        },
-        "7": {
-          "caption": "Staged",
-          "description": "The user is in a staged status, awaiting provisioning in the source system."
-        },
-        "8": {
-          "caption": "Suspended",
-          "description": "The user is suspended or deactivated. For example, due to security policy or manual administrator intervention."
-        },
-        "9": {
-          "caption": "Deleted",
-          "description": "The user is deleted. For example, due to automated removal from the user leaving an organization or manual administrator intervention."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The user state is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
-        }
-      },
-      "requirement": "recommended"
-    },
     "type": {
       "description": "The type of the user. For example, System, AWS IAM User, etc.",
       "requirement": "optional"

--- a/objects/user.json
+++ b/objects/user.json
@@ -39,6 +39,11 @@
       "description": "Organization and org unit related to the user.",
       "requirement": "optional"
     },
+    "phone_number": {
+      "caption": "Telephone Number",
+      "description": "The telephone number of the user.",
+      "requirement": "optional"
+    },
     "risk_level": {
       "requirement": "optional"
     },
@@ -47,6 +52,60 @@
     },
     "risk_score": {
       "requirement": "optional"
+    },
+    "state": {
+      "description": "The state of the user. For example, Active, Provisioned, Suspended, etc.",
+      "requirement": "optional"
+    },
+    "state_id": {
+      "description": "The user state identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The user state is unknown."
+        },
+        "1": {
+          "caption": "Active",
+          "description": "The user is active."
+        },
+        "2": {
+          "caption": "Deprovisioned",
+          "description": "The user has been deprovisioned or deactivated in the source system."
+        },
+        "3": {
+          "caption": "Locked Out",
+          "description": "The user is locked out. For example, due to too many failed logins or administrative action."
+        },
+        "4": {
+          "caption": "Password Expired",
+          "description": "The user has an expired password."
+        },
+        "5": {
+          "caption": "Provisioned",
+          "description": "The user is provisioned in the source system, but is not otherwise activated."
+        },
+        "6": {
+          "caption": "Recovery",
+          "description": "The user is in a recovery state in the source system. For example, the password was forgotten."
+        },
+        "7": {
+          "caption": "Staged",
+          "description": "The user is in a staged status, awaiting provisioning in the source system."
+        },
+        "8": {
+          "caption": "Suspended",
+          "description": "The user is suspended. For example, due to security policy or manual administrator intervention."
+        },
+        "9": {
+          "caption": "Deleted",
+          "description": "The user is deleted. For example, due to automated removal from the user leaving an organization or manual administrator intervention."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The user state is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
+        }
+      },
+      "requirement": "recommended"
     },
     "type": {
       "description": "The type of the user. For example, System, AWS IAM User, etc.",
@@ -78,7 +137,8 @@
     },
     "uid": {
       "description": "The unique user identifier. For example, the Windows user SID, ActiveDirectory DN or AWS user ARN.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 31
     },
     "uid_alt": {
       "description": "The alternate user identifier. For example, the Active Directory user GUID or AWS user Principal ID.",

--- a/objects/user.json
+++ b/objects/user.json
@@ -26,6 +26,9 @@
       "description": "The administrative groups to which the user belongs.",
       "requirement": "optional"
     },
+    "has_mfa": {
+      "requirement": "recommended"
+    },
     "ldap_person": {
       "description": "The additional LDAP attributes that describe a person.",
       "requirement": "optional"
@@ -94,7 +97,7 @@
         },
         "8": {
           "caption": "Suspended",
-          "description": "The user is suspended. For example, due to security policy or manual administrator intervention."
+          "description": "The user is suspended or deactivated. For example, due to security policy or manual administrator intervention."
         },
         "9": {
           "caption": "Deleted",


### PR DESCRIPTION
Expands the `user` object to add relevant data that comes from various Identity Providers or Directories while keep relevance with LDAP and MITRE D3FEND.

- Add Observable `type_id` 31-35 for User UID, Group Name, Group UID, Account Name, Account UID
- Add `phone_number` to `user` and to `ldap_person` - this attribute can be assigned to both or one or the other depending on the upstream system. For instance Entra ID or Okta
- ~~Add `state_id` and `state` to `user` to represent the various states of a user record in a directory or IDP such as their provisioning status, (de)activation. This is 1:1 with Okta with an extra `Deleted` enum added for Google Workspace~~ Removed as #1136 already has a solution
- Add `has_mfa` Boolean to Dictionary and `user` object as a quick way to tell if a `user` has MFA/2FA enabled/assigned to them
