### PR TITLE
Fixed references metaschema id

### DIFF
--- a/metaschema/references.schema.json
+++ b/metaschema/references.schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schema.ocsf.io/observable.schema.json",
+    "$id": "https://schema.ocsf.io/references.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "title": "References",
     "description": "A list of references. A reference is a hyperlink to an associated definition for the current item (attribute, event class, or object), for example where an equivalent is defined in MITRE d3fend.",


### PR DESCRIPTION
#### Related Issue: 

Follow-up to a minor bug in #1189

#### Description of changes:

The `$id` of the new `reference` metaschema was accidentally left copy/pasted from `observable`.  This PR fixes that issue.  Since it's a minor bugfix, I left the release notes as-is, but I'm happy to change that if desired.
