### PR TITLE
Updating hostname_t regex, other minor formatting changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ Thankyou! -->
 6. Added new `file` enum to `osint.type_id`. #1168
 7. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
 8. Added new `Email Account` enum to `account.type_id`. #1179
-9. Updating regex for `hostname_t` to allow FQDNs. #1182
+9. Removing regex for `hostname_t`, considering the vast variance in its values. #1182
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Thankyou! -->
 6. Added new `file` enum to `osint.type_id`. #1168
 7. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
 8. Added new `Email Account` enum to `account.type_id`. #1179
+9. Updating regex for `hostname_t` to allow FQDNs. #1182
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -4931,7 +4931,6 @@
         "observable": 1,
         "caption": "Hostname",
         "description": "Unique name assigned to a device connected to a computer network. It may be a fully qualified domain name (FQDN). For example:<br><code>r2-d2.example.com.</code>,<br><code>mx.example.com</code>",
-        "regex": "^(?!:\\/\\/)(?=.{1,255}$)((.{1,63}\\.){1,127}(?![0-9]*$)[a-z0-9-]+\\.?)$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -4895,7 +4895,7 @@
       },
       "datetime_t": {
         "caption": "Datetime",
-        "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example:<br> <code>2024-09-10T23:20:50.520Z</code>,<br> <code>2024-09-10 23:20:50.520789Z</code>.",
+        "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example:<br><code>2024-09-10T23:20:50.520Z</code>,<br><code>2024-09-10 23:20:50.520789Z</code>.",
         "regex": "^\\d{4}-\\d{2}-\\d{2}[Tt]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?([Zz]|[\\+-]\\d{2}:\\d{2})?$",
         "type": "string_t",
         "type_name": "String"
@@ -4903,7 +4903,7 @@
       "email_t": {
         "observable": 5,
         "caption": "Email Address",
-        "description": "Email address. For example: <code>john_doe@example.com</code>.",
+        "description": "Email address. For example:<br><code>john_doe@example.com</code>.",
         "regex": "^[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$",
         "type": "string_t",
         "type_name": "String"
@@ -4911,7 +4911,7 @@
       "file_hash_t": {
         "observable": 8,
         "caption": "Hash",
-        "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>.",
+        "description": "Hash. A unique value that corresponds to the content of the file, image, ja3_hash or hassh found in the schema. For example:<br> MD5: <code>3172ac7e2b55cbb81f04a6e65855a628</code>.",
         "regex": "^[a-fA-F0-9]+$",
         "type": "string_t",
         "type_name": "String"
@@ -4919,19 +4919,19 @@
       "file_name_t": {
         "observable": 7,
         "caption": "File Name",
-        "description": "File name. For example: <code>text-file.txt</code>.",
+        "description": "File name. For example:<br><code>text-file.txt</code>.",
         "type": "string_t",
         "type_name": "String"
       },
       "float_t": {
         "caption": "Float",
-        "description": "Real floating-point value. For example: <code>3.14</code>."
+        "description": "Real floating-point value. For example:<br><code>3.14</code>."
       },
       "hostname_t": {
         "observable": 1,
         "caption": "Hostname",
-        "description": "Unique name assigned to a device connected to a computer network. A domain name in general is an Internet address that can be resolved through the Domain Name System (DNS). For example: <code>r2-d2.example.com</code>.",
-        "regex": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$",
+        "description": "Unique name assigned to a device connected to a computer network. It may be a fully qualified domain name (FQDN). For example:<br><code>r2-d2.example.com.</code>,<br><code>mx.example.com</code>",
+        "regex": "^(?!:\\/\\/)(?=.{1,255}$)((.{1,63}\\.){1,127}(?![0-9]*$)[a-z0-9-]+\\.?)$",
         "type": "string_t",
         "type_name": "String"
       },
@@ -4943,7 +4943,7 @@
         "max_len": 40,
         "observable": 2,
         "caption": "IP Address",
-        "description": "Internet Protocol address (IP address), in either IPv4 or IPv6 format. For example, <code>192.168.200.24</code> or <code>2001:0db8:85a3:0000:0000:8a2e:0370:7334</code>.",
+        "description": "Internet Protocol address (IP address), in either IPv4 or IPv6 format. For example:<br><code>192.168.200.24</code>, <br> <code>2001:0db8:85a3:0000:0000:8a2e:0370:7334</code>.",
         "regex": "((^\\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]).){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\\s*$)|(^\\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)(.(25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)){3}))|:)))(%.+)?\\s*$))",
         "type": "string_t",
         "type_name": "String"
@@ -4960,7 +4960,7 @@
         "max_len": 32,
         "observable": 3,
         "caption": "MAC Address",
-        "description": "Media Access Control (MAC) address. For example: <code>18:36:F3:98:4F:9A</code>.",
+        "description": "Media Access Control (MAC) address. For example:<br><code>18:36:F3:98:4F:9A</code>.",
         "regex": "^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$",
         "type": "string_t",
         "type_name": "String"
@@ -4968,7 +4968,7 @@
       "port_t": {
         "observable": 11,
         "caption": "Port",
-        "description": "The TCP/UDP port number. For example: <code>80</code> or <code>22</code>.",
+        "description": "The TCP/UDP port number. For example:<br><code>80</code>,<br><code>22</code>.",
         "type": "integer_t",
         "type_name": "Integer",
         "range": [
@@ -4979,7 +4979,7 @@
       "process_name_t": {
         "observable": 9,
         "caption": "Process Name",
-        "description": "Process name. For example: <code>Notepad</code>.",
+        "description": "Process name. For example:<br><code>Notepad</code>.",
         "type": "string_t",
         "type_name": "String"
       },
@@ -4998,33 +4998,33 @@
         "max_len": 42,
         "observable": 12,
         "caption": "Subnet",
-        "description": "The subnet represented in a CIDR notation, using the format network_address/prefix_length. The network_address can be in either IPv4 or IPv6 format. The prefix length indicates the number of bits used for the network portion, and the remaining bits are available for host addresses within that subnet. <div>For example:<ul><li>192.168.1.0/24</li><li>2001:0db8:85a3:0000::/64</li></ul></div>",
+        "description": "The subnet represented in a CIDR notation, using the format network_address/prefix_length. The network_address can be in either IPv4 or IPv6 format. The prefix length indicates the number of bits used for the network portion, and the remaining bits are available for host addresses within that subnet. For example:<br><code>192.168.1.0/24</code>,<br><code>2001:0db8:85a3:0000::/64</code>",
         "type": "string_t",
         "type_name": "String"
       },
       "timestamp_t": {
         "caption": "Timestamp",
-        "description": "The timestamp format is the number of milliseconds since the Epoch 01/01/1970 00:00:00 UTC. For example <code>1618524549901</code>.",
+        "description": "The timestamp format is the number of milliseconds since the Epoch 01/01/1970 00:00:00 UTC. For example:<br><code>1618524549901</code>.",
         "type": "long_t",
         "type_name": "Long"
       },
       "url_t": {
         "observable": 6,
         "caption": "URL String",
-        "description": "Uniform Resource Locator (URL) string. For example: <code>http://www.example.com/download/trouble.exe</code>.",
+        "description": "Uniform Resource Locator (URL) string. For example:<br><code>http://www.example.com/download/trouble.exe</code>.",
         "type": "string_t",
         "type_name": "String"
       },
       "username_t": {
         "observable": 4,
         "caption": "User Name",
-        "description": "User name. For example: <code>john_doe</code>.",
+        "description": "User name. For example:<br><code>john_doe</code>.",
         "type": "string_t",
         "type_name": "String"
       },
       "uuid_t": {
         "caption": "UUID",
-        "description": "128-bit universal unique identifier. For example: <code>123e4567-e89b-12d3-a456-42661417400</code>.",
+        "description": "128-bit universal unique identifier. For example:<br><code>123e4567-e89b-12d3-a456-42661417400</code>.",
         "regex": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
         "type": "string_t",
         "type_name": "String"


### PR DESCRIPTION
#### Related Issue: 
Current hostname_t regex, doesn't allow fqdns. However, hostname_t is used by attributes which can and will represent fqdns in the dataset. (`dns_query.hostname`). 

#### Description of changes:
1. ~Updating hostname_t regex to reflect FQDNs. (https://regexr.com/3g5j0)~ Removing the regex for hostname_t, based on all the feedback around it -> no generally agreeable regex for hostname_t, there are multiple RFCs, that touch on it one way or the other allowing a variety of values to be treated as hostnames. Plus OCSF's usage of hostname_t also extends to fields that provide FQDNs.  
2. Minor formatting consistency updates
