### PR TITLE
Identity Provider object additions, create SCIM & SSO objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,7 @@ Thankyou! -->
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169 
     1. Added `variable_name` and `variable_value` as `long_string`. #1228
     1. Added `imei_list` as an array `string_t`. #1225
-    1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169
-    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, `scim_user_schema`, `scopes`, `sso_idle_timeout`, `sso_login_endpoint`, `sso_logout_endpoint`, and `sso_metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
+    1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
 * #### Objects
     1. Added `environment_variable` object. #1172

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,14 @@ Thankyou! -->
     1. Added `location` to the `managed_entity` object. #1169
     1. Added `unmanned_system_operator` to the dictionary, extends `user`. #1169
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. #1169
-    1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169 
+    1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169
+    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, and `scim_user_schema` entries to the dictionary to support the new `scim` object.
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
     1. Added a generic `key_value_object` object. #1219
     1. Added `unmanned_aerial_system` and `unmanned_system_operating_area` objects. #1169
+    1. Added `scim` object.
 
 ### Improved
 * #### Event Classes
@@ -105,6 +107,7 @@ Thankyou! -->
     1. Added `control_parameters` and `status_details` to the compliance object. #1219
     1. Added `geodetic_altitude`, `height`, `horizontal_accuracy`, and `pressure_altitude` to `location`. #1169
     1. Added `location` to `managed_entity`. #1169
+    1. Added `auth_factors`, `digest`, `domain`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`.
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
@@ -151,6 +154,7 @@ Thankyou! -->
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
+1. Fixed some more formatting of attribute descriptions in `dictionary.json` and `idp.json`.
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Thankyou! -->
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169 
     1. Added `variable_name` and `variable_value` as `long_string`. #1228
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169
-    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, and `scim_user_schema` entries to the dictionary to support the new `scim` object. #1239
+    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, `scim_user_schema`, `scopes`, `sso_idle_timeout`, `sso_login_endpoint`, `sso_logout_endpoint`, and `sso_metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
 * #### Objects
     1. Added `environment_variable` object. #1172
@@ -77,6 +77,7 @@ Thankyou! -->
     1. Added `unmanned_aerial_system` and `unmanned_system_operating_area` objects. #1169
     1. Added a `long_string` object. #1228
     1. Added `scim` object. #1239
+    1. Added `sso` object. #1239
 
 ### Improved
 * #### Event Classes
@@ -112,7 +113,7 @@ Thankyou! -->
     1. Added `control_parameters` and `status_details` to the compliance object. #1219
     1. Added `geodetic_altitude`, `height`, `horizontal_accuracy`, and `pressure_altitude` to `location`. #1169
     1. Added `location` to `managed_entity`. #1169
-    1. Added `auth_factors`, `digest`, `domain`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
+    1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,13 +68,13 @@ Thankyou! -->
     1. Added `unmanned_system_operator` to the dictionary, extends `user`. #1169
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. #1169
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169
-    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, and `scim_user_schema` entries to the dictionary to support the new `scim` object.
+    1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, and `scim_user_schema` entries to the dictionary to support the new `scim` object. #1239
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
     1. Added a generic `key_value_object` object. #1219
     1. Added `unmanned_aerial_system` and `unmanned_system_operating_area` objects. #1169
-    1. Added `scim` object.
+    1. Added `scim` object. #1239
 
 ### Improved
 * #### Event Classes
@@ -107,7 +107,7 @@ Thankyou! -->
     1. Added `control_parameters` and `status_details` to the compliance object. #1219
     1. Added `geodetic_altitude`, `height`, `horizontal_accuracy`, and `pressure_altitude` to `location`. #1169
     1. Added `location` to `managed_entity`. #1169
-    1. Added `auth_factors`, `digest`, `domain`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`.
+    1. Added `auth_factors`, `digest`, `domain`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
 
 ### Bugfixes
     1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
@@ -154,7 +154,7 @@ Thankyou! -->
         - Objects; top level attribute allowing link(s) about an object
     - The `source` and `references` attributes are also supported in when extending or patching event classes and objects.
 1. Fixed minor spelling mistakes in attribute descriptions in `dictionary.json`. #1213
-1. Fixed some more formatting of attribute descriptions in `dictionary.json` and `idp.json`.
+1. Fixed some more formatting of attribute descriptions in `dictionary.json` and `idp.json`. #1239
 
 ## [v1.3.0] - August 1st, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Thankyou! -->
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. #1169
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169
     1. Added `scim_group_provisioning_enabled`, `scim_group_schema`, `scim_user_provisioning_enabled`, and `scim_user_schema` entries to the dictionary to support the new `scim` object. #1239
+    1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176

--- a/dictionary.json
+++ b/dictionary.json
@@ -2285,6 +2285,11 @@
       "description": "The client identifier cookie during client/server exchange.",
       "type": "string_t"
     },
+    "idle_timeout": {
+      "caption": "SSO Idle Timeout",
+      "description": "Duration (in minutes) of allowed inactivity before a timeout See specific usage.",
+      "type": "integer_t"
+    },
     "idp": {
       "caption": "Identity Provider",
       "description": "This object describes details about the Identity Provider used.",
@@ -2963,6 +2968,16 @@
         }
       }
     },
+    "login_endpoint": {
+      "caption": "Login Endpoint",
+      "description": "URL for initiating a login request. See specific usage.",
+      "type": "url_t"
+    },
+    "logout_endpoint": {
+      "caption": "Logout Endpoint",
+      "description": "URL for initiating a logout request. See specific usage.",
+      "type": "url_t"
+    },
     "long": {
       "caption": "Longitude",
       "description": "The geographical Longitude coordinate represented in Decimal Degrees (DD). For example: <code>-71.057083</code>.",
@@ -3009,6 +3024,11 @@
       "caption": "Metadata",
       "description": "The metadata associated with the event or a finding.",
       "type": "metadata"
+    },
+    "metadata_endpoint": {
+      "caption": "Metadata Endpoint",
+      "description": "URL where metadata about is available (e.g., for SAML configurations). See specific usage.",
+      "type": "url_t"
     },
     "metrics": {
       "caption": "Metrics",
@@ -4433,26 +4453,6 @@
       "caption": "SSO",
       "description": "The Single Sign-On (SSO) object provides a structure for normalizing SSO attributes, configuration, and/or settings from Identity Providers.",
       "type": "sso"
-    },
-    "sso_idle_timeout": {
-      "caption": "SSO Idle Timeout",
-      "description": "Duration (in minutes) of allowed inactivity before Single Sign-On (SSO) session expiration.",
-      "type": "integer_t"
-    },
-    "sso_login_endpoint": {
-      "caption": "SSO Login Endpoint",
-      "description": "URL for initiating an SSO login request.",
-      "type": "url_t"
-    },
-    "sso_logout_endpoint": {
-      "caption": "SSO Logout Endpoint",
-      "description": "URL for initiating an SSO logout request, allowing sessions to be terminated across applications.",
-      "type": "url_t"
-    },
-    "sso_metadata_endpoint": {
-      "caption": "SSO Metadata Endpoint",
-      "description": "URL where metadata about the SSO configuration is available (e.g., for SAML configurations).",
-      "type": "url_t"
     },
     "standards": {
       "caption": "Compliance Standards: List",

--- a/dictionary.json
+++ b/dictionary.json
@@ -251,7 +251,7 @@
     },
     "auth_protocol": {
       "caption": "Auth Protocol",
-      "description": "The authentication protocol as defined by the caption of 'auth_protocol_id'. In the case of 'Other', it is defined by the event source.",
+      "description": "The authentication protocol as defined by the caption of <code>auth_protocol_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
       "type": "string_t"
     },
     "auth_protocol_id": {
@@ -293,6 +293,9 @@
         },
         "10": {
           "caption": "RADIUS"
+        },
+        "11": {
+          "caption": "Basic Authentication"
         },
         "99": {
           "caption": "Other",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4395,6 +4395,11 @@
       "description": "The URL pointing towards the source of an entity. See specific usage.",
       "type": "url_t"
     },
+    "sso": {
+      "caption": "Single-Sign On (SSO)",
+      "description": "The SSO configuration object provides a structure for normalizing Single Sign-On (SSO) settings and attributes.",
+      "type": "sso"
+    },
     "standards": {
       "caption": "Compliance Standards: List",
       "description": "Compliance standards are a set of criteria organizations can follow to protect sensitive and confidential information. e.g. <code>NIST SP 800-53, CIS AWS Foundations Benchmark v1.4.0, ISO/IEC 27001</code>",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2189,6 +2189,11 @@
       "type": "group",
       "is_array": true
     },
+    "group_provisioning_enabled": {
+      "caption": "Group Provisioning Enabled",
+      "description": "Indicates whether group provisioning is automated (e.g., for a SCIM resource). See specific usage.",
+      "type": "boolean_t"
+    },
     "handshake_dur": {
       "caption": "Handshake Duration",
       "description": "The amount of total time for the TLS handshake to complete after the TCP connection is established, including client-side delays, in milliseconds.",
@@ -4065,11 +4070,6 @@
       ],
       "type": "scim"
     },
-    "scim_group_provisioning_enabled": {
-      "caption": "SCIM Group Provisioning Enabled",
-      "description": "Indicates whether the SCIM resource is configured to provision groups, automatically or otherwise.",
-      "type": "boolean_t"
-    },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
       "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This attribute will capture key-value pairs for the scheme implemented in a SCIM resource.",
@@ -4080,11 +4080,6 @@
         }
       ],
       "type": "json_t"
-    },
-    "scim_user_provisioning_enabled": {
-      "caption": "SCIM User Provisioning Enabled",
-      "description": "Indicates whether the SCIM resource is configured to provision users, automatically or otherwise.",
-      "type": "boolean_t"
     },
     "scim_user_schema": {
       "caption": "SCIM User Schema",
@@ -4940,6 +4935,11 @@
       "caption": "HTTP User-Agent",
       "description": "The request header that identifies the operating system and web browser.",
       "type": "string_t"
+    },
+    "user_provisioning_enabled": {
+      "caption": "User Provisioning Enabled",
+      "description": "Indicates whether user provisioning is automated (e.g., for a SCIM resource). See specific usage.",
+      "type": "boolean_t"
     },
     "user_result": {
       "caption": "User Result",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4915,11 +4915,6 @@
       "description": "The attributes that are not mapped to the event schema. The names and values of those attributes are specific to the event source.",
       "type": "object"
     },
-    "unmanned_system_operator": {
-      "caption": "Unmanned Systems Operator",
-      "description": "The human or machine operator of an UAS",
-      "type": "user"
-    },
     "untruncated_size": {
       "caption": "Untruncated Size",
       "description": "The size in bytes of an attribute before truncation. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4034,14 +4034,14 @@
       "description": "The System for Cross-domain Identity Management (SCIM) resource object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
       "type": "scim"
     },
-    "scim_user_schema": {
-      "caption": "SCIM User Schema",
-      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:User' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
-      "type": "json_t"
-    },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
       "description": "SCIM provides a schema for representing groups, identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:Group' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
+      "type": "json_t"
+    },
+    "scim_user_schema": {
+      "caption": "SCIM User Schema",
+      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:User' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
       "type": "json_t"
     },
     "scheme": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3089,7 +3089,7 @@
     },
     "metadata_endpoint": {
       "caption": "Metadata Endpoint",
-      "description": "URL where metadata about is available (e.g., for SAML configurations). See specific usage.",
+      "description": "URL where metadata about a configuration or resource is available (e.g., for SAML configurations). See specific usage.",
       "type": "url_t"
     },
     "metrics": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -4034,10 +4034,20 @@
       "description": "The System for Cross-domain Identity Management (SCIM) resource object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
       "type": "scim"
     },
+    "scim_group_provisioning_enabled": {
+      "caption": "SCIM Group Provisioning Enabled",
+      "description": "Indicates whether the SCIM resource is configured to provision groups.",
+      "type": "boolean_t"
+    },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
       "description": "SCIM provides a schema for representing groups, identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:Group' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
       "type": "json_t"
+    },
+    "scim_user_provisioning_enabled": {
+      "caption": "SCIM User Provisioning Enabled",
+      "description": "Indicates whether the SCIM resource is configured to provision users.",
+      "type": "boolean_t"
     },
     "scim_user_schema": {
       "caption": "SCIM User Schema",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4047,12 +4047,12 @@
     },
     "scim_group_provisioning_enabled": {
       "caption": "SCIM Group Provisioning Enabled",
-      "description": "Indicates whether the SCIM resource is configured to provision groups.",
+      "description": "Indicates whether the SCIM resource is configured to provision groups, automatically or otherwise.",
       "type": "boolean_t"
     },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
-      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
+      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This attribute will capture key-value pairs for the scheme implemented in a SCIM resource.",
       "references": [
         {
           "url": "https://datatracker.ietf.org/doc/html/rfc7643", 
@@ -4063,12 +4063,12 @@
     },
     "scim_user_provisioning_enabled": {
       "caption": "SCIM User Provisioning Enabled",
-      "description": "Indicates whether the SCIM resource is configured to provision users.",
+      "description": "Indicates whether the SCIM resource is configured to provision users, automatically or otherwise.",
       "type": "boolean_t"
     },
     "scim_user_schema": {
       "caption": "SCIM User Schema",
-      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
+      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. his attribute will capture key-value pairs for the scheme implemented in a SCIM resource. This object is inclusive of both the basic and Enterprise User Schema Extension.",
       "references": [
         {
           "url": "https://datatracker.ietf.org/doc/html/rfc7643", 

--- a/dictionary.json
+++ b/dictionary.json
@@ -4400,6 +4400,11 @@
       "description": "The SSO configuration object provides a structure for normalizing Single Sign-On (SSO) settings and attributes.",
       "type": "sso"
     },
+    "sso_idle_timeout": {
+      "caption": "SSO Idle Timeout",
+      "description": "Duration (in minutes) of allowed inactivity before Single Sign-On (SSO) session expiration.",
+      "type": "integer_t"
+    },
     "standards": {
       "caption": "Compliance Standards: List",
       "description": "Compliance standards are a set of criteria organizations can follow to protect sensitive and confidential information. e.g. <code>NIST SP 800-53, CIS AWS Foundations Benchmark v1.4.0, ISO/IEC 27001</code>",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4431,7 +4431,7 @@
     },
     "sso": {
       "caption": "SSO",
-      "description": "The Single Sign-On (SSO) configuration object provides a structure for normalizing SSO settings and attributes.",
+      "description": "The Single Sign-On (SSO) object provides a structure for normalizing SSO attributes, configuration, and/or settings from Identity Providers.",
       "type": "sso"
     },
     "sso_idle_timeout": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -4026,6 +4026,11 @@
       "description": "The unique identifier of the schedule associated with a scan job.",
       "type": "string_t"
     },
+    "scim": {
+      "caption": "System for Cross-domain Identity Management (SCIM)",
+      "description": "The SCIM Configuration object provides a structured set of attributes related to System for Cross-domain Identity Management (SCIM) protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications.",
+      "type": "scim"
+    },
     "scheme": {
       "caption": "Scheme",
       "description": "The scheme portion of the URL. For example: <code>http</code>, <code>https</code>, <code>ftp</code>, or <code>sftp</code>.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4030,9 +4030,19 @@
       "type": "string_t"
     },
     "scim": {
-      "caption": "System for Cross-domain Identity Management (SCIM)",
-      "description": "The SCIM Configuration object provides a structured set of attributes related to System for Cross-domain Identity Management (SCIM) protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications.",
+      "caption": "SCIM",
+      "description": "The System for Cross-domain Identity Management (SCIM) Configuration object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
       "type": "scim"
+    },
+    "scim_user_schema": {
+      "caption": "SCIM User Schema",
+      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:User' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
+      "type": "json_t"
+    },
+    "scim_group_schema": {
+      "caption": "SCIM Group Schema",
+      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:Group' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
+      "type": "json_t"
     },
     "scheme": {
       "caption": "Scheme",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4037,6 +4037,12 @@
     "scim": {
       "caption": "SCIM",
       "description": "The System for Cross-domain Identity Management (SCIM) resource object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
+      "references": [
+        {
+          "url": "https://datatracker.ietf.org/doc/html/rfc7643", 
+          "description": "System for Cross-domain Identity Management (SCIM) RFC."
+        }
+      ],
       "type": "scim"
     },
     "scim_group_provisioning_enabled": {
@@ -4047,6 +4053,12 @@
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
       "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
+      "references": [
+        {
+          "url": "https://datatracker.ietf.org/doc/html/rfc7643", 
+          "description": "System for Cross-domain Identity Management (SCIM) RFC spec."
+        }
+      ],
       "type": "json_t"
     },
     "scim_user_provisioning_enabled": {
@@ -4057,6 +4069,12 @@
     "scim_user_schema": {
       "caption": "SCIM User Schema",
       "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
+      "references": [
+        {
+          "url": "https://datatracker.ietf.org/doc/html/rfc7643", 
+          "description": "System for Cross-domain Identity Management (SCIM) RFC spec."
+        }
+      ],
       "type": "json_t"
     },
     "scheme": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2226,11 +2226,6 @@
       "type": "group",
       "is_array": true
     },
-    "group_provisioning_enabled": {
-      "caption": "Group Provisioning Enabled",
-      "description": "Indicates whether group provisioning is automated (e.g., for a SCIM resource). See specific usage.",
-      "type": "boolean_t"
-    },
     "handshake_dur": {
       "caption": "Handshake Duration",
       "description": "The amount of total time for the TLS handshake to complete after the TCP connection is established, including client-side delays, in milliseconds.",
@@ -2578,6 +2573,11 @@
       "description": "Indicates if a fix is available for the reported vulnerability.",
       "type": "boolean_t"
     },
+    "is_group_provisioning_enabled": {
+      "caption": "Group Provisioning Enabled",
+      "description": "Indicates whether group provisioning is automated (e.g., for a SCIM resource). See specific usage.",
+      "type": "boolean_t"
+    },
     "is_hotp": {
       "caption": "HMAC-based One-time Password (HOTP)",
       "description": "Whether the authentication factor is an HMAC-based One-time Password (HOTP).",
@@ -2666,6 +2666,11 @@
     "is_trusted": {
       "caption": "Trusted Device",
       "description": "The event occurred on a trusted device.",
+      "type": "boolean_t"
+    },
+    "is_user_provisioning_enabled": {
+      "caption": "User Provisioning Enabled",
+      "description": "Indicates whether user provisioning is automated (e.g., for a SCIM resource). See specific usage.",
       "type": "boolean_t"
     },
     "is_vpn": {
@@ -5012,11 +5017,6 @@
       "caption": "HTTP User-Agent",
       "description": "The request header that identifies the operating system and web browser.",
       "type": "string_t"
-    },
-    "user_provisioning_enabled": {
-      "caption": "User Provisioning Enabled",
-      "description": "Indicates whether user provisioning is automated (e.g., for a SCIM resource). See specific usage.",
-      "type": "boolean_t"
     },
     "user_result": {
       "caption": "User Result",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4041,7 +4041,7 @@
     },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
-      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:Group' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
+      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>.",
       "type": "json_t"
     },
     "scim_user_provisioning_enabled": {
@@ -4051,7 +4051,7 @@
     },
     "scim_user_schema": {
       "caption": "SCIM User Schema",
-      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: 'urn:ietf:params:scim:schemas:core:2.0:User' as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
+      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This object is inclusive of both the basic and Enterprise User Schema Extension.",
       "type": "json_t"
     },
     "scheme": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -4449,7 +4449,7 @@
       "description": "URL for initiating an SSO logout request, allowing sessions to be terminated across applications.",
       "type": "url_t"
     },
-    "sso_metadata_url": {
+    "sso_metadata_endpoint": {
       "caption": "SSO Metadata Endpoint",
       "description": "URL where metadata about the SSO configuration is available (e.g., for SAML configurations).",
       "type": "url_t"

--- a/dictionary.json
+++ b/dictionary.json
@@ -4031,7 +4031,7 @@
     },
     "scim": {
       "caption": "SCIM",
-      "description": "The System for Cross-domain Identity Management (SCIM) Configuration object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
+      "description": "The System for Cross-domain Identity Management (SCIM) resource object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
       "type": "scim"
     },
     "scim_user_schema": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -4054,6 +4054,12 @@
       "description": "The scheme portion of the URL. For example: <code>http</code>, <code>https</code>, <code>ftp</code>, or <code>sftp</code>.",
       "type": "string_t"
     },
+    "scopes": {
+      "caption": "Scopes",
+      "description": "Scopes define the specific permissions or actions that the client is allowed to perform on behalf of the user. Each scope represents a different set of permissions, and the user can selectively grant or deny access to specific scopes during the authorization process.",
+      "is_array": true,
+      "type": "string_t"
+    },
     "score": {
       "caption": "Reputation Score",
       "description": "The reputation score, normalized to the caption of the score_id value. In the case of 'Other', it is defined by the event source.",
@@ -4396,14 +4402,29 @@
       "type": "url_t"
     },
     "sso": {
-      "caption": "Single-Sign On (SSO)",
-      "description": "The SSO configuration object provides a structure for normalizing Single Sign-On (SSO) settings and attributes.",
+      "caption": "SSO",
+      "description": "The Single Sign-On (SSO) configuration object provides a structure for normalizing SSO settings and attributes.",
       "type": "sso"
     },
     "sso_idle_timeout": {
       "caption": "SSO Idle Timeout",
       "description": "Duration (in minutes) of allowed inactivity before Single Sign-On (SSO) session expiration.",
       "type": "integer_t"
+    },
+    "sso_login_endpoint": {
+      "caption": "SSO Login Endpoint",
+      "description": "URL for initiating an SSO login request.",
+      "type": "url_t"
+    },
+    "sso_logout_endpoint": {
+      "caption": "SSO Logout Endpoint",
+      "description": "URL for initiating an SSO logout request, allowing sessions to be terminated across applications.",
+      "type": "url_t"
+    },
+    "sso_metadata_url": {
+      "caption": "SSO Metadata Endpoint",
+      "description": "URL where metadata about the SSO configuration is available (e.g., for SAML configurations).",
+      "type": "url_t"
     },
     "standards": {
       "caption": "Compliance Standards: List",

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -6,7 +6,7 @@
   "observable": 30,
   "attributes": {
     "algorithm": {
-      "description": "The hash algorithm used to create the digital fingerprint, normalized to the caption of 'algorithm_id'. In the case of 'Other', it is defined by the event source.",
+      "description": "The hash algorithm used to create the digital fingerprint, normalized to the caption of <code>algorithm_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
       "requirement": "optional"
     },
     "algorithm_id": {

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -6,35 +6,66 @@
   "attributes": {
     "algorithm": {
       "caption": "Encryption Algorithm",
-      "description": "The encryption algorithm supported by the Identity Provider, normalized to the caption of <code>algorithm_id</code>. In the case of <code>Other</code>, the Encryption Algorithm is defined by the event source."
+      "description": "The encryption algorithm supported by the Identity Provider, normalized to the caption of <code>algorithm_id</code>. In the case of <code>Other</code>, the Encryption Algorithm is defined by the event source.",
+      "requirement": "optional"
     },
     "algorithm_id": {
       "caption": "Encryption Algorithm ID",
-      "description": "The identifier of the normalized encryption algorithm supported by the Identity Provider."
+      "description": "The identifier of the normalized encryption algorithm supported by the Identity Provider.",
+      "requirement": "optional"
     },
     "name": {
-      "description": "The name of the identity provider."
+      "description": "The name of the identity provider.",
+      "requirement": "recommended"
     },
     "digest": {
       "caption": "Certificate Fingerprint",
-      "description": "The fingerprint of the X.509 certificate used by the Identity Provider."
+      "description": "The fingerprint of the X.509 certificate used by the Identity Provider.",
+      "requirement": "optional"
     },
     "domain": {
-      "description": "The primary domain associated with the Identity Provider."
+      "description": "The primary domain associated with the Identity Provider.",
+      "requirement": "optional"
     },
     "issuer": {
-      "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer."
+      "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer.",
+      "requirement": "optional"
     },
     "protocol_name": {
       "caption": "Supported Protocol",
-      "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>."
+      "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+      "requirement": "optional"
+    },
+    "state": {
+      "description": "The state of the Identity Provider, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "state_id": {
+      "description": "The normalized state ID of the Identity Provider to reflect its configuration or activation status.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The state is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The state is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
+        }
+      },
+      "requirement": "optional"
+    },
+    "tenant_uid": {
+      "description": "The tenant ID associated with the Identity Provider.",
+      "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier of the Identity Provider."
+      "description": "The unique identifier of the Identity Provider.",
+      "requirement": "recommended"
     },
     "url_string": {
       "caption": "Configuration URL",
-      "description": "The URL for accessing the configuration or metadata of the Identity Provider."
+      "description": "The URL for accessing the configuration or metadata of the Identity Provider.",
+      "requirement": "optional"
     }
   },
   "constraints": {

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -88,11 +88,5 @@
       "description": "The URL for accessing the configuration or metadata of the Identity Provider.",
       "requirement": "optional"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "uid",
-      "name"
-    ]
   }
 }

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -12,13 +12,13 @@
       "description": "The name of the Identity Provider.",
       "requirement": "recommended"
     },
-    "digest": {
-      "caption": "Certificate Fingerprint",
-      "description": "The fingerprint of the X.509 certificate used by the Identity Provider.",
-      "requirement": "optional"
-    },
     "domain": {
       "description": "The primary domain associated with the Identity Provider.",
+      "requirement": "optional"
+    },
+    "fingerprint": {
+      "caption": "Certificate Fingerprint",
+      "description": "The fingerprint of the X.509 certificate used by the Identity Provider.",
       "requirement": "optional"
     },
     "has_mfa": {

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -5,10 +5,30 @@
   "name": "idp",
   "attributes": {
     "name": {
-      "description":"The name of the identity provider."
+      "description": "The name of the identity provider."
+    },
+    "digital_signature": {
+      "description": "Information about the X.509 certificate used by the Identity Provider.",
+      "requirement": "optional"
+    },
+    "domain": {
+      "description": "The primary domain associated with the Identity Provider."
+    },
+    "issuer": {
+      "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer."
     },
     "uid": {
-      "description":"The unique identifier of the identity provider."
+      "description": "The unique identifier of the Identity Provider."
+    },
+    "url_string": {
+      "caption": "Configuration URL",
+      "description": "The URL for accessing the configuration or metadata of the Identity Provider."
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "uid",
+      "name"
+    ]
   }
 }

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -32,7 +32,8 @@
     },
     "has_mfa": {
       "caption": "MFA Enforced",
-      "description": "The Identity Provider enforces Multi Factor Authentication (MFA)."
+      "description": "The Identity Provider enforces Multi Factor Authentication (MFA).",
+      "requirement": "optional"
     },
     "issuer": {
       "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer.",
@@ -41,6 +42,9 @@
     "protocol_name": {
       "caption": "Supported Protocol",
       "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+      "requirement": "optional"
+    },
+    "scim": {
       "requirement": "optional"
     },
     "state": {

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -14,6 +14,9 @@
       "description": "The identifier of the normalized encryption algorithm supported by the Identity Provider.",
       "requirement": "optional"
     },
+    "auth_factors": {
+      "description": "The Authentication Factors object describes the different types of Multi-Factor Authentication (MFA) methods and/or devices supported by the Identity Provider."
+    },
     "name": {
       "description": "The name of the identity provider.",
       "requirement": "recommended"
@@ -27,6 +30,10 @@
       "description": "The primary domain associated with the Identity Provider.",
       "requirement": "optional"
     },
+    "has_mfa": {
+      "caption": "MFA Enforced",
+      "description": "The Identity Provider enforces Multi Factor Authentication (MFA)."
+    },
     "issuer": {
       "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer.",
       "requirement": "optional"
@@ -37,7 +44,7 @@
       "requirement": "optional"
     },
     "state": {
-      "description": "The state of the Identity Provider, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
+      "description": "The configuration state of the Identity Provider, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
       "requirement": "optional"
     },
     "state_id": {
@@ -45,11 +52,27 @@
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The state is unknown."
+          "description": "The configuration state of the Identity Provider is unknown."
+        },
+        "1": {
+          "caption": "Active",
+          "description": "The Identity Provider is in an Active state, or otherwise Enabled."
+        },
+        "2": {
+          "caption": "Suspended",
+          "description": "The Identity Provider is in a Suspended state."
+        },
+        "3": {
+          "caption": "Deprecated",
+          "description": "The Identity Provider is in a Deprecated state, or is otherwise Disabled."
+        },
+        "4": {
+          "caption": "Deleted",
+          "description": "The Identity Provider is in a Deleted state."
         },
         "99": {
           "caption": "Other",
-          "description": "The state is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
+          "description": "The configuration state of the Identity Provider is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
         }
       },
       "requirement": "optional"

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -38,6 +38,9 @@
     "scim": {
       "requirement": "optional"
     },
+    "sso": {
+      "requirement": "optional"
+    },
     "state": {
       "description": "The configuration state of the Identity Provider, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
       "requirement": "optional"

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -19,10 +19,6 @@
       "caption": "Certificate Fingerprint",
       "description": "The fingerprint of the X.509 certificate used by the Identity Provider."
     },
-    "digital_signature": {
-      "description": "Information about the X.509 certificate used by the Identity Provider.",
-      "requirement": "optional"
-    },
     "domain": {
       "description": "The primary domain associated with the Identity Provider."
     },

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -4,8 +4,20 @@
   "extends": "_entity",
   "name": "idp",
   "attributes": {
+    "algorithm": {
+      "caption": "Encryption Algorithm",
+      "description": "The encryption algorithm supported by the Identity Provider, normalized to the caption of <code>algorithm_id</code>. In the case of <code>Other</code>, the Encryption Algorithm is defined by the event source."
+    },
+    "algorithm_id": {
+      "caption": "Encryption Algorithm ID",
+      "description": "The identifier of the normalized encryption algorithm supported by the Identity Provider."
+    },
     "name": {
       "description": "The name of the identity provider."
+    },
+    "digest": {
+      "caption": "Certificate Fingerprint",
+      "description": "The fingerprint of the X.509 certificate used by the Identity Provider."
     },
     "digital_signature": {
       "description": "Information about the X.509 certificate used by the Identity Provider.",
@@ -16,6 +28,10 @@
     },
     "issuer": {
       "description": "The unique identifier (often a URL) used by the Identity Provider as its issuer."
+    },
+    "protocol_name": {
+      "caption": "Supported Protocol",
+      "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>."
     },
     "uid": {
       "description": "The unique identifier of the Identity Provider."

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -4,16 +4,6 @@
   "extends": "_entity",
   "name": "idp",
   "attributes": {
-    "algorithm": {
-      "caption": "Encryption Algorithm",
-      "description": "The encryption algorithm supported by the Identity Provider, normalized to the caption of <code>algorithm_id</code>. In the case of <code>Other</code>, the Encryption Algorithm is defined by the event source.",
-      "requirement": "optional"
-    },
-    "algorithm_id": {
-      "caption": "Encryption Algorithm ID",
-      "description": "The identifier of the normalized encryption algorithm supported by the Identity Provider.",
-      "requirement": "optional"
-    },
     "auth_factors": {
       "description": "The Authentication Factors object describes the different types of Multi-Factor Authentication (MFA) methods and/or devices supported by the Identity Provider.",
       "requirement": "optional"

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -15,7 +15,8 @@
       "requirement": "optional"
     },
     "auth_factors": {
-      "description": "The Authentication Factors object describes the different types of Multi-Factor Authentication (MFA) methods and/or devices supported by the Identity Provider."
+      "description": "The Authentication Factors object describes the different types of Multi-Factor Authentication (MFA) methods and/or devices supported by the Identity Provider.",
+      "requirement": "optional"
     },
     "name": {
       "description": "The name of the Identity Provider.",

--- a/objects/idp.json
+++ b/objects/idp.json
@@ -18,7 +18,7 @@
       "description": "The Authentication Factors object describes the different types of Multi-Factor Authentication (MFA) methods and/or devices supported by the Identity Provider."
     },
     "name": {
-      "description": "The name of the identity provider.",
+      "description": "The name of the Identity Provider.",
       "requirement": "recommended"
     },
     "digest": {
@@ -60,7 +60,7 @@
         },
         "1": {
           "caption": "Active",
-          "description": "The Identity Provider is in an Active state, or otherwise Enabled."
+          "description": "The Identity Provider is in an Active state, or otherwise enabled."
         },
         "2": {
           "caption": "Suspended",
@@ -68,7 +68,7 @@
         },
         "3": {
           "caption": "Deprecated",
-          "description": "The Identity Provider is in a Deprecated state, or is otherwise Disabled."
+          "description": "The Identity Provider is in a Deprecated state, or is otherwise disabled."
         },
         "4": {
           "caption": "Deleted",

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -105,7 +105,8 @@
       },
       "uid_alt": {
         "caption": "External ID",
-        "description": "A String that is an identifier for the resource as defined by the provisioning client. The 'externalId' may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain's identifier of the resource and the identifier used by the service provider."
+        "description": "A String that is an identifier for the resource as defined by the provisioning client. The 'externalId' may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain's identifier of the resource and the identifier used by the service provider.",
+        "requirement": "optional"
       },
       "url_string": {
         "caption": "SCIM Endpoint URL",

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -4,10 +4,25 @@
     "extends": "object",
     "name": "scim",
     "attributes": {
-      "value": {
-        "description": "The digital fingerprint value.",
-        "requirement": "required",
-        "type": "file_hash_t"
+      "protocol_name": {
+        "caption": "Supported Protocol",
+        "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+        "requirement": "optional"
+      },
+      "vendor_name": {
+        "caption": "Service Provider",
+        "description": "Name of the vendor or service provider implementing SCIM. E.g., <code>Okta</code>, <code>Auth0</code>, <code>Microsoft</code>.",
+        "requirement": "optional"
+      },
+      "version": {
+        "caption": "SCIM Version",
+        "description": "SCIM protocol version supported e.g., <code>SCIM 2.0</code>.",
+        "requirement": "recommended"
+      },
+      "url_string": {
+        "caption": "SCIM Endpoint URL",
+        "description": "The primary URL for SCIM API requests.",
+        "requirement": "optional"
       }
     }
   }

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -1,0 +1,14 @@
+{
+    "caption": "System for Cross-domain Identity Management (SCIM)",
+    "description": "The SCIM Configuration object provides a structured set of attributes related to System for Cross-domain Identity Management (SCIM) protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications.",
+    "extends": "object",
+    "name": "scim",
+    "attributes": {
+      "value": {
+        "description": "The digital fingerprint value.",
+        "requirement": "required",
+        "type": "file_hash_t"
+      }
+    }
+  }
+  

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -12,6 +12,10 @@
         "description": "The normalized identifier of the authorization protocol used by the SCIM resource.",
         "requirement": "optional"
       },
+      "created_time": {
+        "description": "When the SCIM resource was added to the service provider.",
+        "requirement": "optional"
+      },
       "error_message": {
         "caption": "Last Error Message",
         "description": "Message or code associated with the last encountered error.",
@@ -20,6 +24,10 @@
       "last_run_time": {
         "caption": "Last Sync Time",
         "description": "Timestamp of the most recent successful synchronization.",
+        "requirement": "optional"
+      },
+      "modified_time": {
+        "description": "The most recent time when the SCIM resource was updated at the service provider.",
         "requirement": "optional"
       },
       "name": {
@@ -34,6 +42,12 @@
       "rate_limit": {
         "description": "Maximum number of requests allowed by the SCIM resource within a specified time frame to avoid throttling.",
         "requirement": "optional"
+      },
+      "scim_group_schema": {
+        "requirement": "recommended"
+      },
+      "scim_user_schema": {
+        "requirement": "recommended"
       },
       "state": {
         "description": "The provisioning state of the SCIM resource, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -43,8 +43,14 @@
         "description": "Maximum number of requests allowed by the SCIM resource within a specified time frame to avoid throttling.",
         "requirement": "optional"
       },
+      "scim_group_provisioning_enabled": {
+        "requirement": "optional"
+      },
       "scim_group_schema": {
         "requirement": "recommended"
+      },
+      "scim_user_provisioning_enabled": {
+        "requirement": "optional"
       },
       "scim_user_schema": {
         "requirement": "recommended"

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -21,9 +21,14 @@
         "description": "Message or code associated with the last encountered error.",
         "requirement": "optional"
       },
-      "group_provisioning_enabled": {
+      "is_group_provisioning_enabled": {
         "caption": "SCIM Group Provisioning Enabled",
         "description": "Indicates whether the SCIM resource is configured to provision groups, automatically or otherwise.",
+        "requirement": "optional"
+      },
+      "is_user_provisioning_enabled": {
+        "caption": "SCIM User Provisioning Enabled",
+        "description": "Indicates whether the SCIM resource is configured to provision users, automatically or otherwise.",
         "requirement": "optional"
       },
       "last_run_time": {
@@ -110,11 +115,6 @@
       "url_string": {
         "caption": "SCIM Endpoint URL",
         "description": "The primary URL for SCIM API requests.",
-        "requirement": "optional"
-      },
-      "user_provisioning_enabled": {
-        "caption": "SCIM User Provisioning Enabled",
-        "description": "Indicates whether the SCIM resource is configured to provision users, automatically or otherwise.",
         "requirement": "optional"
       }
     }

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -21,6 +21,11 @@
         "description": "Message or code associated with the last encountered error.",
         "requirement": "optional"
       },
+      "group_provisioning_enabled": {
+        "caption": "SCIM Group Provisioning Enabled",
+        "description": "Indicates whether the SCIM resource is configured to provision groups, automatically or otherwise.",
+        "requirement": "optional"
+      },
       "last_run_time": {
         "caption": "Last Sync Time",
         "description": "Timestamp of the most recent successful synchronization.",
@@ -43,14 +48,8 @@
         "description": "Maximum number of requests allowed by the SCIM resource within a specified time frame to avoid throttling.",
         "requirement": "optional"
       },
-      "scim_group_provisioning_enabled": {
-        "requirement": "optional"
-      },
       "scim_group_schema": {
         "requirement": "recommended"
-      },
-      "scim_user_provisioning_enabled": {
-        "requirement": "optional"
       },
       "scim_user_schema": {
         "requirement": "recommended"
@@ -111,6 +110,11 @@
       "url_string": {
         "caption": "SCIM Endpoint URL",
         "description": "The primary URL for SCIM API requests.",
+        "requirement": "optional"
+      },
+      "user_provisioning_enabled": {
+        "caption": "SCIM User Provisioning Enabled",
+        "description": "Indicates whether the SCIM resource is configured to provision users, automatically or otherwise.",
         "requirement": "optional"
       }
     }

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -105,7 +105,7 @@
       },
       "uid_alt": {
         "caption": "External ID",
-        "description": "A String that is an identifier for the resource as defined by the provisioning client. The 'externalId' may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain's identifier of the resource and the identifier used by the service provider.",
+        "description": "A String that is an identifier for the resource as defined by the provisioning client. The <code>externalId</code> may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain's identifier of the resource and the identifier used by the service provider.",
         "requirement": "optional"
       },
       "url_string": {

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -12,9 +12,61 @@
         "description": "The normalized identifier of the authorization protocol used by the SCIM Configuration.",
         "requirement": "optional"
       },
+      "error_message": {
+        "caption": "Last Error Message",
+        "description": "Message or code associated with the last encountered error.",
+        "requirement": "optional"
+      },
+      "last_run_time": {
+        "caption": "Last Sync Time",
+        "description": "Timestamp of the most recent successful synchronization.",
+        "requirement": "optional"
+      },
+      "name": {
+        "description": "The name of the SCIM Configuration.",
+        "requirement": "recommended"
+      },
       "protocol_name": {
         "caption": "Supported Protocol",
         "description": "The supported protocol for the SCIM Configuration. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+        "requirement": "optional"
+      },
+      "rate_limit": {
+        "description": "Maximum number of requests allowed by the SCIM Configuration within a specified time frame to avoid throttling.",
+        "requirement": "optional"
+      },
+      "state": {
+        "description": "The provisioning state of the SCIM Configuration, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
+        "requirement": "optional"
+      },
+      "state_id": {
+        "description": "The normalized state ID of the SCIM Configuration to reflect its activation status.",
+        "enum": {
+          "0": {
+            "caption": "Unknown",
+            "description": "The provisioning state of the SCIM Configuration is unknown."
+          },
+          "1": {
+            "caption": "Pending",
+            "description": "The SCIM Configuration is Pending activation or creation."
+          },
+          "2": {
+            "caption": "Active",
+            "description": "The SCIM Configuration is in an Active state, or otherwise enabled."
+          },
+          "3": {
+            "caption": "Failed",
+            "description": "The SCIM Configuration is in a Failed state."
+          },
+          "4": {
+            "caption": "Deleted",
+            "description": "The SCIM Configuration is in a Deleted state, or otherwise disabled."
+          },
+          "99": {
+            "caption": "Other",
+            "description": "The provisioning state of the SCIM Configuration is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
+          }
+        },
         "requirement": "optional"
       },
       "vendor_name": {
@@ -25,6 +77,10 @@
       "version": {
         "caption": "SCIM Version",
         "description": "SCIM protocol version supported e.g., <code>SCIM 2.0</code>.",
+        "requirement": "recommended"
+      },
+      "uid": {
+        "description": "The unique identifier of the SCIM Configuration.",
         "requirement": "recommended"
       },
       "url_string": {

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -9,7 +9,7 @@
         "requirement": "optional"
       },
       "auth_protocol_id": {
-        "description": "The normalized identifier of the authorization protocol used by the SCIM Configuration.",
+        "description": "The normalized identifier of the authorization protocol used by the SCIM resource.",
         "requirement": "optional"
       },
       "error_message": {
@@ -23,48 +23,48 @@
         "requirement": "optional"
       },
       "name": {
-        "description": "The name of the SCIM Configuration.",
+        "description": "The name of the SCIM resource.",
         "requirement": "recommended"
       },
       "protocol_name": {
         "caption": "Supported Protocol",
-        "description": "The supported protocol for the SCIM Configuration. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+        "description": "The supported protocol for the SCIM resource. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
         "requirement": "optional"
       },
       "rate_limit": {
-        "description": "Maximum number of requests allowed by the SCIM Configuration within a specified time frame to avoid throttling.",
+        "description": "Maximum number of requests allowed by the SCIM resource within a specified time frame to avoid throttling.",
         "requirement": "optional"
       },
       "state": {
-        "description": "The provisioning state of the SCIM Configuration, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
+        "description": "The provisioning state of the SCIM resource, normalized to the caption of the <code>state_id</code> value. In the case of <code>Other</code>, it is defined by the event source.",
         "requirement": "optional"
       },
       "state_id": {
-        "description": "The normalized state ID of the SCIM Configuration to reflect its activation status.",
+        "description": "The normalized state ID of the SCIM resource to reflect its activation status.",
         "enum": {
           "0": {
             "caption": "Unknown",
-            "description": "The provisioning state of the SCIM Configuration is unknown."
+            "description": "The provisioning state of the SCIM resource is unknown."
           },
           "1": {
             "caption": "Pending",
-            "description": "The SCIM Configuration is Pending activation or creation."
+            "description": "The SCIM resource is Pending activation or creation."
           },
           "2": {
             "caption": "Active",
-            "description": "The SCIM Configuration is in an Active state, or otherwise enabled."
+            "description": "The SCIM resource is in an Active state, or otherwise enabled."
           },
           "3": {
             "caption": "Failed",
-            "description": "The SCIM Configuration is in a Failed state."
+            "description": "The SCIM resource is in a Failed state."
           },
           "4": {
             "caption": "Deleted",
-            "description": "The SCIM Configuration is in a Deleted state, or otherwise disabled."
+            "description": "The SCIM resource is in a Deleted state, or otherwise disabled."
           },
           "99": {
             "caption": "Other",
-            "description": "The provisioning state of the SCIM Configuration is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
+            "description": "The provisioning state of the SCIM resource is not mapped. See the <code>state</code> attribute, which contains a data source specific value."
           }
         },
         "requirement": "optional"

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -1,6 +1,6 @@
 {
-    "caption": "System for Cross-domain Identity Management (SCIM)",
-    "description": "The SCIM Configuration object provides a structured set of attributes related to System for Cross-domain Identity Management (SCIM) protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications.",
+    "caption": "SCIM",
+    "description": "The System for Cross-domain Identity Management (SCIM) Configuration object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
     "extends": "object",
     "name": "scim",
     "attributes": {
@@ -80,8 +80,12 @@
         "requirement": "recommended"
       },
       "uid": {
-        "description": "The unique identifier of the SCIM Configuration.",
+        "description": "A unique identifier for a SCIM resource as defined by the service provider.",
         "requirement": "recommended"
+      },
+      "uid_alt": {
+        "caption": "External ID",
+        "description": "A String that is an identifier for the resource as defined by the provisioning client. The 'externalId' may simplify identification of a resource between the provisioning client and the service provider by allowing the client to use a filter to locate the resource with an identifier from the provisioning domain, obviating the need to store a local mapping between the provisioning domain's identifier of the resource and the identifier used by the service provider."
       },
       "url_string": {
         "caption": "SCIM Endpoint URL",

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -4,9 +4,17 @@
     "extends": "object",
     "name": "scim",
     "attributes": {
+      "auth_protocol": {
+        "description": "The authorization protocol as defined by the caption of <code>auth_protocol_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
+        "requirement": "optional"
+      },
+      "auth_protocol_id": {
+        "description": "The normalized identifier of the authorization protocol used by the SCIM Configuration.",
+        "requirement": "optional"
+      },
       "protocol_name": {
         "caption": "Supported Protocol",
-        "description": "The supported protocol of the Identity Provider. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
+        "description": "The supported protocol for the SCIM Configuration. E.g., <code>SAML</code>, <code>OIDC</code>, or <code>OAuth2</code>.",
         "requirement": "optional"
       },
       "vendor_name": {

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -51,7 +51,7 @@
       "sso_logout_endpoint": {
         "requirement": "optional"
       },
-      "sso_metadata_url": {
+      "sso_metadata_endpoint": {
         "requirement": "optional"
       },
       "vendor_name": {

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -1,6 +1,6 @@
 {
     "caption": "SSO",
-    "description": "The Single Sign-On (SSO) configuration object provides a structure for normalizing SSO settings and attributes.",
+    "description": "The Single Sign-On (SSO) object provides a structure for normalizing SSO attributes, configuration, and/or settings from Identity Providers.",
     "extends": "object",
     "name": "sso",
     "attributes": {
@@ -14,7 +14,7 @@
       },
       "certificate": {
         "caption": "SAML Certificate",
-        "description": "Digital Signature associated with the SSO configuration, e.g., SAML X.509 certificate details.",
+        "description": "Digital Signature associated with the SSO resource, e.g., SAML X.509 certificate details.",
         "requirement": "recommended"
       },
       "created_time": {

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -26,6 +26,26 @@
         "description": "The duration (in minutes) for an SSO session, after which re-authentication is required.",
         "requirement": "optional"
       },
+      "idle_timeout": {
+        "caption": "SSO Idle Timeout",
+        "description": "Duration (in minutes) of allowed inactivity before Single Sign-On (SSO) session expiration.",
+        "requirement": "optional"
+      },
+      "login_endpoint": {
+        "caption": "SSO Login Endpoint",
+        "description": "URL for initiating an SSO login request.",
+        "requirement": "optional"
+      },
+      "logout_endpoint": {
+        "caption": "SSO Logout Endpoint",
+        "description": "URL for initiating an SSO logout request, allowing sessions to be terminated across applications.",
+        "requirement": "optional"
+      },
+      "metadata_endpoint": {
+        "caption": "SSO Metadata Endpoint",
+        "description": "URL where metadata about the SSO configuration is available (e.g., for SAML configurations).",
+        "requirement": "optional"
+      },
       "modified_time": {
         "description": "The most recent time when the SSO resource was updated.",
         "requirement": "optional"
@@ -40,18 +60,6 @@
         "requirement": "optional"
       },
       "scopes": {
-        "requirement": "optional"
-      },
-      "sso_idle_timeout": {
-        "requirement": "optional"
-      },
-      "sso_login_endpoint": {
-        "requirement": "optional"
-      },
-      "sso_logout_endpoint": {
-        "requirement": "optional"
-      },
-      "sso_metadata_endpoint": {
         "requirement": "optional"
       },
       "vendor_name": {

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -4,8 +4,43 @@
     "extends": "object",
     "name": "sso",
     "attributes": {
-      "digital_signature": {
+      "certificate": {
+        "caption": "X509 Certificates",
         "description": "Digital Signature associated with the SSO configuration, e.g., SAML X.509 certificate details.",
+        "requirement": "recommended"
+      },
+      "created_time": {
+        "description": "When the SSO resource was created.",
+        "requirement": "optional"
+      },
+      "duration_mins": {
+        "caption": "SSO Session Duration",
+        "description": "The duration (in minutes) for an SSO session, after which re-authentication is required.",
+        "requirement": "optional"
+      },
+      "modified_time": {
+        "description": "The most recent time when the SSO resource was updated.",
+        "requirement": "optional"
+      },
+      "name": {
+        "description": "The name of the SSO resource.",
+        "requirement": "recommended"
+      },
+      "protocol_name": {
+        "caption": "Supported Protocol",
+        "description": "The supported protocol for the SSO resource. E.g., <code>SAML</code> or <code>OIDC</code>.",
+        "requirement": "optional"
+      },
+      "sso_idle_timeout": {
+        "requirement": "optional"
+      },
+      "vendor_name": {
+        "caption": "Service Provider",
+        "description": "Name of the vendor or service provider implementing SSO. E.g., <code>Okta</code>, <code>Auth0</code>, <code>Microsoft</code>.",
+        "requirement": "optional"
+      },
+      "uid": {
+        "description": "A unique identifier for a SSO resource.",
         "requirement": "recommended"
       }
     }

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -1,11 +1,19 @@
 {
-    "caption": "Single-Sign On (SSO)",
-    "description": "The SSO configuration object provides a structure for normalizing Single Sign-On (SSO) settings and attributes.",
+    "caption": "SSO",
+    "description": "The Single Sign-On (SSO) configuration object provides a structure for normalizing SSO settings and attributes.",
     "extends": "object",
     "name": "sso",
     "attributes": {
+      "auth_protocol": {
+        "description": "The authorization protocol as defined by the caption of <code>auth_protocol_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
+        "requirement": "optional"
+      },
+      "auth_protocol_id": {
+        "description": "The normalized identifier of the authentication protocol used by the SSO resource.",
+        "requirement": "optional"
+      },
       "certificate": {
-        "caption": "X509 Certificates",
+        "caption": "SAML Certificate",
         "description": "Digital Signature associated with the SSO configuration, e.g., SAML X.509 certificate details.",
         "requirement": "recommended"
       },
@@ -31,7 +39,19 @@
         "description": "The supported protocol for the SSO resource. E.g., <code>SAML</code> or <code>OIDC</code>.",
         "requirement": "optional"
       },
+      "scopes": {
+        "requirement": "optional"
+      },
       "sso_idle_timeout": {
+        "requirement": "optional"
+      },
+      "sso_login_endpoint": {
+        "requirement": "optional"
+      },
+      "sso_logout_endpoint": {
+        "requirement": "optional"
+      },
+      "sso_metadata_url": {
         "requirement": "optional"
       },
       "vendor_name": {

--- a/objects/sso.json
+++ b/objects/sso.json
@@ -1,0 +1,12 @@
+{
+    "caption": "Single-Sign On (SSO)",
+    "description": "The SSO configuration object provides a structure for normalizing Single Sign-On (SSO) settings and attributes.",
+    "extends": "object",
+    "name": "sso",
+    "attributes": {
+      "digital_signature": {
+        "description": "Digital Signature associated with the SSO configuration, e.g., SAML X.509 certificate details.",
+        "requirement": "recommended"
+      }
+    }
+  }


### PR DESCRIPTION
#### Description of changes:

Improves the Identity Provider (`idp`) Object by expanding greatly on its remit and original two attributes, seemingly this was made only for support mapping of CloudTrail logs, now the IDP object can be used to describe a multitude of configurations related to IDPs and their configurations such as those in AWS (Identity Center), Google Workspace, Salesforce, and more.

- Creates a new `scim` Object to represent System for Cross-domain Identity Management (SCIM) resource configurations as part of an IDP
- Creates a new `sso` Object to represent Single Sign-On resource configurations as part of an IDP
- Adds several new dictionary attributes that are SSO- and SCIM-specific, see CHANGELOG for more details.
- Adds several new attributes to the `idp` Object to reflect details that can be programmatically retrieved via APIs or details that are expressed in logs from a variety of tools
- Fixes formatting for several descriptions, replace single quotes with <code> tags where appropriate

And yes, I ran the server this time 🎃 

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/47a30fb8-d4a1-418f-aa3d-d1d91d1fd2f9">

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/6084986d-25f6-4d86-8c66-b68150e2a0f2">

<img width="1913" alt="image" src="https://github.com/user-attachments/assets/d20ed757-6ad6-4435-b4ba-f3f425ae3a5c">