### PR TITLE
Minor addition to the cvss object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Thankyou! -->
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155
-    3. Added `vendor_namr` to `cvss` object. #1165
+    3. Added `vendor_name` to `cvss` object. #1165
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Thankyou! -->
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155
+    3. Added `vendor_namr` to `cvss` object. #1165
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/objects/cvss.json
+++ b/objects/cvss.json
@@ -26,6 +26,10 @@
     "vector_string": {
       "requirement": "optional"
     },
+    "vendor_name":{
+      "description": "The vendor that provided the CVSS score. For example: <code>NVD, REDHAT</code> etc.",
+      "requirement": "recommended"
+    },
     "version": {
       "description": "The CVSS version. For example: <code>3.1</code>.",
       "requirement": "required"


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:
1. Adding `vendor_name` to the `cvss` object to help represent the source/vendor that provided the cvss scores. 
2. Snippet from a sample source event from Amazon Inspector

```
"cvss": [
      {
        "baseScore": 10,
        "scoringVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
        "version": "3.1",
        "source": "UBUNTU_CVE"
      },
      {
        "baseScore": 10,
        "scoringVector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
        "version": "3.1",
        "source": "NVD"
      }
    ],

```
