### PR TITLE
Added vendor_name and model to the device object.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Thankyou! -->
     7. Added `src_url` to the `cvss` object. #1176
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
+    10. Added `vendor_name` and `model` to `device` object.
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -2944,7 +2944,7 @@
     },
     "model": {
       "caption": "Model",
-      "description": "The peripheral device model.",
+      "description": "The model name of an entity. See specific usage.",
       "type": "string_t"
     },
     "modified_time": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -74,6 +74,10 @@
       "description": "The time when the device was last known to have been modified.",
       "requirement": "optional"
     },
+    "model": {
+      "description": "The model of the device. For example <code>ThinkPad X1 Carbon</code>.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The alternate device name, ordinarily as assigned by an administrator. <p><b>Note:</b> The <b>Name</b> could be any other string that helps to identify the device, such as a phone number; for example <code>310-555-1234</code>.</p>",
       "requirement": "optional"
@@ -116,6 +120,10 @@
     "uid_alt": {
       "description": "An alternate unique identifier of the device if any. For example the ActiveDirectory DN.",
       "requirement": "optional"
+    },
+    "vendor_name": {
+      "description": "The vendor for the device. For example <code>Dell</code> or <code>Lenovo</code>",
+      "requirement": "recommended"
     }
   }
 }

--- a/objects/device.json
+++ b/objects/device.json
@@ -122,7 +122,7 @@
       "requirement": "optional"
     },
     "vendor_name": {
-      "description": "The vendor for the device. For example <code>Dell</code> or <code>Lenovo</code>",
+      "description": "The vendor for the device. For example <code>Dell</code> or <code>Lenovo</code>.",
       "requirement": "recommended"
     }
   }

--- a/objects/peripheral_device.json
+++ b/objects/peripheral_device.json
@@ -9,7 +9,7 @@
       "requirement": "required"
     },
     "model": {
-      "descriptioni": "The peripheral device model.",
+      "description": "The peripheral device model.",
       "requirement": "recommended"
     },
     "name": {

--- a/objects/peripheral_device.json
+++ b/objects/peripheral_device.json
@@ -9,6 +9,7 @@
       "requirement": "required"
     },
     "model": {
+      "descriptioni": "The peripheral device model.",
       "requirement": "recommended"
     },
     "name": {


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:
The `Device` object was missing the vendor and model of the device, which is not the same as the vendor of the embedded hardware information (usually BIOS vendor etc.).

Adjusted the descriptions in dictionary to be See specific usage for model to not be only for peripheral device.

