### PR TITLE
Change "misspellings" of identifier contraction "Id" to "ID"

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -982,7 +982,7 @@
       "type": "string_t"
     },
     "confidence_id": {
-      "caption": "Confidence Id",
+      "caption": "Confidence ID",
       "description": "The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.",
       "type": "integer_t",
       "enum": {
@@ -2891,7 +2891,7 @@
     },
     "message_uid": {
       "caption": "Message UID",
-      "description": "The email header Message-Id value, as defined by RFC 5322.",
+      "description": "The email header Message-ID value, as defined by RFC 5322.",
       "type": "string_t"
     },
     "metadata": {
@@ -4092,7 +4092,7 @@
       "type": "string_t"
     },
     "share_type_id": {
-      "caption": "Share Type Id",
+      "caption": "Share Type ID",
       "description": "The normalized identifier of the share type.",
       "sibling": "share_type",
       "type": "integer_t",


### PR DESCRIPTION
#### Related Issue: 
None

#### Description of changes:
Change occurrences of `Id` in `dictionary.json` to `ID`. There were three (3) occurrences of `Id` in the dictionary, while the other 69 were `ID`.

This change affects `caption` and `description` fields only. No enum captions were changed. This has no affect on existing OCSF events, and does not represent a breaking change, including while validating events.

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
    * **_Is this necessary for a typo fix?_** (2 reviewers say "no".)
 
