### PR TITLE
Fix changelog section ordering 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,7 +150,6 @@ Thankyou! -->
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
-1. Added `http_request` and `http_response` to the evidences object. #1212
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ Thankyou! -->
     1. Added `risk_details` to `data_security_finding` class. #1178
     1. Removed constraint from `group_management` class. #1193
     1. Added `Archived|5` as an enum item to `status_id` attribute in Findings classes. #1219
+* #### Profiles
+    1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178
+    1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
+    1. Added `policy` attribute to the `security_control` profile. #1178
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     1. Added `has_mfa` to `user` object. #1155
@@ -107,15 +111,10 @@ Thankyou! -->
     1. Added `location` to `managed_entity`. #1169
 
 ### Bugfixes
-    1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
-    1. Added a fix (profile: null) to `OSINT Inventory Info` so that the `osint` attribute is present w/o the OSINT profile, per the class definition.
-    1. Added http_response to all classes that have http_request, but no http_response object. #1200
-    1. Removed redundant `name` attribute from Windows extension to the `startup_item` object for consistency with other extensions. #1203
-
-* #### Profiles
-    1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178
-    1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
-    1. Added `policy` attribute to the `security_control` profile. #1178
+1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
+1. Added a fix (profile: null) to `OSINT Inventory Info` so that the `osint` attribute is present w/o the OSINT profile, per the class definition.
+1. Added http_response to all classes that have http_request, but no http_response object. #1200
+1. Removed redundant `name` attribute from Windows extension to the `startup_item` object for consistency with other extensions. #1203
     
 ### Deprecated
 1. Deprecated `project_uid` in favor of `account.uid`. #1166
@@ -151,6 +150,7 @@ Thankyou! -->
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
+1. Added `http_request` and `http_response` to the evidences object. #1212
 
 ## [v1.3.0] - August 1st, 2024
 


### PR DESCRIPTION
#### Related Issue: 

N/A

#### Description of changes:

Fix ~~two~~ one minor issue~~s~~ I noticed when reviewing the change-log after the [latest update](https://github.com/ocsf/ocsf-schema/commit/8d86a98f7ea225736e42843e774c21002943d86a):

~~1. The Unreleased Misc. section missed a recently added line: ...~~

2. The "Bugfixes" section somehow got moved inside the "Improved" section, resulting in incorrect indent and formatting.  In 1.3.0, Bugfixes follow Improved Profiles:

<img width="849" alt="image" src="https://github.com/user-attachments/assets/96f1dc4b-9116-428d-b382-689b93058473">

But in Unreleased, the order was reversed:

<img width="886" alt="image" src="https://github.com/user-attachments/assets/3336749e-654b-4e99-b896-ecd38c06ed9f">
