### PR TITLE
add `http_headers` to `email`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
-    11. Added `http_headers` to `email` object. 
+    11. Added `http_headers` to `email` object. #1199
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Thankyou! -->
     8. Added `advisory`, `exploit_last_seen_time` to the `vulnerability` object. #1176
     9. Added `related_cwes` to the `cve` object. #1176
     10. Added `vendor_name` and `model` to `device` object.
+    11. Added `http_headers` to `email` object. 
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/objects/email.json
+++ b/objects/email.json
@@ -20,6 +20,9 @@
     "from": {
       "requirement": "required"
     },
+    "http_headers": {
+      "requirement": "optional"
+    },
     "message_uid": {
       "requirement": "recommended"
     },


### PR DESCRIPTION
#### Description of changes:

Adds `http_headers` to `email` - accounts for vendor specific (Google Workspace Email, Entra ID Messages, etc.) headers