### PR TITLE
Sibling bugfix - confidence_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,14 +46,16 @@ Thankyou! -->
     1. Added `OSINT Inventory Info` event class to the Discovery category. #1154
     2. Added `Script Activity` event class to the System category. #1159
     3. Added `Startup Item Query` event class. #1119
-
 * #### Dictionary Attributes
     1. Added `has_mfa` as a `boolean_t`. #1155
     2. Added `environment_variables` as an array of `environment_variable`. #1172
     3. Added `is_attribute_truncated` as a `boolean_t`. #1172
     4. Added `forward_addr` as an `email_t`. #1179
+    5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
+    6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
 * #### Objects
     1. Added `environment_variable` object. #1172
+    2. Added `advisory` object. #1176
 
 ### Improved
 * #### Event Classes
@@ -65,9 +67,17 @@ Thankyou! -->
     4. Added `file`, `reputation`, `subnet`, and `script` to `osint` object. #1168
     5. Added `environment_variables` attribute to the `process` object. #1172
     6. Added `forward_addr` to the `user` object. #1179
+    7. Added `src_url` to the `cvss` object. #1176
+    8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
+    9. Added `related_cwes` to the `cve` object. #1176
+
+### Bugfixes
+1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #
 
 ### Deprecated
 1. Deprecated `project_uid` in favor of `account.uid`. #1166
+2. Deprecated `kb_article_list` in favor of `advisory` in the vulnerability object. #1176
+3. Deprecated `cwe` in favor of `related_cwes` in the `cve` object. #1176
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/dictionary.json
+++ b/dictionary.json
@@ -989,6 +989,7 @@
     "confidence_id": {
       "caption": "Confidence ID",
       "description": "The normalized confidence refers to the accuracy of the rule that created the finding. A rule with a low confidence means that the finding scope is wide and may create finding reports that may not be malicious in nature.",
+      "sibling": "confidence",
       "type": "integer_t",
       "enum": {
         "0": {


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:
1. Adding sibling definition for `confidence_id`. It has been missing since we first added this attribute to the framework.
2. Adding missing changelog entries for #1176 

