### PR TITLE
Updated the community_uid attribute to add source and references

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -958,7 +958,9 @@
     },
     "community_uid": {
       "caption": "Community ID",
-      "description": "The <a target='_blank' href='https://github.com/corelight/community-id-spec'>Community ID</a> of the network connection.",
+      "source": "community_id",
+      "references": [{"url": "https://github.com/corelight/community-id-spec", "description": "Community ID definition."}],
+      "description": "The Community ID of the network connection.",
       "type": "string_t"
     },
     "company_name": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
The `community_uid` is a direct reflection of the `community_id` defined by CoreLight.  This PR adds the new `source` and `references` tags to the meta schema which is rendered in a standard way by the browser, and can be machine parsed without looking at the `description` of the attribute.

<img width="1430" alt="Screenshot 2024-10-23 at 2 37 36 PM" src="https://github.com/user-attachments/assets/e822b1c7-8edd-4097-a0de-72f43a2d0408">
