### PR TITLE
Minor addition: Adding a new attribute to keyvalue object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Thankyou! -->
     1. Added `is_encrypted` as `boolean_t`; `column_name`, `cell_name`, `storage_class`, `key_uid`, `json_path` as `string_t` & `column_number`, `row_number`, `page_number`, `record_index_in_array` as `integer_t`. #1245
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
+    1. Added `values` as an array of `string_t`. #1251
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
@@ -120,6 +121,7 @@ Thankyou! -->
     1. Added `discovery_details`, `occurrence_details`, `status` trio, `total`, `uid`, `size`, & `src_url` to the `data_classification` object. #1245
     1. `data_bucket` object now inherits `resource_details` instead of `_entity`. Also, added `encryption_details` object to the `data_bucket` object. #1245
     1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
+    1. Added `values` to `key_value_object`. #1251
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -5040,7 +5040,7 @@
       "type": "string_t"
     },
     "values": {
-      "caption": "Value",
+      "caption": "Values",
       "description": "An array of values associated to an attribute. See specific usage.",
       "type": "string_t",
       "is_array": true

--- a/dictionary.json
+++ b/dictionary.json
@@ -5036,8 +5036,14 @@
     },
     "value": {
       "caption": "Value",
-      "description": "The value that pertains to the object. See specific usage.",
+      "description": "The value associated to an attribute. See specific usage.",
       "type": "string_t"
+    },
+    "values": {
+      "caption": "Value",
+      "description": "An array of values associated to an attribute. See specific usage.",
+      "type": "string_t",
+      "is_array": true
     },
     "variable_name": {
       "caption": "Variable Name",

--- a/objects/key_value_object.json
+++ b/objects/key_value_object.json
@@ -10,7 +10,17 @@
     },
     "value": {
       "description": "The value associated to the key.",
-      "requirement": "required"
+      "requirement": "optional"
+    },
+    "values": {
+      "description": "Optionall, the values associated to the key. You can populate this attribute, when you have multiple values for the same key.",
+      "requirement": "optional"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "value",
+      "values"
+    ]
   }
 }


### PR DESCRIPTION
#### Description of changes
1. Added `values` as string array attr to dict
2. Added as an optional attr to the key_value object. This will allow users to populate multiple values of a key, without having to duplicate the entire object in cases where a key has multiple values. Refer to the example below of control_parameters which is of type key_value_object - 
```
"control_parameters": [
      {
        "name": "authorizedTcpPorts",
        "values": [
          "443",
          "1020",
          "1021",
          "1022",
          "1023",
          "1024",
          "1025"
        ]
      }
```

