### PR TITLE
Fix grammar for *_permissions attributes

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -102,7 +102,7 @@
     },
     "actual_permissions": {
       "caption": "Actual Permissions",
-      "description": "The permissions that were granted to the in a platform-native format.",
+      "description": "The permissions that were granted in a platform-native format. See specific usage.",
       "type": "integer_t"
     },
     "affected_code": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3708,7 +3708,7 @@
     },
     "requested_permissions": {
       "caption": "Requested Permissions",
-      "description": "The permissions mask that were requested by the process.",
+      "description": "The permissions mask. See specific usage.",
       "type": "integer_t"
     },
     "requirements": {

--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -42,6 +42,7 @@
       }
     },
     "actual_permissions": {
+      "description": "The permissions that were granted to the process in a platform-native format.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -52,6 +52,7 @@
       "requirement": "recommended"
     },
     "requested_permissions": {
+      "description": "The permissions mask that was requested by the process.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/system/memory.json
+++ b/events/system/memory.json
@@ -42,7 +42,7 @@
       }
     },
     "actual_permissions": {
-      "description": "The permissions that were granted to the process in a platform-native format.",
+      "description": "The permissions that were granted to access memory.",
       "group": "primary",
       "requirement": "recommended"
     },
@@ -52,7 +52,7 @@
       "requirement": "recommended"
     },
     "requested_permissions": {
-      "description": "The permissions mask that was requested by the process.",
+      "description": "The permissions mask that was requested to access memory.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/system/process.json
+++ b/events/system/process.json
@@ -55,6 +55,7 @@
       "requirement": "required"
     },
     "requested_permissions": {
+      "description": "The permissions mask that was requested by the process.",
       "group": "primary",
       "requirement": "recommended"
     }

--- a/events/system/process.json
+++ b/events/system/process.json
@@ -28,6 +28,7 @@
       "description": "The actor that performed the activity on the target <code>process</code>. For example, the process that started a new process or injected code into another process."
     },
     "actual_permissions": {
+      "description": "The permissions that were granted to the process in a platform-native format.",
       "group": "primary",
       "requirement": "recommended"
     },


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

1. Today, there are typos in the descriptions of these attributes:
   - `actual_permissions`: `The permissions that were granted to the in a platform-native format.`
   - `requested_permissions`: `The permissions mask that were requested by the process`

This PR cleans up the typos, and applies our `See specific usage` verbiage to the base dictionary descriptions.

NOTE: Since this is simply a description update, no update to CHANGELOG should be needed.