### PR TITLE
Addressed a few issues with recent Script Activity PR.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Thankyou! -->
     5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
+    8. Added `is_script_content_truncated` as a `boolean_t`. #1198
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -75,6 +76,8 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
+    11. Added `is_script_content_truncated` to `script` object. #1198
+    12. Added entry for VBA macros to `type_id` enum in `script` object. #1198
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -2503,6 +2503,11 @@
       "description": "The indication of whether this is a lease/session renewal event.",
       "type": "boolean_t"
     },
+    "is_script_content_truncated": {
+      "caption": "Is Script Content Truncated",
+      "description": "Indicates if the contents of the <code>script_content</code> attribute have been truncated.",
+      "type": "boolean_t"
+    },
     "is_secure": {
       "caption": "Secure",
       "description": "The cookie attribute indicates that cookies are sent to the server only when the request is encrypted using the HTTPS protocol.",
@@ -4009,7 +4014,7 @@
     "script_content": {
       "observable": 36,
       "caption": "Script Content",
-      "description": "The script content, normalized to UTF-8 encoding irrespective of its original encoding.",
+      "description": "The script content, normalized to UTF-8 encoding irrespective of its original encoding. When emitting this attribute, it may be appropriate to truncate large scripts. When consuming this attribute, large scripts should be anticipated.",
       "type": "string_t"
     },
     "section_a": {

--- a/objects/script.json
+++ b/objects/script.json
@@ -12,8 +12,11 @@
       "description": "An array of the script's cryptographic hashes. Note that these hashes are calculated on the script in its original encoding, and not on the normalized UTF-8 encoding found in the <code>script_content</code> attribute.",
       "requirement": "recommended"
     },
+    "is_script_content_truncated": {
+      "requirement": "optional"
+    },
     "parent_uid": {
-      "description": "When a script is a dynamically executed sub-script, and when the underlying script engine supports use of the <code>uid</code> attribute, this <code>parent_uid</code> attribute identifies the parent script.",
+      "description": "This attribute relates a sub-script to a parent script having the matching <code>uid</code> attribute. In the case of PowerShell, sub-script execution can be identified by matching the activity correlation ID of the raw ETW events provided by the OS.",
       "requirement": "optional"
     },
     "script_content": {
@@ -49,6 +52,9 @@
         "6": {
           "caption": "Unix Shell"
         },
+        "7": {
+          "caption": "VBA"
+        },
         "99": {
           "caption": "Other",
           "description": "The script type is not mapped. See the <code>type</code> attribute which contains an event source specific value."
@@ -56,7 +62,7 @@
       }
     },
     "uid": {
-      "description": "Some script engines assign a unique ID to each individual execution of a given script, e.g. PowerShell's Script Block ID. This <code>uid</code> attribute enables a dynamically executed sub-script to refer to its parent.",
+      "description": "Some script engines assign a unique ID to each individual execution of a given script. This attribute captures that unique ID. In the case of PowerShell, the unique ID corresponds to the <code>ScriptBlockId</code> in the raw ETW events provided by the OS.",
       "requirement": "optional"
     }
   }


### PR DESCRIPTION
#### Related Issue: 

#1197 

#### Description of changes:

As described in the issue but to recap:
- Added an ~`is_script_truncated`~ `is_script_content_truncated` flag.
- Added an entry to the `type_id` enum in the `script` object.
- Improved descriptions in previous PR as requested at the time.