### PR TITLE
D3fend reference links moved to new references meta data fields.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3263,7 +3263,7 @@
     },
     "package": {
       "caption": "Software Package",
-      "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/", "description": "D3FEND Ontology d3f:SoftwarePackage."}],
+      "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/", "description": "D3FEND™ Ontology d3f:SoftwarePackage."}],
       "description": "The Software Package object describes details about a software package.",
       "type": "package"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -1145,7 +1145,8 @@
     "country": {
       "observable": 14,
       "caption": "Country",
-      "description": "The ISO 3166-1 Alpha-2 country code. For the complete list of country codes see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en' >ISO 3166-1 alpha-2 codes</a>.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
+      "references": [{"url": "https://www.iso.org/obp/ui/#iso:pub:PUB500001:en", "description": "ISO 3166-1 alpha-2 codes"}],
+      "description": "The ISO 3166-1 Alpha-2 country code.<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
       "type": "string_t"
     },
     "cpe_name": {
@@ -3226,7 +3227,8 @@
     },
     "package": {
       "caption": "Software Package",
-      "description": "The Software Package object describes details about a software package. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/'>d3f:SoftwarePackage</a>.",
+      "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/", "description": "D3FEND Ontology d3f:SoftwarePackage."}],
+      "description": "The Software Package object describes details about a software package.",
       "type": "package"
     },
     "package_manager": {

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }

--- a/objects/certificate.json
+++ b/objects/certificate.json
@@ -1,8 +1,9 @@
 {
   "caption": "Digital Certificate",
   "name": "certificate",
+  "description": "The Digital Certificate, also known as a Public Key Certificate, object contains information about the ownership and usage of a public key. It serves as a means to establish trust in the authenticity and integrity of the public key and the associated entity.",
   "extends": "object",
-  "description": "The Digital Certificate, also known as a Public Key Certificate, object contains information about the ownership and usage of a public key. It serves as a means to establish trust in the authenticity and integrity of the public key and the associated entity. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Certificate/'>d3f:Certificate</a>.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Certificate/", "description": "D3FEND™ Ontology d3f:Certificate."}],
   "attributes": {
     "created_time": {
       "description": "The time when the certificate was created.",

--- a/objects/d3f_tactic.json
+++ b/objects/d3f_tactic.json
@@ -1,15 +1,18 @@
 {
   "caption": "MITRE D3FEND™ Tactic",
-  "description": "The MITRE D3FEND™ Tactic object describes the tactic ID and/or name that is associated to an attack, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>.",
-  "extends": "_entity",
   "name": "d3f_tactic",
+  "description": "The MITRE D3FEND™ Tactic object describes the tactic ID and/or name that is associated to an attack",
+  "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
+  "extends": "_entity",
   "attributes": {
     "name": {
-      "description": "The tactic name that is associated with the defensive technique, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>. For example: <code>Isolate</code>.",
+      "description": "The tactic name that is associated with the defensive technique. For example: <code>Isolate</code>.",
+      "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
       "requirement" : "optional"
     },    
     "src_url": {
-      "description": "The versioned permalink of the defensive tactic, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>. For example: <code>https://d3fend.mitre.org/tactic/d3f:Isolate/</code>.",
+      "description": "The versioned permalink of the defensive tactic. For example: <code>https://d3fend.mitre.org/tactic/d3f:Isolate/</code>.",
+      "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
       "requirement" : "optional"
     }
   }

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -1,18 +1,22 @@
 {
   "caption": "MITRE DEFEND™ Technique",
-  "description": "The MITRE DEFEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>.",
-  "extends": "_entity",
   "name": "d3f_technique",
+  "description": "The MITRE DEFEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
+  "references": [{"url": "href='https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}],
+  "extends": "_entity",
   "attributes": {
     "name": {
-      "description": "The name of the defensive technique, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>. For example: <code>IO Port Restriction</code>."
+      "description": "The name of the defensive technique. For example: <code>IO Port Restriction</code>.",
+      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}]
     },
     "src_url": {
-      "description": "The versioned permalink of the defensive technique, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>.",
+      "description": "The versioned permalink of the defensive technique. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>.",
+      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}],
       "requirement" : "optional"
     },
     "uid": {
-      "description": "The unique identifier of the defensive technique, as defined by <a target='_blank' href='https://mitre.mitre.org'>D3FEND<sup>TM</sup> Matrix</a>. For example: <code>D3-IOPR</code>."
+      "description": "The unique identifier of the defensive technique. For example: <code>D3-IOPR</code>.",
+      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}]
     }
   }
 }

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -11,7 +11,7 @@
     },
     "src_url": {
       "description": "The versioned permalink of the defensive technique. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>.",
-      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}],
+      "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
       "requirement" : "optional"
     },
     "uid": {

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -16,7 +16,7 @@
     },
     "uid": {
       "description": "The unique identifier of the defensive technique. For example: <code>D3-IOPR</code>.",
-      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}]
+      "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}]
     }
   }
 }

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -2,7 +2,7 @@
   "caption": "MITRE DEFEND™ Technique",
   "name": "d3f_technique",
   "description": "The MITRE D3FEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
-  "references": [{"url": "href='https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}],
+  "references": [{"url": "href='https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
   "extends": "_entity",
   "attributes": {
     "name": {

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -7,7 +7,7 @@
   "attributes": {
     "name": {
       "description": "The name of the defensive technique. For example: <code>IO Port Restriction</code>.",
-      "references": [{"url": "https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}]
+      "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}]
     },
     "src_url": {
       "description": "The versioned permalink of the defensive technique. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>.",

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -1,7 +1,7 @@
 {
   "caption": "MITRE DEFEND™ Technique",
   "name": "d3f_technique",
-  "description": "The MITRE DEFEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
+  "description": "The MITRE D3FEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
   "references": [{"url": "href='https://d3fend.mitre.org", "description": "DEFEND™ Matrix"}],
   "extends": "_entity",
   "attributes": {

--- a/objects/d3fend.json
+++ b/objects/d3fend.json
@@ -1,19 +1,20 @@
 {
     "caption": "MITRE D3FEND™",
     "name": "d3fend",
-    "description": "The <a target='_blank' href='https://d3fend.mitre.org'>MITRE D3FEND™</a> object describes the tactic, technique & sub-technique associated with a countermeasure as defined in <a target='_blank' href='https://d3fend.mitre.org/'>DEFEND Matrix<sup>TM</sup></a>.",
+    "description": "The MITRE D3FEND™ object describes the tactic, technique & sub-technique associated with a countermeasure.",
+    "references": [{"url": "https://d3fend.mitre.org", "description": "D3FEND™ Matrix"}],
     "extends": "object",
     "attributes": {
       "d3f_tactic": {
-        "description": "The Tactic object describes the tactic ID and/or name that is associated with a countermeasure, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND Matrix<sup>TM</sup></a>.",
+        "description": "The Tactic object describes the tactic ID and/or name that is associated with a countermeasure.",
         "requirement": "recommended"
       },
       "d3f_technique": {
-        "description": "The Defend Technique object describes the technique ID and/or name associated with a countermeasure, as defined by <a target='_blank' href='https://d3fend.mitre.org'>D3FEND Matrix<sup>TM</sup></a>.",
+        "description": "The Technique object describes the technique ID and/or name associated with a countermeasure.",
         "requirement": "recommended"
       },
       "version": {
-        "description": "The <a target='_blank' href='https://d3fend.mitre.org'>D3FEND Matrix<sup>TM</sup></a> version.",
+        "description": "The D3FEND<sup>TM</sup> Matrix version.",
         "requirement": "recommended"
       }
     },

--- a/objects/d3fend.json
+++ b/objects/d3fend.json
@@ -14,7 +14,7 @@
         "requirement": "recommended"
       },
       "version": {
-        "description": "The D3FEND<sup>TM</sup> Matrix version.",
+        "description": "The D3FEND™ Matrix version.",
         "requirement": "recommended"
       }
     },

--- a/objects/dce_rpc.json
+++ b/objects/dce_rpc.json
@@ -1,7 +1,8 @@
 {
   "caption": "DCE/RPC",
   "name": "dce_rpc",
-  "description": "The DCE/RPC, or Distributed Computing Environment/Remote Procedure Call, object describes the remote procedure call system for distributed computing environments. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:RemoteProcedureCall/'>d3f:RemoteProcedureCall</a>.",
+  "description": "The DCE/RPC, or Distributed Computing Environment/Remote Procedure Call, object describes the remote procedure call system for distributed computing environments.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:RemoteProcedureCall/", "description": "D3FEND™ Ontology d3f:RemoteProcedureCall."}],
   "extends": "object",
   "attributes": {
     "command": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -1,8 +1,9 @@
 {
   "caption": "Device",
-  "description": "The Device object represents an addressable computer system or host, which is typically connected to a computer network and participates in the transmission or processing of data within the computer network. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Host/'>d3f:Host</a>.",
-  "extends": "endpoint",
   "name": "device",
+  "description": "The Device object represents an addressable computer system or host, which is typically connected to a computer network and participates in the transmission or processing of data within the computer network.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Host/", "description": "D3FEND™ Ontology d3f:Host."}],
+  "extends": "endpoint",
   "attributes": {
     "autoscale_uid": {
       "requirement": "optional"

--- a/objects/dns_query.json
+++ b/objects/dns_query.json
@@ -2,7 +2,8 @@
   "caption": "DNS Query",
   "name": "dns_query",
   "extends": "_dns",
-  "description": "The DNS query object represents a specific request made to the Domain Name System (DNS) to retrieve information about a domain or perform a DNS operation. This object encapsulates the necessary attributes and methods to construct and send DNS queries, specify the query type (e.g., A, AAAA, MX). Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:DNSLookup/'>d3f:DNSLookup</a>.",
+  "description": "The DNS query object represents a specific request made to the Domain Name System (DNS) to retrieve information about a domain or perform a DNS operation. This object encapsulates the necessary attributes and methods to construct and send DNS queries, specify the query type (e.g., A, AAAA, MX).",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:DNSLookup/", "description": "D3FEND™ Ontology d3f:DNSLookup."}],
   "attributes": {
     "hostname": {
       "description": "The hostname or domain being queried. For example: <code>www.example.com</code>",

--- a/objects/email.json
+++ b/objects/email.json
@@ -1,7 +1,8 @@
 {
   "caption": "Email",
-  "description": "The Email object describes the email metadata such as sender, recipients, and direction. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Email/'>d3f:Email</a>.",
   "name": "email",
+  "description": "The Email object describes the email metadata such as sender, recipients, and direction.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Email/", "description": "D3FEND™ Ontology d3f:Email."}],
   "extends": "object",
   "observable": 22,
   "profiles": [

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -1,8 +1,8 @@
 {
   "caption": "Endpoint",
+  "name": "endpoint",
   "description": "The Endpoint object describes a physical or virtual device that connects to and exchanges information with a computer network. Some examples of endpoints are mobile devices, desktop computers, virtual machines, embedded devices, and servers. Internet-of-Things devices—like cameras, lighting, refrigerators, security systems, smart speakers, and thermostats—are also endpoints.",
   "extends": "_entity",
-  "name": "endpoint",
   "observable": 20,
   "profiles": [
     "container"

--- a/objects/file.json
+++ b/objects/file.json
@@ -1,8 +1,9 @@
 {
   "caption": "File",
-  "observable": 24,
   "name": "file",
-  "description": "The File object represents the metadata associated with a file stored in a computer system. It encompasses information about the file itself, including its attributes, properties, and organizational details. Defined by D3FEND <a target='_blank' href='https://next.d3fend.mitre.org/dao/artifact/d3f:File/'>d3f:File</a>.",
+  "observable": 24,
+  "description": "The File object represents the metadata associated with a file stored in a computer system. It encompasses information about the file itself, including its attributes, properties, and organizational details.",
+  "references": [{"url": "https://next.d3fend.mitre.org/dao/artifact/d3f:File/", "description": "D3FEND™ Ontology d3f:File"}],
   "extends": "_entity",
   "profiles": [
     "data_classification"

--- a/objects/image.json
+++ b/objects/image.json
@@ -2,7 +2,7 @@
   "caption": "Image",
   "name": "image",
   "description": "The Image object provides a description of a specific Virtual Machine (VM) or Container image.",
-  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/", "description": "D3FEND Ontology d3f:ContainerImage"}],
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/", "description": "D3FEND™ Ontology d3f:ContainerImage"}],
   "extends": "_entity",
   "attributes": {
     "labels": {

--- a/objects/image.json
+++ b/objects/image.json
@@ -1,8 +1,9 @@
 {
   "caption": "Image",
-  "description": "The Image object provides a description of a specific Virtual Machine (VM) or Container image. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/'>d3f:ContainerImage</a>.",
-  "extends": "_entity",
   "name": "image",
+  "description": "The Image object provides a description of a specific Virtual Machine (VM) or Container image.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ContainerImage/", "description": "D3FEND Ontology d3f:ContainerImage"}],
+  "extends": "_entity",
   "attributes": {
     "labels": {
       "description": "The list of labels associated to the image.",

--- a/objects/kernel.json
+++ b/objects/kernel.json
@@ -1,8 +1,9 @@
 {
   "caption": "Kernel Resource",
-  "description": "The Kernel Resource object provides information about a specific kernel resource, including its name and type. It describes essential attributes associated with a resource managed by the kernel of an operating system. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Kernel/'>d3f:Kernel</a>.",
-  "extends": "object",
   "name": "kernel",
+  "description": "The Kernel Resource object provides information about a specific kernel resource, including its name and type. It describes essential attributes associated with a resource managed by the kernel of an operating system.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Kernel/", "description": "D3FEND™ Ontology d3f:Kernel"}],
+  "extends": "object",
   "attributes": {
     "is_system": {
       "requirement": "optional"

--- a/objects/kernel_driver.json
+++ b/objects/kernel_driver.json
@@ -2,7 +2,7 @@
   "caption": "Kernel Extension",
   "name": "kernel_driver",
   "description": "The Kernel Extension object describes a kernel driver that has been loaded or unloaded into the operating system (OS) kernel.",
-  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:KernelModule/", "description": "D3FEND Ontology d3f:KernelModule"}],
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:KernelModule/", "description": "D3FEND™ Ontology d3f:KernelModule"}],
   "extends": "object",
   "attributes": {
     "file": {

--- a/objects/kernel_driver.json
+++ b/objects/kernel_driver.json
@@ -1,7 +1,8 @@
 {
   "caption": "Kernel Extension",
   "name": "kernel_driver",
-  "description": "The Kernel Extension object describes a kernel driver that has been loaded or unloaded into the operating system (OS) kernel. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:KernelModule/'>d3f:KernelModule</a>.",
+  "description": "The Kernel Extension object describes a kernel driver that has been loaded or unloaded into the operating system (OS) kernel.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:KernelModule/", "description": "D3FEND Ontology d3f:KernelModule"}],
   "extends": "object",
   "attributes": {
     "file": {

--- a/objects/location.json
+++ b/objects/location.json
@@ -1,9 +1,9 @@
 {
-  "observable": 26,
   "caption": "Geo Location",
-  "description": "The Geo Location object describes a geographical location, usually associated with an IP address. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:PhysicalLocation/'>d3f:PhysicalLocation</a>.",
-  "extends": "object",
   "name": "location",
+  "observable": 26,
+  "description": "The Geo Location object describes a geographical location, usually associated with an IP address.",
+  "extends": "object",
   "attributes": {
     "city": {
       "requirement": "recommended"
@@ -44,7 +44,8 @@
       "requirement": "optional"
     },
     "region": {
-      "description": "The alphanumeric code that identifies the principal subdivision (e.g. province or state) of the country. Region codes are defined at <a target='_blank' href='https://www.iso.org/iso-3166-country-codes.html'>ISO 3166-2</a> and have a limit of three characters. For example, see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:code:3166:US'>the region codes for the US</a>.",
+      "description": "The alphanumeric code that identifies the principal subdivision (e.g. province or state) of the country. For example, 'CH-VD' for the Canton of Vaud, Switzerland",
+      "references": [{"url": "https://www.iso.org/iso-3166-country-codes.html", "description": "ISO Region Codes"}, {"url": "https://www.iso.org/obp/ui/#iso:code:3166:US", "description": "U.S. Region Codes"}],
       "requirement": "optional"
     }
   },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -1,8 +1,9 @@
 {
   "caption": "Metadata",
-  "description": "The Metadata object describes the metadata associated with the event. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Metadata/'>d3f:Metadata</a>.",
-  "extends": "object",
   "name": "metadata",
+  "description": "The Metadata object describes the metadata associated with the event.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Metadata/", "description": "D3FEND™ Ontology d3f:Metadata"}],
+  "extends": "object",
   "attributes": {
     "$include": [
       "profiles/data_classification.json"

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -1,8 +1,9 @@
 {
   "caption": "Network Connection Information",
-  "description": "The Network Connection Information object describes characteristics of an OSI Transport Layer communication, including TCP and UDP. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:NetworkSession/'>d3f:NetworkSession</a>.",
-  "extends": "object",
   "name": "network_connection_info",
+  "description": "The Network Connection Information object describes characteristics of an OSI Transport Layer communication, including TCP and UDP.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:NetworkSession/", "description": "D3FEND™ Ontology d3f:NetworkSession"}],
+  "extends": "object",
   "attributes": {
     "boundary": {
       "requirement": "optional"

--- a/objects/network_proxy.json
+++ b/objects/network_proxy.json
@@ -1,7 +1,8 @@
 {
   "caption": "Network Proxy Endpoint",
   "name": "network_proxy",
-  "description": "The network proxy endpoint object describes a proxy server, which acts as an intermediary between a client requesting a resource and the server providing that resource.  Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:ProxyServer/'>d3f:ProxyServer</a>.",
+  "description": "The network proxy endpoint object describes a proxy server, which acts as an intermediary between a client requesting a resource and the server providing that resource.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ProxyServer/", "description": "D3FEND™ Ontology d3f:ProxyServer"}],
   "extends": "network_endpoint",
   "attributes": {
   }

--- a/objects/network_traffic.json
+++ b/objects/network_traffic.json
@@ -1,8 +1,9 @@
 {
   "caption": "Network Traffic",
-  "description": "The Network Traffic object describes characteristics of network traffic. Network traffic refers to data moving across a network at a given point of time. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:NetworkTraffic/'>d3f:NetworkTraffic</a>.",
-  "extends": "object",
   "name": "network_traffic",
+  "description": "The Network Traffic object describes characteristics of network traffic. Network traffic refers to data moving across a network at a given point of time.",
+  "references": [{"description": "D3FEND™ Ontology d3f:NetworkTraffic", "url": "https://d3fend.mitre.org/dao/artifact/d3f:NetworkTraffic/"}],
+  "extends": "object",
   "attributes": {
     "bytes": {
       "requirement": "recommended"

--- a/objects/os.json
+++ b/objects/os.json
@@ -1,14 +1,16 @@
 {
   "caption": "Operating System (OS)",
-  "description": "The Operating System (OS) object describes characteristics of an OS, such as Linux or Windows. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:OperatingSystem/'>d3f:OperatingSystem</a>.",
-  "extends": "object",
   "name": "os",
+  "description": "The Operating System (OS) object describes characteristics of an OS, such as Linux or Windows.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:OperatingSystem/", "description": "D3FEND™ Ontology d3f:OperatingSystem"}],
+  "extends": "object",
   "attributes": {
     "build": {
       "requirement": "optional"
     },
     "country": {
-      "description": "The operating system country code, as defined by the ISO 3166-1 standard (Alpha-2 code). For the complete list of country codes, see <a target='_blank' href='https://www.iso.org/obp/ui/#iso:pub:PUB500001:en'>ISO 3166-1 alpha-2 codes</a>.",
+      "references": [{"url": "https://www.iso.org/obp/ui/#iso:pub:PUB500001:en", "description": "ISO 3166-1 alpha-2 codes"}],
+      "description": "The operating system country code, as defined by the ISO 3166-1 standard (Alpha-2 code).<p><b>Note:</b> The two letter country code should be capitalized. For example: <code>US</code> or <code>CA</code>.</p>",
       "requirement": "optional"
     },
     "cpe_name": {

--- a/objects/package.json
+++ b/objects/package.json
@@ -1,8 +1,9 @@
 {
   "caption": "Software Package",
-  "description": "The Software Package object describes details about a software package. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/'>d3f:SoftwarePackage</a>.",
-  "extends": "object",
   "name": "package",
+  "description": "The Software Package object describes details about a software package.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:SoftwarePackage/", "description": "D3FEND™ Ontology d3f:SoftwarePackage."}],
+  "extends": "object",
   "attributes": {
     "architecture": {
       "requirement": "recommended"

--- a/objects/process.json
+++ b/objects/process.json
@@ -1,8 +1,9 @@
 {
   "caption": "Process",
-  "description": "The Process object describes a running instance of a launched program. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Process/'>d3f:Process</a>.",
-  "extends": "_entity",
   "name": "process",
+  "description": "The Process object describes a running instance of a launched program.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Process/", "description": "D3FEND™ Ontology d3f:Process"}],
+  "extends": "_entity",
   "observable": 25,
   "profiles": [
     "container"

--- a/objects/session.json
+++ b/objects/session.json
@@ -1,8 +1,9 @@
 {
   "caption": "Session",
-  "description": "The Session object describes details about an authenticated session. e.g. Session Creation Time, Session Issuer. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Session/'>d3f:Session</a>.",
-  "extends": "object",
   "name": "session",
+  "description": "The Session object describes details about an authenticated session. e.g. Session Creation Time, Session Issuer.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Session/", "description": "D3FEND™ Ontology d3f:Session"}],
+  "extends": "object",
   "attributes": {
     "count": {
       "description": "The number of identical sessions spawned from the same source IP, destination IP, application, and content/threat type seen over a period of time.",

--- a/objects/url.json
+++ b/objects/url.json
@@ -1,9 +1,10 @@
 {
-  "observable": 23,
   "caption": "Uniform Resource Locator",
-  "description": "The Uniform Resource Locator(URL) object describes the characteristics of a URL. Defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc1738'>RFC 1738</a> and by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:URL/'>d3f:URL</a>.",
-  "extends": "object",
   "name": "url",
+  "observable": 23,
+  "description": "The Uniform Resource Locator(URL) object describes the characteristics of a URL.",
+  "references": [{"url": "https://datatracker.ietf.org/doc/html/rfc1738", "description": "Defined in RFC 1738"}, {"url": "https://d3fend.mitre.org/dao/artifact/d3f:URL/", "description": "D3FEND™ Ontology d3f:URL"}],
+  "extends": "object",
   "attributes": {
     "categories": {
       "requirement": "optional"

--- a/objects/url.json
+++ b/objects/url.json
@@ -2,7 +2,7 @@
   "caption": "Uniform Resource Locator",
   "name": "url",
   "observable": 23,
-  "description": "The Uniform Resource Locator(URL) object describes the characteristics of a URL.",
+  "description": "The Uniform Resource Locator (URL) object describes the characteristics of a URL.",
   "references": [{"url": "https://datatracker.ietf.org/doc/html/rfc1738", "description": "Defined in RFC 1738"}, {"url": "https://d3fend.mitre.org/dao/artifact/d3f:URL/", "description": "D3FEND™ Ontology d3f:URL"}],
   "extends": "object",
   "attributes": {

--- a/objects/user.json
+++ b/objects/user.json
@@ -1,8 +1,9 @@
 {
   "caption": "User",
-  "description": "The User object describes the characteristics of a user/person or a security principal. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:UserAccount/'>d3f:UserAccount</a>.",
-  "extends": "_entity",
   "name": "user",
+  "description": "The User object describes the characteristics of a user/person or a security principal.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:UserAccount/", "description": "D3FEND™ Ontology d3f:UserAccount"}],
+  "extends": "_entity",
   "observable": 21,
   "attributes": {
     "account": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
Updated existing MITRE d3fend references in descriptions to use the new `references` meta data tag field.
Removed the d3fend reference to d3f:PhysicalLocation from `location` as it was removed.
Updated the `country` attribute to use new `references` meta data tag field.
