### PR TITLE
Add Community ID to Network Connection Info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,6 +360,7 @@ n/a
     15. Added firewall, router, switch, hub to endpoint `type_id` enum. #921
     16. Added `is_vpn` to the `session` object. #922
     17. Added `state` to `network_connection_info` object. #932
+    18. Added `community_id` to `network_connection_info` object. #1202
 
 ### Bugfixes
 `n/a`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Thankyou! -->
     9. Added `is_deleted` a `boolean_t`. #1196
     10. Added `is_script_content_truncated` as a `boolean_t`. #1198
     11. Added `body_length` as an `integer_t` #1200
-    12. Added `community_id` as a `string_t`. #1202
+    12. Added `community_uid` as a `string_t`. #1202
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -365,7 +365,7 @@ n/a
     15. Added firewall, router, switch, hub to endpoint `type_id` enum. #921
     16. Added `is_vpn` to the `session` object. #922
     17. Added `state` to `network_connection_info` object. #932
-    18. Added `community_id` to `network_connection_info` object. #1202
+    18. Added `community_uid` to `network_connection_info` object. #1202
 
 ### Bugfixes
 `n/a`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Thankyou! -->
     9. Added `is_deleted` a `boolean_t`. #1196
     10. Added `is_script_content_truncated` as a `boolean_t`. #1198
     11. Added `body_length` as an `integer_t` #1200
+    12. Added `community_id` as a `string_t`. #1202
+
 * #### Objects
     1. Added `environment_variable` object. #1172
     2. Added `advisory` object. #1176

--- a/dictionary.json
+++ b/dictionary.json
@@ -949,6 +949,11 @@
       "description": "The user-provided comment.",
       "type": "string_t"
     },
+    "community_id": {
+      "caption": "Community ID",
+      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community Id</a> of the network connection.",
+      "type": "string_t"
+    },
     "company_name": {
       "caption": "Company Name",
       "description": "The name of the company that published the file. For example: <code>Microsoft Corporation</code>.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -954,9 +954,9 @@
       "description": "The user-provided comment.",
       "type": "string_t"
     },
-    "community_id": {
+    "community_uid": {
       "caption": "Community ID",
-      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community Id</a> of the network connection.",
+      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community ID</a> of the network connection.",
       "type": "string_t"
     },
     "company_name": {

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -10,6 +10,10 @@
     "boundary_id": {
       "requirement": "recommended"
     },
+    "community_id": {
+      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community Id</a> of the network connection.",
+      "requirement": "optional"
+    },
     "direction": {
       "requirement": "optional"
     },

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -10,7 +10,7 @@
     "boundary_id": {
       "requirement": "recommended"
     },
-    "community_id": {
+    "community_uid": {
       "requirement": "optional"
     },
     "direction": {

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -11,7 +11,6 @@
       "requirement": "recommended"
     },
     "community_id": {
-      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community Id</a> of the network connection.",
       "requirement": "optional"
     },
     "direction": {


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

The `Network Connection Object` did not have a Community ID. In a [Slack thread](https://opencybersecu-lz97379.slack.com/archives/C03KF0TELR0/p1724701632419199) we found that there is consensus that adding this makes sense.
