### PR TITLE
Improved descriptions for usage of is_alert.

### DIFF
--- a/events/findings/data_security_finding.json
+++ b/events/findings/data_security_finding.json
@@ -98,6 +98,7 @@
         "is_alert": {
             "profile": null,
             "group": "primary",
+            "description": "Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.",
             "requirement": "recommended"
         },      
         "resources": {

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -43,6 +43,7 @@
     "is_alert": {
       "profile": null,
       "group": "primary",
+      "description": "Indicates that the event is considered to be an alertable signal. For example, an <code>activity_id</code> of 'Create' could constitute an alertable signal and the value would be <code>true</code>, while 'Close' likely would not and either omit the attribute or set its value to <code>false</code>.  Note that other events with the <code>security_control</code> profile may also be deemed alertable signals and may also carry <code>is_alert = true</code> attributes.",
       "requirement": "recommended"
     },
     "remediation": {

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -60,6 +60,7 @@
       "description": "The firewall rule that pertains to the control that triggered the event, if applicable."
     },
     "is_alert": {
+      "description": "Indicates that the event is considered to be an alertable signal. Should be set to <code>true</code> if <code>disposition_id = Alert</code> among other dispositions, and/or <code>risk_level_id</code> or <code>severity_id</code> of the event is elevated. Not all control events will be alertable, for example if <code>disposition_id = Exonerated</code> or <code>disposition_id = Allowed</code>.",
       "requirement": "recommended"
     },
     "malware": {


### PR DESCRIPTION
#### Related Issue: 1177 and PR 1178

#### Description of changes:
Made the descriptions of `is_alert` in the `Detection Finding` class and the `Security Control` profile more specific with examples.
