### PR TITLE
Issue #1227: Support `@deprecated`, `source`, and `references` in enum items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ Thankyou! -->
 1. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
 1. Added new `Email Account` enum to `account.type_id`. #1179
 1. Removing regex for `hostname_t`, considering the vast variance in its values. #1182
-1. In the metaschema, added support for additional metadata fields: `source` and `references`.
+1. In the metaschema, added support for additional metadata fields: `source` and `references`. #1227 (for enum values)
     - The `source` attribute is a string for describing the location where an attribute's value comes from.
     - The `references` attribute is a list objects with `url` and `description` fields. These are intended to for reference to external resources. The `url` and `description` attributes are used to construct anchor (`a`) tags with the `url` used in the anchor's `href` attribute, and `description` used in the entity portion of the tag.
     - The `source` field can be used in attributes defined anywhere in the schema, specifically:
@@ -142,6 +142,7 @@ Thankyou! -->
         - Event class attributes
         - Object attributes
         - Profile attributes
+        - Enum values in all places where attributes occur (the 4 cases above)
     - The `references` field can also be used in attributes anywhere in the schema, as well as for event classes, objects, and enum values; specifically:
         - Dictionary attributes
         - Event class attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ Thankyou! -->
 1. Relaxed data-type constraints for `file_hash_t`, `resource_uid_t` & `string_t`. Fixed regex for `datetime_t`. #1174
 1. Added new `Email Account` enum to `account.type_id`. #1179
 1. Removing regex for `hostname_t`, considering the vast variance in its values. #1182
-1. In the metaschema, added support for additional metadata fields: `source` and `references`. #1227 (for enum values)
+1. In the metaschema, added support for additional metadata fields: `source` and `references`. #1189 #1237
     - The `source` attribute is a string for describing the location where an attribute's value comes from.
     - The `references` attribute is a list objects with `url` and `description` fields. These are intended to for reference to external resources. The `url` and `description` attributes are used to construct anchor (`a`) tags with the `url` used in the anchor's `href` attribute, and `description` used in the entity portion of the tag.
     - The `source` field can be used in attributes defined anywhere in the schema, specifically:
@@ -153,7 +153,7 @@ Thankyou! -->
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
-1. In the metaschema, added support for `@deprecated` in enum values. #1227
+1. In the metaschema, added support for `@deprecated` in enum values. #1237
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,15 +142,17 @@ Thankyou! -->
         - Event class attributes
         - Object attributes
         - Profile attributes
-    - The `references` field can also be used in attributes anywhere in the schema, as well as for event classes, objects; specifically:
+    - The `references` field can also be used in attributes anywhere in the schema, as well as for event classes, objects, and enum values; specifically:
         - Dictionary attributes
         - Event class attributes
         - Object attributes
         - Profile attributes
+        - Enum values in all places where attributes occur
         - Event classes; top level attribute allowing link(s) about an event class
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
+1. In the metaschema, added support for `@deprecated` in enum values. #1227
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/metaschema/attribute.schema.json
+++ b/metaschema/attribute.schema.json
@@ -16,25 +16,7 @@
             "description": "The description of the attribute."
         },
         "enum": {
-            "type": "object",
-            "description": "An enumeration of options for this attribute.",
-            "additionalProperties": {
-                "type": "object",
-                "required": [
-                    "caption"
-                ],
-                "properties": {
-                    "caption": {
-                        "type": "string",
-                        "description": "The caption of this enum value."
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "The description of this enum value."
-                    },
-                    "additionalProperties": false
-                }
-            }
+            "$ref": "enum.schema.json"
         },
         "group": {
             "type": "string",

--- a/metaschema/dictionary-attribute.schema.json
+++ b/metaschema/dictionary-attribute.schema.json
@@ -21,25 +21,7 @@
             "description": "The description of the attribute."
         },
         "enum": {
-            "type": "object",
-            "description": "An enumeration of options for this attribute.",
-            "additionalProperties": {
-                "type": "object",
-                "required": [
-                    "caption"
-                ],
-                "properties": {
-                    "caption": {
-                        "type": "string",
-                        "description": "The caption of this enum value."
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "The description of this enum value."
-                    },
-                    "additionalProperties": false
-                }
-            }
+            "$ref": "enum.schema.json"
         },
         "sibling": {
             "type": "string",

--- a/metaschema/enum.schema.json
+++ b/metaschema/enum.schema.json
@@ -1,0 +1,30 @@
+{
+    "$id": "https://schema.ocsf.io/enum.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Enumeration",
+    "description": "An enumeration of options for an attribute.",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "required": [
+            "caption"
+        ],
+        "properties": {
+            "@deprecated": {
+                "$ref": "deprecated.schema.json"
+            },
+            "caption": {
+                "type": "string",
+                "description": "The caption of this enum value."
+            },
+            "description": {
+                "type": "string",
+                "description": "The description of this enum value."
+            },
+            "references": {
+                "$ref": "references.schema.json"
+            },    
+            "additionalProperties": false
+        }
+    }
+}

--- a/metaschema/enum.schema.json
+++ b/metaschema/enum.schema.json
@@ -21,10 +21,14 @@
                 "type": "string",
                 "description": "The description of this enum value."
             },
+            "source": {
+                "type": "string",
+                "description": "The source value and its origin, for example an OS-specific enumeration value."
+            },
             "references": {
                 "$ref": "references.schema.json"
-            },    
-            "additionalProperties": false
-        }
+            }
+        },
+        "additionalProperties": false
     }
 }


### PR DESCRIPTION
#### Related Issue: 
Issue #1227

#### Description of changes:
Added support for `@deprecated`, `source`, and `references` in enum items.
