### PR TITLE
Removed redundant attribute from Windows extension to `startup_item` object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ Thankyou! -->
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
     2. Added a fix (profile: null) to `OSINT Inventory Info` so that the `osint` attribute is present w/o the OSINT profile, per the class definition.
+    3. Removed redundant `name` attribute from Windows extension to the `startup_item` object for consistency with other extensions. #1203
 
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178

--- a/extensions/windows/objects/startup_item.json
+++ b/extensions/windows/objects/startup_item.json
@@ -1,6 +1,5 @@
 {
   "caption": "Startup Item",
-  "name": "startup_item",
   "description": "The startup item object describes an application component that has associated startup criteria and configurations.",
   "extends": "startup_item",
   "attributes": {


### PR DESCRIPTION
#### Issue: 

I raised this issue in Slack and it was discussed at the weekly OCSF call on 8th October 2024. It was agreed that I would submit this PR. Apologies for the delay!

A recent PR extended `startup_item` for Windows. The intenion of the author of that PR was that the extended object would have the same name as the base object. This is normally achieved by omiting the `name` attribute from the extended object's definition. However, the `name` attribute was explicitly specified in that PR. Although this is permitted by the metaschema, it had the effect of breaking some code generation tooling. It also meant that the extension was inconsistent with other non-renaming object extensions.

#### Description of changes:

The `name` attribute has been removed from the Windows extension to the `startup_item` object.
