### PR TITLE
Fix `parent_process` recursion and add `grandparent_process`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Thankyou! -->
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155
+    3. Added `parent_process` and `grandparent_process` as standalone objects, distinct from `process`.
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/dictionary.json
+++ b/dictionary.json
@@ -2099,6 +2099,11 @@
       "description": "The given or first name of the user.",
       "type": "string_t"
     },
+    "grandparent_process": {
+      "caption": "Grandparent Process",
+      "description": "The Grandparent Process object signifies the originating process that indirectly initiates a chain of descendant processes. By tracing back through Parent Processes, the Grandparent Process object helps to map out the broader process tree, establishing a clearer picture of process lineage and inheritance.",
+      "type": "grandparent_process"
+    },
     "group": {
       "caption": "Group",
       "description": "The group object associated with an entity such as user, policy, or rule.",
@@ -3196,8 +3201,8 @@
     },
     "parent_process": {
       "caption": "Parent Process",
-      "description": "The parent process of this process object. It is recommended to only populate this field for the first process object, to prevent deep nesting.",
-      "type": "process"
+      "description": "The Parent Process object represents the process that initiates or spawns a new child process. This object tracks the lineage and origin of child processes, providing visibility into the hierarchical structure of process execution.",
+      "type": "parent_process"
     },
     "path": {
       "caption": "Path",

--- a/objects/grandparent_process.json
+++ b/objects/grandparent_process.json
@@ -1,8 +1,8 @@
 {
-  "caption": "Process",
-  "description": "The Process object describes a running instance of a launched program. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
+  "caption": "Grandparent Process",
+  "description": "The Grandparent Process object signifies the originating process that indirectly initiates a chain of descendant processes. By tracing back through Parent Processes, the Grandparent Process object helps to map out the broader process tree, establishing a clearer picture of process lineage and inheritance. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
   "extends": "_entity",
-  "name": "process",
+  "name": "grandparent_process",
   "observable": 25,
   "profiles": [
     "container"
@@ -37,12 +37,6 @@
     "name": {
       "description": "The friendly name of the process, for example: <code>Notepad++</code>.",
       "type": "process_name_t"
-    },
-    "parent_process": {
-      "requirement": "recommended"
-    },
-    "grandparent_process": {
-      "requirement": "optional"
     },
     "pid": {
       "requirement": "recommended"

--- a/objects/grandparent_process.json
+++ b/objects/grandparent_process.json
@@ -3,7 +3,6 @@
   "description": "The Grandparent Process object signifies the originating process that indirectly initiates a chain of descendant processes. By tracing back through Parent Processes, the Grandparent Process object helps to map out the broader process tree, establishing a clearer picture of process lineage and inheritance. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
   "extends": "_entity",
   "name": "grandparent_process",
-  "observable": 25,
   "profiles": [
     "container"
   ],
@@ -15,11 +14,11 @@
       "requirement": "recommended"
     },
     "created_time": {
-      "description": "The time when the process was created/started.",
+      "description": "The time when the grandparent process was created/started.",
       "requirement": "recommended"
     },
     "file": {
-      "description": "The process file object.",
+      "description": "the grandparent process file object.",
       "requirement": "recommended"
     },
     "integrity": {
@@ -35,7 +34,7 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The friendly name of the process, for example: <code>Notepad++</code>.",
+      "description": "The friendly name of the grandparent process, for example: <code>Notepad++</code>.",
       "type": "process_name_t"
     },
     "pid": {
@@ -49,7 +48,7 @@
       "requirement": "optional"
     },
     "terminated_time": {
-      "description": "The time when the process was terminated.",
+      "description": "The time when the grandparent process was terminated.",
       "requirement": "optional"
     },
     "tid": {

--- a/objects/parent_process.json
+++ b/objects/parent_process.json
@@ -1,8 +1,8 @@
 {
-  "caption": "Process",
-  "description": "The Process object describes a running instance of a launched program. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
+  "caption": "Parent Process",
+  "description": "The Parent Process object represents the process that initiates or spawns a new child process. This object tracks the lineage and origin of child processes, providing visibility into the hierarchical structure of process execution. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
   "extends": "_entity",
-  "name": "process",
+  "name": "parent_process",
   "observable": 25,
   "profiles": [
     "container"
@@ -37,12 +37,6 @@
     "name": {
       "description": "The friendly name of the process, for example: <code>Notepad++</code>.",
       "type": "process_name_t"
-    },
-    "parent_process": {
-      "requirement": "recommended"
-    },
-    "grandparent_process": {
-      "requirement": "optional"
     },
     "pid": {
       "requirement": "recommended"

--- a/objects/parent_process.json
+++ b/objects/parent_process.json
@@ -3,7 +3,6 @@
   "description": "The Parent Process object represents the process that initiates or spawns a new child process. This object tracks the lineage and origin of child processes, providing visibility into the hierarchical structure of process execution. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
   "extends": "_entity",
   "name": "parent_process",
-  "observable": 25,
   "profiles": [
     "container"
   ],
@@ -15,11 +14,11 @@
       "requirement": "recommended"
     },
     "created_time": {
-      "description": "The time when the process was created/started.",
+      "description": "The time when the parent process was created/started.",
       "requirement": "recommended"
     },
     "file": {
-      "description": "The process file object.",
+      "description": "the parent process file object.",
       "requirement": "recommended"
     },
     "integrity": {
@@ -35,7 +34,7 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The friendly name of the process, for example: <code>Notepad++</code>.",
+      "description": "The friendly name of the parent process, for example: <code>Notepad++</code>.",
       "type": "process_name_t"
     },
     "pid": {
@@ -49,7 +48,7 @@
       "requirement": "optional"
     },
     "terminated_time": {
-      "description": "The time when the process was terminated.",
+      "description": "The time when the parent process was terminated.",
       "requirement": "optional"
     },
     "tid": {


### PR DESCRIPTION
#### Related Issue

#1108 

#### Description of changes:

In an effort to limit the potentially limitless recursion within `parent_process` being typed as a `process` and to get a more straightforward approach to modeling both it and grandparent process I made the following changes.

1. `parent_process` is now its own distinct Object, changes are mostly flavor but most notably it is no longer self-referential due to the current version being typed as a `process` object.
2. Added a new `grandparent_process` but instead of starting it from `parent_process`, it also lives within the `process` object, this prevents an unnecessary (IMHO) extra layer of depth in the schema, which is already very deep depending if process is referred to from `actor` or `evidences`.

These changes do not break the current Observable for `process` nor does it break the `Process Name` or `Process ID` observables.

However, these can negatively impact mappers who are using the extra layer of depth to model grandparent processes under the current mechanism of `process.parent_process.parent_process`. This data is available from several EDR and APM tools.