### PR TITLE
fix(objects/device): typo in groups description

### DIFF
--- a/objects/device.json
+++ b/objects/device.json
@@ -29,7 +29,7 @@
       "requirement": "optional"
     },
     "groups": {
-      "description": "The group names to which the device belongs. For example: <code>[\"Windows Laptops\", \"Engineering\"]<code/>.",
+      "description": "The group names to which the device belongs. For example: <code>[\"Windows Laptops\", \"Engineering\"]</code>.",
       "requirement": "optional"
     },
     "hostname": {


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

Fixes a typo in the closing `<code>` tag of the Device groups description.

### Delete once you have confirmed the following: 

1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
4. Is your PR title in sync with the description?
