### PR TITLE
 Adding http_request and http_response to evidences object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ Thankyou! -->
         - Event classes; top level attribute allowing link(s) about an event class
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
+11. Added `http_request` and `http_response` to the evidences object.     
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ Thankyou! -->
         - Event classes; top level attribute allowing link(s) about an event class
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
-11. Added `http_request` and `http_response` to the evidences object.     
+11. Added `http_request` and `http_response` to the evidences object. #1212
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -48,6 +48,14 @@
       "description": "Describes details about the file associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
+    "http_response": {
+      "description": "Describes details about the http response associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "http_request": {
+      "description": "Describes details about the http request associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
     "process": {
       "description": "Describes details about the process associated to the activity that triggered the detection.",
       "requirement": "recommended"


### PR DESCRIPTION
Adding http_request and http_response to evidences object 
<img width="1538" alt="image" src="https://github.com/user-attachments/assets/84ffecd8-17c6-4dd9-bd09-6503538ee76a">

