### PR TITLE
Add Common Process Identifier (CPID) field to process entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,13 @@ Thankyou! -->
 ### Added
 * #### Dictionary Attributes 
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  1. Added `cpid` as a `uuid_t`. [#1246](https://github.com/ocsf/ocsf-schema/pull/1246)
 	
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
+  1. Added `cpid` to `process_entity` object. [#1246](https://github.com/ocsf/ocsf-schema/pull/1246)
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -1285,6 +1285,13 @@
         }
       }
     },
+    "cpid": {
+      "caption": "Common Process Identifier",
+      "source": "cpid",
+      "references": [{"url": "https://github.com/ocsf/common-process-id", "description": "OCSF Common Process Identifier (CPID) Specification"}],
+      "description": "A unique process identifier that can be assigned deterministically by multiple system data producers.",
+      "type": "uuid_t"
+    },
     "cpu_bits": {
       "caption": "CPU Bits",
       "description": "The cpu architecture, the number of bits used for addressing in memory. For example: <code>32</code> or <code>64</code>.",

--- a/objects/process.json
+++ b/objects/process.json
@@ -67,7 +67,8 @@
   "constraints": {
     "at_least_one": [
       "pid",
-      "uid"
+      "uid",
+      "cpid"
     ]
   },
   "profiles": [

--- a/objects/process_entity.json
+++ b/objects/process_entity.json
@@ -7,6 +7,9 @@
     "cmd_line": {
       "requirement": "recommended"
     },
+    "cpid":{
+      "requirement": "recommended"
+    },
     "created_time": {
       "description": "The time when the process was created/started.",
       "requirement": "recommended"
@@ -32,7 +35,8 @@
       "name",
       "path",
       "pid",
-      "uid"
+      "uid",
+      "cpid"
     ]
   }
 }


### PR DESCRIPTION
UUID attribute created for cpid.
Attribute added to the process object.
Reference feature used to link to CPID specification.

#### Related Issue: 
https://github.com/ocsf/ocsf-schema/discussions/1205

#### Description of changes:
The Common Process Identifier (CPID) provides a way to deterministically create a unique process identifier.
This enable multiple system/endpoint data producers to assign the same unique identifier to the same process.
However, existing endpoint software implementations have their own process identification systems which would get mapped to `process.uid`.
This pull request adds a new `cpid` field to `process` so `process.uid` can continue to be used for existing unique identification schemes.

More details in the CPID spec here: https://github.com/ocsf/common-process-id/blob/main/specification.md