### PR TITLE
Updating default Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default Owners for everything in the repo
-* @floydtree @pagbabian-splunk @Aniak5 @mikeradka @zschmerber
+* @floydtree @pagbabian-splunk @Aniak5 @mikeradka @zschmerber @jonrau-at-queryai @davemcatcisco


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:
* Adding @jonrau-at-queryai and @davemcatcisco to codeowners file, to increase the pool of default reviewers added to a PR.
