### PR TITLE
Adding a Tags - key:value pair object to the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,19 +48,21 @@ Thankyou! -->
     3. Added `Startup Item Query` event class. #1119
 * #### Dictionary Attributes
     1. Added `has_mfa` as a `boolean_t`. #1155
-    2. Added `environment_variables` as an array of `environment_variable`. #1172
+    2. Added `environment_variables` as an array of `environment_variable` object. #1172
     3. Added `is_attribute_truncated` as a `boolean_t`. #1172
     4. Added `forward_addr` as an `email_t`. #1179
-    5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` respectively. #1176
+    5. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` objects respectively. #1176
     6. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
     7. Added `is_alert` as a `boolean_t`, #1179
     8. Added `working_directory` as a `string_t`. #1195
     9. Added `is_deleted` a `boolean_t`. #1196
     10. Added `is_script_content_truncated` as a `boolean_t`. #1198
     11. Added `body_length` as an `integer_t` #1200
+    12. Added `tags` as n array of `tag` object. #1207
 * #### Objects
     1. Added `environment_variable` object. #1172
     2. Added `advisory` object. #1176
+    3. Added a `tag` object. #1207
 
 ### Improved
 * #### Event Classes
@@ -85,6 +87,7 @@ Thankyou! -->
     14. Added `is_script_content_truncated` to `script` object. #1198
     15. Added entry for VBA macros to `type_id` enum in `script` object. #1198
     16. Added `body_length` to the `http_response` and `http_request` objects. #1200
+    17. Added `tags` to the `account`, `container`, `image`, `ldap_person`, `metadata`, `resource_details`, `service`, `web_resource` objects. #1207
 
 
 ### Bugfixes
@@ -101,6 +104,7 @@ Thankyou! -->
 1. Deprecated `project_uid` in favor of `account.uid`. #1166
 2. Deprecated `kb_article_list` in favor of `advisory` in the vulnerability object. #1176
 3. Deprecated `cwe` in favor of `related_cwes` in the `cve` object. #1176
+4. Deprecated `tag` in favor of `labels` or `tags` in `image` & `container` object. #1207
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/dictionary.json
+++ b/dictionary.json
@@ -76,7 +76,6 @@
     "activity_id": {
       "caption": "Activity ID",
       "description": "The normalized identifier of the activity that triggered the event.",
-      "suppress_checks": ["sibling_convention"],
       "sibling": "activity_name",
       "type": "integer_t",
       "enum": {
@@ -88,7 +87,10 @@
           "caption": "Other",
           "description": "The event activity is not mapped. See the <code>activity_name</code> attribute, which contains a data source specific value."
         }
-      }
+      },
+      "suppress_checks": [
+        "sibling_convention"
+      ]
     },
     "activity_name": {
       "caption": "Activity",
@@ -105,7 +107,7 @@
       "description": "The permissions that were granted in a platform-native format. See specific usage.",
       "type": "integer_t"
     },
-    "advisory":{
+    "advisory": {
       "caption": "Security Advisory",
       "description": "Detail about the security advisory, that is used to publicly disclose cybersecurity vulnerabilities by a vendor.",
       "type": "advisory"
@@ -1179,10 +1181,10 @@
       "type": "user"
     },
     "credential_uid": {
+      "observable": 19,
       "caption": "User Credential ID",
       "description": "The unique identifier of the user's credential. For example, AWS Access Key ID.",
-      "type": "string_t",
-      "observable": 19
+      "type": "string_t"
     },
     "criticality": {
       "caption": "Criticality",
@@ -1670,9 +1672,16 @@
       "description": "The Domain-based Message Authentication, Reporting and Conformance (DMARC) policy status.",
       "type": "string_t"
     },
+    "dnssec_status": {
+      "caption": "DNSSEC Status",
+      "description": "The normalized value of dnssec_status_id.",
+      "type": "string_t"
+    },
     "dnssec_status_id": {
       "caption": "DNSSEC Status ID",
       "description": "Describes the normalized status of DNS Security Extensions (DNSSEC) for a domain.",
+      "sibling": "dnssec_status",
+      "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
@@ -1690,14 +1699,7 @@
           "caption": "Other",
           "description": "The DNSSEC status is not mapped. See the <code>dnssec_status</code> attribute, which contains a data source specific value."
         }
-      },
-      "sibling": "dnssec_status",
-      "type": "integer_t"
-    },
-    "dnssec_status": {
-      "caption": "DNSSEC Status",
-      "description": "The normalized value of dnssec_status_id.",
-      "type": "string_t"
+      }
     },
     "domain": {
       "caption": "Domain",
@@ -1712,8 +1714,8 @@
     "domain_contacts": {
       "caption": "Domain Contacts",
       "description": "An array of <code>Domain Contact</code> objects.",
-      "is_array": true,
-      "type": "domain_contact"
+      "type": "domain_contact",
+      "is_array": true
     },
     "driver": {
       "caption": "Kernel Driver",
@@ -1894,7 +1896,7 @@
       "description": "The expiration time. See specific usage.",
       "type": "timestamp_t"
     },
-    "exploit_last_seen_time":{
+    "exploit_last_seen_time": {
       "caption": "Exploit Last Seen Time",
       "description": "The time when the exploit was most recently observed.",
       "type": "timestamp_t"
@@ -2438,6 +2440,11 @@
       "description": "A determination if a policy, rule, or enforcement action was applied.",
       "type": "boolean_t"
     },
+    "is_attribute_truncated": {
+      "caption": "Attribute Truncated",
+      "description": "The indication of whether or not an attribute is truncated.",
+      "type": "boolean_t"
+    },
     "is_cleartext": {
       "caption": "Cleartext Credentials",
       "description": "Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>",
@@ -2553,11 +2560,6 @@
       "description": "The event occurred on a trusted device.",
       "type": "boolean_t"
     },
-    "is_attribute_truncated": {
-      "caption": "Attribute Truncated",
-      "description": "The indication of whether or not an attribute is truncated.",
-      "type": "boolean_t"
-    },
     "is_vpn": {
       "caption": "VPN Session",
       "description": "The indication of whether the session is a VPN session.",
@@ -2653,7 +2655,7 @@
     },
     "labels": {
       "caption": "Labels",
-      "description": "The list of labels attached to an event, object, or attribute.",
+      "description": "The list of labels attached to an entity. See specific usage.",
       "type": "string_t",
       "is_array": true
     },
@@ -2982,6 +2984,12 @@
       "description": "The name of the entity. See specific usage.",
       "type": "string_t"
     },
+    "name_servers": {
+      "caption": "Name Servers",
+      "description": "A collection of name servers related to a domain registration or other record.",
+      "type": "string_t",
+      "is_array": true
+    },
     "namespace": {
       "caption": "Namespace",
       "description": "The namespace is useful in merger or acquisition situations. For example, when similar entities exist that you need to keep separate.",
@@ -2991,12 +2999,6 @@
       "caption": "Namespace PID",
       "description": "If running under a process namespace (such as in a container), the process identifier within that process namespace.",
       "type": "integer_t"
-    },
-    "name_servers": {
-      "caption": "Name Servers",
-      "description": "A collection of name servers related to a domain registration or other record.",
-      "is_array": true,
-      "type": "string_t"
     },
     "network_driver": {
       "caption": "Network Driver",
@@ -3099,7 +3101,6 @@
     "opcode_id": {
       "caption": "DNS Opcode ID",
       "description": "The DNS opcode ID specifies the normalized query message type as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc5395.html'>RFC-5395</a>.",
-      "suppress_checks": ["enum_convention"],
       "type": "integer_t",
       "enum": {
         "0": {
@@ -3134,7 +3135,10 @@
           "caption": "Other",
           "description": "The DNS Opcode is not defined by the RFC. See the <code>opcode</code> attribute, which contains a data source specific value."
         }
-      }
+      },
+      "suppress_checks": [
+        "enum_convention"
+      ]
     },
     "open_mask": {
       "caption": "Open Mask",
@@ -3175,6 +3179,12 @@
       "caption": "OS",
       "description": "The endpoint operating system.",
       "type": "os"
+    },
+    "osint": {
+      "caption": "OSINT",
+      "description": "The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.",
+      "type": "osint",
+      "is_array": true
     },
     "ou_name": {
       "caption": "Org Unit Name",
@@ -3715,18 +3725,6 @@
       "type": "analytic",
       "is_array": true
     },
-    "related_events": {
-      "caption": "Related Events",
-      "description": "Describes events and/or other findings related to the finding as identified by the security product.",
-      "type": "related_event",
-      "is_array": true
-    },
-    "related_vulnerabilities": {
-      "caption": "Related Vulnerability IDs",
-      "description": "List of vulnerability IDs (e.g. CVE ID) that are related to this vulnerability.",
-      "type": "string_t",
-      "is_array": true
-    },
     "related_cves": {
       "caption": "Related CVEs",
       "description": "Describes Common Vulnerabilities and Exposures <a target='_blank' href='https://cve.mitre.org/'>(CVE)</a> entries that are related to an entity. See specific usage.",
@@ -3737,6 +3735,18 @@
       "caption": "Related CWEs",
       "description": "Describes Common Weakness Enumeration <a target='_blank' href='https://cwe.mitre.org/'>(CWE)</a> entries that are related to an entity. See specific usage.",
       "type": "cwe",
+      "is_array": true
+    },
+    "related_events": {
+      "caption": "Related Events",
+      "description": "Describes events and/or other findings related to the finding as identified by the security product.",
+      "type": "related_event",
+      "is_array": true
+    },
+    "related_vulnerabilities": {
+      "caption": "Related Vulnerability IDs",
+      "description": "List of vulnerability IDs (e.g. CVE ID) that are related to this vulnerability.",
+      "type": "string_t",
       "is_array": true
     },
     "relay": {
@@ -3830,7 +3840,6 @@
     "risk_level_id": {
       "caption": "Risk Level ID",
       "description": "The normalized risk level id.",
-      "suppress_checks": ["enum_convention"],
       "sibling": "risk_level",
       "type": "integer_t",
       "enum": {
@@ -3853,7 +3862,10 @@
           "caption": "Other",
           "description": "The risk level is not mapped. See the <code>risk_level</code> attribute, which contains a data source specific value."
         }
-      }
+      },
+      "suppress_checks": [
+        "enum_convention"
+      ]
     },
     "risk_score": {
       "caption": "Risk Score",
@@ -3873,6 +3885,7 @@
     "run_mode_ids": {
       "caption": "Run Mode IDs",
       "description": "The list of normalized identifiers that describe application attributes when it is running. See specific usage.",
+      "sibling": "run_modes",
       "type": "integer_t",
       "enum": {
         "0": {
@@ -3884,8 +3897,7 @@
           "description": "The run mode is not mapped. See the <code>run_modes</code> attribute, which contains data source specific values."
         }
       },
-      "is_array": true,
-      "sibling": "run_modes"
+      "is_array": true
     },
     "run_modes": {
       "caption": "Run Modes",
@@ -4231,8 +4243,8 @@
     "signatures": {
       "caption": "Digital Signatures",
       "description": "A collection of <code>Digital Signature</code> objects.",
-      "is_array": true,
-      "type": "digital_signature"
+      "type": "digital_signature",
+      "is_array": true
     },
     "size": {
       "caption": "Size",
@@ -4314,6 +4326,8 @@
     "start_type_id": {
       "caption": "Start Type ID",
       "description": "The start type ID of a service or application.",
+      "sibling": "start_type",
+      "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
@@ -4355,9 +4369,7 @@
           "caption": "Other",
           "description": "The start type is not mapped. See the <code>start_type</code> attribute, which contains a data source specific value."
         }
-      },
-      "type": "integer_t",
-      "sibling": "start_type"
+      }
     },
     "startup_item": {
       "caption": "Startup Item",
@@ -4471,8 +4483,8 @@
     "subdomains": {
       "caption": "Subdomains",
       "description": "An array of subdomain strings. Can be used to collect several subdomains such as those from Domain Generation Algorithms (DGAs).",
-      "is_array": true,
-      "type": "string_t"
+      "type": "string_t",
+      "is_array": true
     },
     "subject": {
       "caption": "Subject Details",
@@ -4537,7 +4549,17 @@
     "tag": {
       "caption": "Image Tag",
       "description": "The image tag. For example: <code>1.11-alpine</code>.",
-      "type": "string_t"
+      "type": "string_t",
+      "@deprecated": {
+        "message": "Use the <code> labels or tags </code> attribute instead.",
+        "since": "1.4.0"
+      }
+    },
+    "tags": {
+      "caption": "Tags",
+      "description": "The list of tags; <code>{key:value}</code> pairs attached to an entity. See specific usage.",
+      "type": "tag",
+      "is_array": true
     },
     "tcp_flags": {
       "caption": "TCP Flags",
@@ -4564,11 +4586,10 @@
       "description": "The time when the entity was terminated. See specific usage.",
       "type": "timestamp_t"
     },
-    "osint": {
-      "caption": "OSINT",
-      "description": "The OSINT (Open Source Intelligence) object contains details related to an indicator such as the indicator itself, related indicators, geolocation, registrar information, subdomains, analyst commentary, and other contextual information. This information can be used to further enrich a detection or finding by providing decisioning support to other analysts and engineers.",
-      "is_array": true,
-      "type": "osint"
+    "ticket": {
+      "caption": "Ticket",
+      "description": "The linked ticket in the ticketing system.",
+      "type": "ticket"
     },
     "tid": {
       "caption": "Thread ID",
@@ -4584,11 +4605,6 @@
       "caption": "Timezone Offset",
       "description": "The number of minutes that the reported event <code>time</code> is ahead or behind UTC, in the range -1,080 to +1,080.",
       "type": "integer_t"
-    },
-    "ticket": {
-      "caption": "Ticket",
-      "description": "The linked ticket in the ticketing system.",
-      "type": "ticket"
     },
     "title": {
       "caption": "Title",

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -3,9 +3,6 @@
   "description": "The Resource object contains attributes that provide information about a particular resource. It serves as a base object, offering attributes that help identify and classify the resource effectively.",
   "extends": "_entity",
   "name": "_resource",
-  "profiles": [
-    "data_classification"
-  ],
   "attributes": {
     "$include": [
       "profiles/data_classification.json"
@@ -15,11 +12,15 @@
       "requirement": "optional"
     },
     "labels": {
-      "description": "The list of labels/tags associated to a resource.",
+      "description": "The list of labels associated to the resource.",
       "requirement": "optional"
     },
     "name": {
       "description": "The name of the resource."
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the resource.",
+      "requirement": "optional"
     },
     "type": {
       "description": "The resource type as defined by the event source.",
@@ -28,5 +29,8 @@
     "uid": {
       "description": "The unique identifier of the resource."
     }
-  }
+  },
+  "profiles": [
+    "data_classification"
+  ]
 }

--- a/objects/account.json
+++ b/objects/account.json
@@ -1,12 +1,20 @@
 {
   "caption": "Account",
   "description": "The Account object contains details about the account that initiated or performed a specific activity within a system or application. Additionally, the Account object refers to logical Cloud and Software-as-a-Service (SaaS) based containers such as AWS Accounts, Azure Subscriptions, Oracle Cloud Compartments, Google Cloud Projects, and otherwise.",
-  "name": "account",
   "extends": "_entity",
+  "name": "account",
   "attributes": {
+    "labels": {
+      "description": "The list of labels associated to the account.",
+      "requirement": "optional"
+    },
     "name": {
-      "description": "The name of the account (e.g. <code> GCP Project name </code>, <code> Linux Account name </code> or <code> AWS Account name </code>).",
-      "observable": 34
+      "observable": 34,
+      "description": "The name of the account (e.g. <code> GCP Project name </code>, <code> Linux Account name </code> or <code> AWS Account name</code>)."
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the account.",
+      "requirement": "optional"
     },
     "type": {
       "caption": "Type",
@@ -16,11 +24,8 @@
     "type_id": {
       "caption": "Type ID",
       "description": "The normalized account type identifier.",
+      "requirement": "recommended",
       "enum": {
-        "99": {
-          "caption": "Other",
-          "description": "The account type is not mapped."
-        },
         "0": {
           "caption": "Unknown",
           "description": "The account type is unknown."
@@ -78,18 +83,16 @@
         },
         "18": {
           "caption": "Email Account"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The account type is not mapped."
         }
-      },
-      "requirement": "recommended"
+      }
     },
     "uid": {
-      "description": "The unique identifier of the account (e.g. <code> AWS Account ID </code>, <code> OCID </code>, <code> GCP Project ID </code>, <code> Azure Subscription ID </code>, <code> Google Workspace Customer ID </code>, or <code> M365 Tenant UID </code>).",
-      "observable": 35
-    },
-    "labels": {
-      "caption": "Labels",
-      "description": "The list of labels/tags associated to the account.",
-      "requirement": "optional"
+      "observable": 35,
+      "description": "The unique identifier of the account (e.g. <code> AWS Account ID </code>, <code> OCID </code>, <code> GCP Project ID </code>, <code> Azure Subscription ID </code>, <code> Google Workspace Customer ID </code>, or <code> M365 Tenant UID</code>)."
     }
   }
 }

--- a/objects/container.json
+++ b/objects/container.json
@@ -1,24 +1,28 @@
 {
-  "caption": "Container",
   "observable": 27,
-  "name": "container",
+  "caption": "Container",
   "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd.",
   "extends": "object",
+  "name": "container",
   "attributes": {
-    "name": {
-      "description": "The container name.",
+    "hash": {
+      "description": "Commit hash of image created for docker or the SHA256 hash of the container. For example: <code>13550340a8681c84c861aac2e5b440161c2b33a3e4f302ac680ca5b686de48de</code>.",
       "requirement": "recommended"
     },
     "image": {
       "description": "The container image used as a template to run the container.",
       "requirement": "recommended"
     },
-    "runtime": {
+    "labels": {
+      "description": "The list of labels associated to the container.",
       "requirement": "optional"
     },
-    "uid": {
-      "description": "The full container unique identifier for this instantiation of the container. For example: <code>ac2ea168264a08f9aaca0dfc82ff3551418dfd22d02b713142a6843caa2f61bf</code>.",
+    "name": {
+      "description": "The container name.",
       "requirement": "recommended"
+    },
+    "network_driver": {
+      "requirement": "optional"
     },
     "orchestrator": {
       "requirement": "optional"
@@ -26,20 +30,24 @@
     "pod_uuid": {
       "requirement": "optional"
     },
-    "tag": {
-      "description": "The tag used by the container. It can indicate version, format, OS.",
+    "runtime": {
       "requirement": "optional"
     },
     "size": {
       "description": "The size of the container image.",
       "requirement": "recommended"
     },
-    "hash": {
-      "description": "Commit hash of image created for docker or the SHA256 hash of the container. For example: <code>13550340a8681c84c861aac2e5b440161c2b33a3e4f302ac680ca5b686de48de</code>.",
-      "requirement": "recommended"
-    },
-    "network_driver": {
+    "tag": {
+      "description": "The tag used by the container. It can indicate version, format, OS.",
       "requirement": "optional"
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the container.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The full container unique identifier for this instantiation of the container. For example: <code>ac2ea168264a08f9aaca0dfc82ff3551418dfd22d02b713142a6843caa2f61bf</code>.",
+      "requirement": "recommended"
     }
   },
   "constraints": {

--- a/objects/http_header.json
+++ b/objects/http_header.json
@@ -5,11 +5,11 @@
   "name": "http_header",
   "attributes": {
     "name": {
-      "description": "The name of the header",
+      "description": "The name of the HTTP header.",
       "requirement": "required"
     },
     "value": {
-      "description": "The value of the header",
+      "description": "The value of the HTTP header.",
       "requirement": "required"
     }
   }

--- a/objects/image.json
+++ b/objects/image.json
@@ -19,7 +19,7 @@
       "requirement": "optional"
     },
     "tags": {
-      "description": "The list of tags; <code>{key:value}</code> pairs associated to the account.",
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the image.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/image.json
+++ b/objects/image.json
@@ -1,11 +1,11 @@
 {
   "caption": "Image",
-  "name": "image",
   "description": "The Image object provides a description of a specific Virtual Machine (VM) or Container image. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/'>d3f:ContainerImage</a>.",
   "extends": "_entity",
+  "name": "image",
   "attributes": {
     "labels": {
-      "description": "The image labels.",
+      "description": "The list of labels associated to the image.",
       "requirement": "optional"
     },
     "name": {
@@ -16,6 +16,10 @@
       "requirement": "optional"
     },
     "tag": {
+      "requirement": "optional"
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the account.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -1,8 +1,8 @@
 {
   "caption": "LDAP Person",
   "description": "The additional LDAP attributes that describe a person.",
-  "name": "ldap_person",
   "extends": "object",
+  "name": "ldap_person",
   "attributes": {
     "cost_center": {
       "requirement": "optional"
@@ -65,6 +65,10 @@
       "requirement": "optional"
     },
     "surname": {
+      "requirement": "optional"
+    },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the user.",
       "requirement": "optional"
     }
   }

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -3,9 +3,6 @@
   "description": "The Metadata object describes the metadata associated with the event. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Metadata/'>d3f:Metadata</a>.",
   "extends": "object",
   "name": "metadata",
-  "profiles": [
-    "data_classification"
-  ],
   "attributes": {
     "$include": [
       "profiles/data_classification.json"
@@ -23,7 +20,7 @@
       "requirement": "optional"
     },
     "labels": {
-      "description": "<p>The list of category labels attached to the event or specific attributes. Labels are user defined tags or aliases added at normalization time.</p>For example: <code>[\"network\", \"connection.ip:destination\", \"device.ip:source\"]</code>",
+      "description": "The list of labels attached to the event. For example: <code>[\"sample\", \"dev\"]</code>",
       "requirement": "optional"
     },
     "log_level": {
@@ -41,11 +38,11 @@
     "logged_time": {
       "requirement": "optional"
     },
-    "modified_time": {
-      "description": "The time when the event was last modified or enriched.",
+    "loggers": {
       "requirement": "optional"
     },
-    "loggers": {
+    "modified_time": {
+      "description": "The time when the event was last modified or enriched.",
       "requirement": "optional"
     },
     "original_time": {
@@ -63,6 +60,10 @@
     "sequence": {
       "requirement": "optional"
     },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the event.",
+      "requirement": "optional"
+    },
     "tenant_uid": {
       "requirement": "recommended"
     },
@@ -75,5 +76,8 @@
       "description": "The version of the OCSF schema, using Semantic Versioning Specification (<a target='_blank' href='https://semver.org'>SemVer</a>). For example: 1.0.0. Event consumers use the version to determine the available event attributes.",
       "requirement": "required"
     }
-  }
+  },
+  "profiles": [
+    "data_classification"
+  ]
 }

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -3,7 +3,6 @@
   "description": "The Resource Details object describes details about resources that were affected by the activity/event.",
   "extends": "_resource",
   "name": "resource_details",
-  "profiles": ["cloud"],
   "attributes": {
     "agent_list": {
       "requirement": "optional"
@@ -37,5 +36,8 @@
       "description": "The version of the resource. For example <code>1.2.3</code>.",
       "requirement": "optional"
     }
-  }
+  },
+  "profiles": [
+    "cloud"
+  ]
 }

--- a/objects/service.json
+++ b/objects/service.json
@@ -11,6 +11,10 @@
     "name": {
       "description": "The name of the service."
     },
+    "tags": {
+      "description": "The list of tags; <code>{key:value}</code> pairs associated to the service.",
+      "requirement": "optional"
+    },
     "uid": {
       "description": "The unique identifier of the service."
     },

--- a/objects/tag.json
+++ b/objects/tag.json
@@ -1,0 +1,16 @@
+{
+  "caption": "Tag",
+  "description": "The Tag object defines a <code>{key:value}</code> pair attached to an entity. A Tag may be used to categorize, filter, and search for entities. For e.g. <code>\"Environment\": \"Production\"</code>, <code>\"Owner\": \"007\"</code>.",
+  "extends": "object",
+  "name": "tag",
+  "attributes": {
+    "name": {
+      "description": "The name of the tag.",
+      "requirement": "required"
+    },
+    "value": {
+      "description": "The value of the tag.",
+      "requirement": "required"
+    }
+  }
+}


### PR DESCRIPTION
#### Related Issue: From Oct 16th, 2024 Network Activity Call. 
Currently, we have `labels`, a string array attribute that can be used to populate labels. A String array is not sufficient when labels come in the form `key:value` pairs. Therefore, adding a tag object which can allow users to populate key:value styled labels/tags in the events.

#### Description of changes:
1. Adding a `tag` object, adding `tags` to dictionary. 
2. Deprecating an inconsistently used `tag` attribute, captioned `Image Tag` (was used in [Image](https://schema.ocsf.io/1.4.0-dev/objects/image?extensions=) and [Container](https://schema.ocsf.io/1.4.0-dev/objects/container?extensions=)) adding labels and tags to the object as alternatives and for consistency.
3. Adding `tags` to all the objects where, `labels` is currently used. And sorting the file contents.
4. Sorting dictionary.
5. Minor description adjustments.
