### PR TITLE
Fix missing description for device_hw_info.vendor_name

### DIFF
--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -45,6 +45,7 @@
       "requirement": "optional"
     },
     "vendor_name": {
+      "description": "The device manufacturer.",
       "requirement": "optional"
     }
   }


### PR DESCRIPTION
#### Related Issue: 

N/A

#### Description of changes:

Fixes runtime warning:

```
 [warning] mfa=Schema.Cache.missing_desc_warning/4 line=1208  Please update the description for device_hw_info.vendor_name: The name of the vendor. See specific usage.
```

It appears dictionary entries where the default description contains "See specific usage" requires an overriding description when the attribute is used ([ocsf-server:cache.ex, line 1208](https://github.com/ocsf/ocsf-server/blob/45ccdb46c05bb9282528868a76338ce1a6d01fd9/lib/schema/cache.ex#L1208)).
