### PR TITLE
Added the profile: null statement to avoid hiding osint when the profile isn't applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,8 @@ Thankyou! -->
     10. Added `vendor_name` and `model` to `device` object.
 
 ### Bugfixes
-1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
+    1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
+    2. Added a fix (profile: null) to `OSINT Inventory Info` so that the `osint` attribute is present w/o the OSINT profile, per the class definition.
 
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178

--- a/events/discovery/osint_inventory_info.json
+++ b/events/discovery/osint_inventory_info.json
@@ -11,6 +11,7 @@
             "requirement": "optional"
         },
         "osint": {
+            "profile": null,
             "description": "The OSINT that is being discovered by an inventory process.",
             "group": "primary",
             "requirement": "required"


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
Bug fix to avoid hiding the `osint` primary attribute when the optional `OSINT` profile isn't selected.