### PR TITLE
Strengthen the event_code description verbiage

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1850,7 +1850,7 @@
     },
     "event_code": {
       "caption": "Event Code",
-      "description": "The <code>Event ID, Code, or Name</code> that the product uses to identify the event.",
+      "description": "The <code>Event ID, Code, or Name</code> that the product uses to primarily identify the event.",
       "type": "string_t"
     },
     "evidence": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1850,7 +1850,7 @@
     },
     "event_code": {
       "caption": "Event Code",
-      "description": "The Event ID or Code that the product uses to describe the event.",
+      "description": "The <code>Event ID, Code, or Name</code> that the product uses to identify the event.",
       "type": "string_t"
     },
     "evidence": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

Minor but useful update to the `event_code` attribute description to indicate that it represents the event's code, id, or name that is used to primarily identify the event.

<img width="409" alt="image" src="https://github.com/user-attachments/assets/e5dee2b6-2bcc-4b55-8482-f65c1195a37a">

Note: since this is a description change, no need to update the CHANGELOG.