### PR TITLE
Updated Description for Network Connection Information object.

### DIFF
--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -1,6 +1,6 @@
 {
   "caption": "Network Connection Information",
-  "description": "The Network Connection Information object describes characteristics of a network connection. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:NetworkSession/'>d3f:NetworkSession</a>.",
+  "description": "The Network Connection Information object describes characteristics of an OSI Transport Layer communication, including TCP and UDP. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:NetworkSession/'>d3f:NetworkSession</a>.",
   "extends": "object",
   "name": "network_connection_info",
   "attributes": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
The existing `network_connection_info` object is applicable to more than TCP / connection based protocols, despite its name including "connection."  The PR makes clear that TCP, UDP or other OSI Transport Layer protocols may be valid as well.

From https://osi-model.com/transport-layer:
The best-known transport protocol of TCP/IP is the Transmission Control Protocol (TCP), and lent its name to the title of the entire suite. It is used for connection-oriented transmissions, whereas the connectionless User Datagram Protocol (UDP) is used for simpler messaging transmissions. 