### PR TITLE
Add Kernel Release field to OS object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Thankyou! -->
     1. Added `is_encrypted` as `boolean_t`; `column_name`, `cell_name`, `storage_class`, `key_uid`, `json_path` as `string_t` & `column_number`, `row_number`, `page_number`, `record_index_in_array` as `integer_t`. #1245
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
+    1. Added `kernel_release` as a `string_t`.
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
@@ -120,6 +121,7 @@ Thankyou! -->
     1. Added `discovery_details`, `occurrence_details`, `status` trio, `total`, `uid`, `size`, & `src_url` to the `data_classification` object. #1245
     1. `data_bucket` object now inherits `resource_details` instead of `_entity`. Also, added `encryption_details` object to the `data_bucket` object. #1245
     1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
+    1. Added `kernel_release` to `os` object.
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,12 +124,9 @@ Thankyou! -->
     1. Added `discovery_details`, `occurrence_details`, `status` trio, `total`, `uid`, `size`, & `src_url` to the `data_classification` object. #1245
     1. `data_bucket` object now inherits `resource_details` instead of `_entity`. Also, added `encryption_details` object to the `data_bucket` object. #1245
     1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
-<<<<<<< HEAD
-    1. Added `kernel_release` to `os` object.
-=======
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
->>>>>>> 5ac9b788383a2ca54680aef0c205922a60249a7c
+    1. Added `kernel_release` to `os` object.
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -2740,6 +2740,11 @@
       "description": "The kernel resource object that pertains to the event.",
       "type": "kernel"
     },
+    "kernel_release": {
+      "caption": "Kernel Release",
+      "description": "The kernel release of the operating system. On Unix-based systems, this is determined from the <code>uname -r</code> command output, for example \"5.15.0-122-generic\". On Windows, this is the same as the OS version.",
+      "type": "string_t"
+    },
     "key_length": {
       "caption": "Key Length",
       "description": "The length of the encryption key.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2742,7 +2742,7 @@
     },
     "kernel_release": {
       "caption": "Kernel Release",
-      "description": "The kernel release of the operating system. On Unix-based systems, this is determined from the <code>uname -r</code> command output, for example \"5.15.0-122-generic\". On Windows, this is the same as the OS version.",
+      "description": "The kernel release of the operating system. On Unix-based systems, this is determined from the <code>uname -r</code> command output, for example \"5.15.0-122-generic\".",
       "type": "string_t"
     },
     "key_length": {

--- a/objects/os.json
+++ b/objects/os.json
@@ -76,6 +76,9 @@
     "version": {
       "description": "The version of the OS running on the device that originated the event. For example: \"Windows 10\", \"OS X 10.7\", or \"iOS 9\".",
       "requirement": "optional"
+    },
+    "kernel_release": {
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/1242

#### Description of changes:

This change adds a new `kernel_release` field to the `os` object.

<img width="1450" alt="image" src="https://github.com/user-attachments/assets/46481f6a-acc0-4695-bda3-aa4e4e9a7d43">