### PR TITLE
Update network_connection_info.uid with examples

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1062,7 +1062,7 @@
     },
     "connection_uid": {
       "caption": "Connection Identifier",
-      "description": "The network connection identifier.",
+      "description": "The network connection identifier. For example: An IPv4 address <code>192.168.1.1</code>, an IPv6 address <code>2002:c0a8::/32</code>, a MAC address <code>3d:cb:be:d0:a7:61</code>, etc.",
       "type": "string_t"
     },
     "container": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1062,7 +1062,7 @@
     },
     "connection_uid": {
       "caption": "Connection Identifier",
-      "description": "The network connection identifier. For example: An IPv4 address <code>192.168.1.1</code>, an IPv6 address <code>2002:c0a8::/32</code>, a MAC address <code>3d:cb:be:d0:a7:61</code>, etc.",
+      "description": "The network connection identifier.",
       "type": "string_t"
     },
     "container": {

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -54,7 +54,7 @@
     },
     "uid": {
       "caption": "Connection UID",
-      "description": "The unique identifier of the connection.",
+      "description": "The unique identifier of the connection. For example: An IPv4 address <code>192.168.1.1</code>, an IPv6 address <code>2002:c0a8::/32</code>, a MAC address <code>3d:cb:be:d0:a7:61</code>, etc.",
       "requirement": "recommended"
     }
   }


### PR DESCRIPTION
Provide examples for `network_connection_info.uid` that seems to provide a field for a network address. It's possible this field has other intended uses as well, but this seems to be the right place so adding some examples.

Based on a conversation in OCSF Slack, #schema https://opencybersecu-lz97379.slack.com/archives/C03C2QPSBPB/p1727259577114689

#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1183

#### Description of changes:
* Added 3 examples of `network connection info` `uid` values to make it clear network addresses are intended to be stored there.
