### PR TITLE
Add is_deleted to the file object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Thankyou! -->
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
+    8. Added `is_deleted` a `boolean_t`. #1196
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -75,6 +76,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
+    11. Added `is_deleted` to `file` object. #1196
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -2450,7 +2450,7 @@
     },
     "is_deleted": {
       "caption": "Deleted",
-      "description": "Indicates if the file was deleted from the filesystem.",
+      "description": "Indicates if the entity was deleted. See specific usage.",
       "type": "boolean_t"
     },
     "is_exploit_available": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2448,6 +2448,11 @@
       "description": "The indication of whether the value is from a default value name. For example, the value name could be missing.",
       "type": "boolean_t"
     },
+    "is_deleted": {
+      "caption": "Deleted",
+      "description": "Indicates if the file was deleted from the filesystem.",
+      "type": "boolean_t"
+    },
     "is_exploit_available": {
       "caption": "Exploit Availability",
       "description": "Indicates if an exploit or a PoC (proof-of-concept) is available for the reported vulnerability.",

--- a/objects/file.json
+++ b/objects/file.json
@@ -49,6 +49,9 @@
     "hashes": {
       "requirement": "recommended"
     },
+    "is_deleted": {
+      "requirement": "optional"
+    },
     "is_system": {
       "requirement": "optional"
     },

--- a/objects/file.json
+++ b/objects/file.json
@@ -50,6 +50,7 @@
       "requirement": "recommended"
     },
     "is_deleted": {
+      "description": "Indicates if the file was deleted from the filesystem.",
       "requirement": "optional"
     },
     "is_system": {


### PR DESCRIPTION
#### Related Issue: 
Fixes #1192

#### Description of changes:

Adds optional `is_deleted` field to the file object, with type `boolean_t`.

In the Dictionary:
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/8133800f-a472-4163-9a38-18ce5148cde3">

In the File object:
<img width="1075" alt="image" src="https://github.com/user-attachments/assets/39d875f3-9014-444c-826b-7a11e5f89cd9">
