### PR TITLE
Removed constraint from group_management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Thankyou! -->
     1. Added `evidences` to `compliance_finding` class. #1157
     2. Added `is_alert` to `detection_finding` and `data_security_finding` classes. #1178
     3. Added `risk_details` to `data_security_finding` class. #1178
-    4. Removed constraint from `group_management` class
+    4. Removed constraint from `group_management` class. #1193
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,8 @@ Thankyou! -->
 * #### Event Classes
     1. Added `evidences` to `compliance_finding` class. #1157
     2. Added `is_alert` to `detection_finding` and `data_security_finding` classes. #1178
-    3. Added `risk_details` to `data_security_finding` class
+    3. Added `risk_details` to `data_security_finding` class. #1178
+    4. Removed constraint from `group_management` class
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     2. Added `has_mfa` to `user` object. #1155

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }


### PR DESCRIPTION
#### Related Issue:  N/A (Slack discussion)

#### Description of changes:
The `Group Management` class had an unnecessary restriction to populate either `user` or `privileges`.  This is too stringent for the case where the group is created or deleted where no users or privileges are known or relevant.  Therefore the PR removes the constraint.