### PR TITLE
Add Zone to managed entity object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Thankyou! -->
 * #### Objects
     1. Added `environment_variable` object. #1172
     2. Added `advisory` object. #1176
+    3. Added `zone` object. #1181
 
 ### Improved
 * #### Event Classes
@@ -70,6 +71,7 @@ Thankyou! -->
     7. Added `src_url` to the `cvss` object. #1176
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
+    10. Added `zone` to the managed_entity object. #1181
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -77,12 +77,12 @@
     },
     "zone": {
       "requirement": "recommended"
-    },
+    }
   },
   "constraints": {
     "at_least_one": [
       "name",
-      "uid",  
+      "uid",
       "device",
       "group",
       "org",

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -42,6 +42,10 @@
         "6": {
           "caption": "Email",
           "description": "A managed Email entity.  This item corresponds to population of the <code>email</code> attribute."
+        },
+        "7": {
+          "caption": "Zone",
+          "description": "A managed Network Zone entity.  This item corresponds to population of the <code>zone</code> attribute."
         }
       }
     },
@@ -70,7 +74,10 @@
     "version": {
       "description": "The version of the managed entity. For example: <code>1.2.3</code>.",
       "requirement": "recommended"
-    }
+    },
+    "zone": {
+      "requirement": "recommended"
+    },
   },
   "constraints": {
     "at_least_one": [
@@ -80,7 +87,8 @@
       "group",
       "org",
       "policy",
-      "user"
+      "user",
+      "zone"
     ]
   }
 }

--- a/objects/zone.json
+++ b/objects/zone.json
@@ -1,6 +1,6 @@
 {
     "caption": "Zone",
-    "description": "The Zone object describes characteristics of a network zone, a logical boundary to allow or deny access to devices based. Additionally, it also describes cloud and Software-as-a-Service (SaaS) logical hierarchies such as AWS Organizations, Google Cloud Organizations, Oracle Cloud Tenancies, and similar constructs.",
+    "description": "The Zone object describes characteristics of a network zone, a logical boundary to allow or deny access to devices based on IP addresses or geolocation for example.",
     "extends": "_entity",
     "name": "zone",
     "attributes": {

--- a/objects/zone.json
+++ b/objects/zone.json
@@ -1,0 +1,14 @@
+{
+    "caption": "Zone",
+    "description": "The Zone object describes characteristics of a network zone, a logical boundary to allow or deny access to devices based. Additionally, it also describes cloud and Software-as-a-Service (SaaS) logical hierarchies such as AWS Organizations, Google Cloud Organizations, Oracle Cloud Tenancies, and similar constructs.",
+    "extends": "_entity",
+    "name": "zone",
+    "attributes": {
+        "name": {
+            "description": "The name of the Network Zone. For example, <code> VPN Gateway </code> or the <code> On Premise Network Zone </code>."
+        },
+        "uid": {
+            "description": "The unique identifier of the network zone. For example, an <code> Okta Network Zone ID </code>."
+        }
+    }
+}


### PR DESCRIPTION
#### Related Issue:
Managed Entity object was did not stand out as an obvious choice when reviewing Okta Network zones.

#### Description of changes:
- Following a discussion based on Okta system logs in [slack](https://opencybersecu-lz97379.slack.com/archives/C05HLGHMKU2/p1727105238130719), Network zones were considered to be an entity based on the operations performed.
- Adding a Zone entity to the managed entity `type_id` enum.
- Adding a Zone object
