### PR TITLE
Add working_directory to the process object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Thankyou! -->
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
+    8. Added `current_working_directory` as a `string_t`. #1195
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -75,6 +76,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
+    11. Added `current_working_directory` to `process` object. #1195
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Thankyou! -->
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
-    8. Added `current_working_directory` as a `string_t`. #1195
+    8. Added `working_directory` as a `string_t`. #1195
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -76,7 +76,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
-    11. Added `current_working_directory` to `process` object. #1195
+    11. Added `working_directory` to `process` object. #1195
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -1184,11 +1184,6 @@
       "description": "Criticality of a resource/object in question",
       "type": "string_t"
     },
-    "current_working_directory": {
-      "caption": "Current Working Directory",
-      "description": "The current working directory of a process.",
-      "type": "string_t"
-    },
     "customer_uid": {
       "caption": "Customer UID",
       "description": "The unique customer identifier.",
@@ -4861,6 +4856,11 @@
       "caption": "WHOIS",
       "description": "The resources of a WHOIS record for a given domain. This can include domain names, IP address blocks, autonomous system information, and/or contact and registration information for a domain.",
       "type": "whois"
+    },
+    "working_directory": {
+      "caption": "Working Directory",
+      "description": "The working directory of a process.",
+      "type": "string_t"
     },
     "x_forwarded_for": {
       "caption": "X-Forwarded-For",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1184,6 +1184,11 @@
       "description": "Criticality of a resource/object in question",
       "type": "string_t"
     },
+    "current_working_directory": {
+      "caption": "Current Working Directory",
+      "description": "The current working directory of a process.",
+      "type": "string_t"
+    },
     "customer_uid": {
       "caption": "Customer UID",
       "description": "The unique customer identifier.",

--- a/objects/process.json
+++ b/objects/process.json
@@ -14,6 +14,9 @@
     "cmd_line": {
       "requirement": "recommended"
     },
+    "current_working_directory": {
+      "requirement": "optional"
+    },
     "created_time": {
       "description": "The time when the process was created/started.",
       "requirement": "recommended"

--- a/objects/process.json
+++ b/objects/process.json
@@ -14,9 +14,6 @@
     "cmd_line": {
       "requirement": "recommended"
     },
-    "current_working_directory": {
-      "requirement": "optional"
-    },
     "created_time": {
       "description": "The time when the process was created/started.",
       "requirement": "recommended"
@@ -71,6 +68,9 @@
     "user": {
       "description": "The user under which this process is running.",
       "requirement": "recommended"
+    },
+    "working_directory": {
+      "requirement": "optional"
     },
     "xattributes": {
       "description": "An unordered collection of zero or more name/value pairs that represent a process extended attribute.",


### PR DESCRIPTION
#### Related Issue: 
#1190

#### Description of changes:
Add optional `working_directory` field to the process object, with type `string_t`.

![image](https://github.com/user-attachments/assets/41761026-27a7-4335-9793-4c0f9510f879)

