### PR TITLE
Expand applicability and direction of `cloud.account` and `cloud.org` & deprecate `project_uid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,6 @@ Thankyou! -->
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155
     3. Added `vendor_name` to `cvss` object. #1165
-    4. Remove `project_uid` from `cloud` object. #1166
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,15 @@ Thankyou! -->
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155
     3. Added `vendor_name` to `cvss` object. #1165
+    4. Remove `project_uid` from `cloud` object. #1166
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155
 2. Added `group.name` and `group.uid` as Observable types - `type_id: 32` and `type_id: 33`, respectively. #1155
 3. Added `account.name` and `account.uid` as Observable types - `type_id: 34` and `type_id: 35`, respectively. #1155
 4. Added `has_mfa` boolean_t to Dictionary. #1155
+5. Deprecate `project_uid`. #1166
+6. Added several new enums to `account.type_id`. #1166
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -3443,7 +3443,11 @@
     "project_uid": {
       "caption": "Project ID",
       "description": "The unique identifier of a Cloud project.",
-      "type": "string_t"
+      "type": "string_t",
+      "@deprecated": {
+        "message": "Use the <code> account.uid </code> attribute instead.",
+        "since": "1.4.0"
+      }
     },
     "protocol_name": {
       "caption": "Protocol Name",

--- a/objects/account.json
+++ b/objects/account.json
@@ -5,7 +5,7 @@
   "extends": "_entity",
   "attributes": {
     "name": {
-      "description": "The name of the account (e.g. GCP Project name, Linux Account name, AWS Account name).",
+      "description": "The name of the account (e.g. <code> GCP Project name </code>, <code> Linux Account name </code> or <code> AWS Account name </code>).",
       "observable": 34
     },
     "type": {
@@ -80,7 +80,7 @@
       "requirement": "recommended"
     },
     "uid": {
-      "description": "The unique identifier of the account (e.g. AWS Account ID, OCID, GCP Project ID, Azure Subscription ID, Google Workspace Customer ID, M365 Tenant UID).",
+      "description": "The unique identifier of the account (e.g. <code> AWS Account ID </code>, <code> OCID </code>, <code> GCP Project ID </code>, <code> Azure Subscription ID </code>, <code> Google Workspace Customer ID </code>, or <code> M365 Tenant UID </code>).",
       "observable": 35
     },
     "labels": {

--- a/objects/account.json
+++ b/objects/account.json
@@ -1,11 +1,11 @@
 {
   "caption": "Account",
-  "description": "The Account object contains details about the account that initiated or performed a specific activity within a system or application.",
+  "description": "The Account object contains details about the account that initiated or performed a specific activity within a system or application. Additionally, the Account object refers to logical Cloud and Software-as-a-Service (SaaS) based containers such as AWS Accounts, Azure Subscriptions, Oracle Cloud Compartments, Google Cloud Projects, and otherwise.",
   "name": "account",
   "extends": "_entity",
   "attributes": {
     "name": {
-      "description": "The name of the account (e.g. GCP Account Name).",
+      "description": "The name of the account (e.g. GCP Project name, Linux Account name, AWS Account name).",
       "observable": 34
     },
     "type": {
@@ -54,12 +54,33 @@
         },
         "10": {
           "caption": "AWS Account"
+        },
+        "11": {
+          "caption": "GCP Project"
+        },
+        "12": {
+          "caption": "OCI Compartment"
+        },
+        "13": {
+          "caption": "Azure Subscription"
+        },
+        "14": {
+          "caption": "Salesforce Account"
+        },
+        "15": {
+          "caption": "Google Workspace"
+        },
+        "16": {
+          "caption": "Servicenow Instance"
+        },
+        "17": {
+          "caption": "M365 Tenant"
         }
       },
       "requirement": "recommended"
     },
     "uid": {
-      "description": "The unique identifier of the account (e.g. AWS Account ID).",
+      "description": "The unique identifier of the account (e.g. AWS Account ID, OCID, GCP Project ID, Azure Subscription ID, Google Workspace Customer ID, M365 Tenant UID).",
       "observable": 35
     },
     "labels": {

--- a/objects/cloud.json
+++ b/objects/cloud.json
@@ -1,6 +1,6 @@
 {
   "caption": "Cloud",
-  "description": "The Cloud object contains information about a cloud account such as AWS Account ID, regions, etc.",
+  "description": "The Cloud object contains information about a cloud or Software-as-a-Service account or similar construct, such as AWS Account ID, regions, organizations, folders, compartments, tenants, etc.",
   "extends": "object",
   "name": "cloud",
   "attributes": {
@@ -8,9 +8,6 @@
       "requirement": "optional"
     },
     "org": {
-      "requirement": "optional"
-    },
-    "project_uid": {
       "requirement": "optional"
     },
     "provider": {

--- a/objects/cloud.json
+++ b/objects/cloud.json
@@ -10,6 +10,9 @@
     "org": {
       "requirement": "optional"
     },
+    "project_uid": {
+      "requirement": "optional"
+    },
     "provider": {
       "description": "The unique name of the Cloud services provider, such as AWS, MS Azure, GCP, etc.",
       "requirement": "required"

--- a/objects/organization.json
+++ b/objects/organization.json
@@ -1,20 +1,22 @@
 {
   "caption": "Organization",
-  "description": "The Organization object describes characteristics of an organization or company and its division if any.",
+  "description": "The Organization object describes characteristics of an organization or company and its division if any. Additionally, it also describes cloud and Software-as-a-Service (SaaS) logical hierarchies such as AWS Organizations, Google Cloud Organizations, Oracle Cloud Tenancies, and similar constructs.",
   "extends": "_entity",
   "name": "organization",
   "attributes": {
     "name": {
-      "description": "The name of the organization. For example, Widget, Inc."
+      "description": "The name of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, Widget, Inc. or the AWS Organization ARN."
     },
     "ou_name": {
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "description": "The name an organizational unit, Oracle Cloud Compartment, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
     },
     "ou_uid": {
-      "requirement": "optional"
+      "requirement": "optional",
+      "description": "The unique identifier an organizational unit, Oracle Cloud Compartment, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
     },
     "uid": {
-      "description": "The unique identifier of the organization. For example, its Active Directory or AWS Org ID."
+      "description": "The unique identifier of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, the AWS Org ID or Oracle Cloud Tenancy ID."
     }
   }
 }

--- a/objects/organization.json
+++ b/objects/organization.json
@@ -9,11 +9,11 @@
     },
     "ou_name": {
       "requirement": "recommended",
-      "description": "The name an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
+      "description": "The name of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
     },
     "ou_uid": {
       "requirement": "optional",
-      "description": "The unique identifier an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
+      "description": "The unique identifier of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
     },
     "uid": {
       "description": "The unique identifier of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, the AWS Org ID or Oracle Cloud Tenancy ID."

--- a/objects/organization.json
+++ b/objects/organization.json
@@ -9,11 +9,11 @@
     },
     "ou_name": {
       "requirement": "recommended",
-      "description": "The name an organizational unit, Oracle Cloud Compartment, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
+      "description": "The name an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
     },
     "ou_uid": {
       "requirement": "optional",
-      "description": "The unique identifier an organizational unit, Oracle Cloud Compartment, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
+      "description": "The unique identifier an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
     },
     "uid": {
       "description": "The unique identifier of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, the AWS Org ID or Oracle Cloud Tenancy ID."

--- a/objects/organization.json
+++ b/objects/organization.json
@@ -5,18 +5,18 @@
   "name": "organization",
   "attributes": {
     "name": {
-      "description": "The name of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, Widget, Inc. or the AWS Organization ARN."
+      "description": "The name of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, <code> Widget, Inc. </code> or the <code> AWS Organization name </code>."
     },
     "ou_name": {
       "requirement": "recommended",
-      "description": "The name of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the AWS OU ARN, or Dev_Prod_OU."
+      "description": "The name of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the <code> GCP Project Name </code>, or <code> Dev_Prod_OU </code>."
     },
     "ou_uid": {
       "requirement": "optional",
-      "description": "The unique identifier of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, the OCID, AWS OU ID, or GCP Folder ID."
+      "description": "The unique identifier of an organizational unit, Google Cloud Folder, or AWS Org Unit. For example, an  <code> Oracle Cloud Tenancy ID </code>, <code> AWS OU ID </code>, or <code> GCP Folder ID </code>."
     },
     "uid": {
-      "description": "The unique identifier of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, the AWS Org ID or Oracle Cloud Tenancy ID."
+      "description": "The unique identifier of the organization, Oracle Cloud Tenancy, Google Cloud Organization, or AWS Organization. For example, an <code> AWS Org ID </code> or <code> Oracle Cloud Domain ID </code>."
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

As per conversations with @floydtree and @zschmerber, some better guidance and applicability of existing `org` and `account` objects was required to account for the various ways that logical compartmentalization are defined in various public cloud and SaaS tools.

For instance, GCP has Org -> Folder -> Project, OCI has Domain -> Tenancy -> Compartment, AWS has Org -> OU -> Account, and various SaaS tools have high level compartmentalization such as Servicenow Instances, M365 Tenants, Salesforce Accounts, etc.

- Deprecate `project_uid` as it was hyper-specific to GCP and doesn't fit other CSPs or SaaS, removed `project_uid` from `cloud`.
- Update all descriptions within `org` and `account` to reflect the applicability to CSP and SaaS platforms with more examples for mappers.
- Added several new `account.type_id` to reflect AWS Account-like equivalents for Azure, GCP, OCI, Salesforce, M365, and Servicenow.
