### PR TITLE
add domain attribute to network endpoint object constraints

### DIFF
--- a/objects/network_endpoint.json
+++ b/objects/network_endpoint.json
@@ -37,7 +37,8 @@
       "svc_name",
       "instance_uid",
       "interface_uid",
-      "interface_name"
+      "interface_name",
+      "domain"
     ]
   }
 }


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:
- After a discussion in slack it was agreed to put together a PR to add the `domain` attribute to the network_endpoint object constraints.

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
