### PR TITLE
Add imei_alts to the device object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Thankyou! -->
     12. Added `is_public` as a `boolean_t` #1208
     13. Added `tags` as n array of `tag` object. #1207
     14. Added `community_uid` as a `string_t`. #1202
+    15. Added `imei_alts` as an array `string_t`.
 
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -92,6 +93,7 @@ Thankyou! -->
     16. Added `body_length` to the `http_response` and `http_request` objects. #1200
     17. Added `is_public` to the `databucket` object. #1208
     18. Added `tags` to the `account`, `container`, `image`, `ldap_person`, `metadata`, `resource_details`, `service`, `web_resource` objects. #1207
+    19. Added `imei_alts` to the `device` object.
 
 
 ### Bugfixes

--- a/dictionary.json
+++ b/dictionary.json
@@ -2264,6 +2264,12 @@
       "description": "The International Mobile Station Equipment Identifier that is associated with the device.",
       "type": "string_t"
     },
+    "imei_alts": {
+      "caption": "Alternate IMEIs",
+      "description": "Alternate International Mobile Station Equipment Identifiers that are associated with the device, such as additional IMEIs for devices with more than one Subscriber Identity Module (SIM).",
+      "is_array": true,
+      "type": "string_t"
+    },
     "impact": {
       "caption": "Impact",
       "description": "The impact , normalized to the caption of the impact_id value. In the case of 'Other', it is defined by the event source.",

--- a/objects/device.json
+++ b/objects/device.json
@@ -46,6 +46,9 @@
     "imei": {
       "requirement": "optional"
     },
+    "imei_alts": {
+      "requirement": "optional"
+    },
     "ip": {
       "description": "The device IP address, in either IPv4 or IPv6 format.",
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

Adds optional `imei_alts` field to the `device` object, as an array of `string_t`, to accommodate additional IMEI values available in Dual-SIM and possible multi-SIM devices.

According to the [Wikipedia article for IMEI](https://en.wikipedia.org/wiki/International_Mobile_Equipment_Identity):

> Dual SIM enabled phones will have two IMEI numbers.



