### PR TITLE
Add Email Account `type_id` and Forwarding Address Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Thankyou! -->
     1. Added `has_mfa` as a `boolean_t`. #1155
     2. Added `environment_variables` as an array of `environment_variable`. #1172
     3. Added `is_attribute_truncated` as a `boolean_t`. #1172
+    4. Added `forward_addr` as an `email_t`.
 * #### Objects
     1. Added `environment_variable` object. #1172
 
@@ -63,6 +64,7 @@ Thankyou! -->
     3. Added `vendor_name` to `cvss` object. #1165
     4. Added `file`, `reputation`, `subnet`, and `script` to `osint` object. #1168
     5. Added `environment_variables` attribute to the `process` object. #1172
+    6. Added `forward_addr` to the `user` object.
 
 ### Deprecated
 1. Deprecated `project_uid` in favor of `account.uid`. #1166
@@ -75,6 +77,7 @@ Thankyou! -->
 5. Cleaned up event class definition files, removed /includes dir, simplified definition of `base_event`. #1167, #1171
 6. Added new `file` enum to `osint.type_id`. #1168
 7. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
+8. Added new `Email Account` enum to `account.type_id`. 
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Thankyou! -->
     1. Added `has_mfa` as a `boolean_t`. #1155
     2. Added `environment_variables` as an array of `environment_variable`. #1172
     3. Added `is_attribute_truncated` as a `boolean_t`. #1172
-    4. Added `forward_addr` as an `email_t`.
+    4. Added `forward_addr` as an `email_t`. #1179
 * #### Objects
     1. Added `environment_variable` object. #1172
 
@@ -64,7 +64,7 @@ Thankyou! -->
     3. Added `vendor_name` to `cvss` object. #1165
     4. Added `file`, `reputation`, `subnet`, and `script` to `osint` object. #1168
     5. Added `environment_variables` attribute to the `process` object. #1172
-    6. Added `forward_addr` to the `user` object.
+    6. Added `forward_addr` to the `user` object. #1179
 
 ### Deprecated
 1. Deprecated `project_uid` in favor of `account.uid`. #1166
@@ -77,7 +77,7 @@ Thankyou! -->
 5. Cleaned up event class definition files, removed /includes dir, simplified definition of `base_event`. #1167, #1171
 6. Added new `file` enum to `osint.type_id`. #1168
 7. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
-8. Added new `Email Account` enum to `account.type_id`. 
+8. Added new `Email Account` enum to `account.type_id`. #1179
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -2085,6 +2085,11 @@
       "description": "The folder that pertains to the event.",
       "type": "file"
     },
+    "forward_addr": {
+      "caption": "Forwarding Address",
+      "description": "The user's forwarding email address.",
+      "type": "email_t"
+    },
     "from": {
       "caption": "From",
       "description": "The email header From values, as defined by RFC 5322.",

--- a/objects/account.json
+++ b/objects/account.json
@@ -75,6 +75,9 @@
         },
         "17": {
           "caption": "M365 Tenant"
+        },
+        "18": {
+          "caption": "Email Account"
         }
       },
       "requirement": "recommended"

--- a/objects/user.json
+++ b/objects/user.json
@@ -19,6 +19,9 @@
     "email_addr": {
       "requirement": "optional"
     },
+    "forward_addr": {
+      "requirement": "optional"
+    },
     "full_name": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

It is quite common for a user to set a forwarding address for their email account.

This PR adds:
- An `Email Account` enum as a `type_id` in the `account` object.
- A `forward_addr` attribute to the `dictionary` and `user` object.

<img width="688" alt="image" src="https://github.com/user-attachments/assets/f1966cad-5390-458b-a701-a49603d7450f">

<img width="678" alt="image" src="https://github.com/user-attachments/assets/ed36f3bc-eadf-4efc-8766-03499e16a4a0">

<img width="778" alt="image" src="https://github.com/user-attachments/assets/8a737b6d-f763-411d-8e02-8a6e76849f4b">
