### PR TITLE
Adding vendor provided severity info to finding_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Thankyou! -->
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
     1. Added `values` as an array of `string_t`. #1251
-    1. Added `kernel_release` as a `string_t`.
+    1. Added `kernel_release` as a `string_t`. #1249
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
@@ -83,6 +83,7 @@ Thankyou! -->
     1. Added `discovery_details`, `encryption_details`, `occurrence_details` objects. #1245
     1. Added `scim` object. #1239
     1. Added `sso` object. #1239
+    1. Added `vendor_attributes` object. #1257
 
 ### Improved
 * #### Event Classes
@@ -126,7 +127,8 @@ Thankyou! -->
     1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
-    1. Added `kernel_release` to `os` object.
+    1. Added `kernel_release` to `os` object. #1249
+    1. Added `vendor_attributes` to `finding_info` object. #1257
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,10 @@ Thankyou! -->
     1. Added `risk_details` to `data_security_finding` class. #1178
     1. Removed constraint from `group_management` class. #1193
     1. Added `Archived|5` as an enum item to `status_id` attribute in Findings classes. #1219
-    1. Added a `Trace` `activity_id` to the `Email Activity` class. #1252
+    1. Added a `Trace`, `activity_id` to the `Email Activity` class. #1252
+    1. Added `vendor_attributes` to all `Findings` Category classes. #1257
 * #### Profiles
-    1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178
+    1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
     1. Added `policy` attribute to the `security_control` profile. #1178
 * #### Objects
@@ -128,7 +129,6 @@ Thankyou! -->
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
     1. Added `kernel_release` to `os` object. #1249
-    1. Added `vendor_attributes` to `finding_info` object. #1257
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -5060,6 +5060,11 @@
       "description": "The CVSS vector string is a text representation of a set of CVSS metrics. It is commonly used to record or transfer CVSS metric information in a concise form. For example: <code>3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H</code>.",
       "type": "string_t"
     },
+    "vendor_attributes":{
+      "caption": "Vendor Attributes",
+      "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.",
+      "type": "vendor_attributes"
+    },
     "vendor_name": {
       "caption": "Vendor Name",
       "description": "The name of the vendor. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -5069,7 +5069,7 @@
     },
     "vendor_attributes":{
       "caption": "Vendor Attributes",
-      "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.",
+      "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.",
       "type": "vendor_attributes"
     },
     "vendor_name": {

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -93,6 +93,9 @@
           "description": "The Finding was archived."
         }
       }
+    },
+    "vendor_attributes": {
+      "requirement": "optional"
     }
   },
   "profiles": [

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -140,6 +140,9 @@
       "group": "context",
       "requirement": "optional"
     },
+    "vendor_attributes": {
+      "requirement": "optional"
+    },
     "verdict": {
       "group": "primary",
       "requirement": "recommended"

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -63,6 +63,9 @@
     "uid": {
       "description": "The unique identifier of the reported finding.",
       "requirement": "required"
+    },
+    "vendor_attributes": {
+      "requirement": "optional"
     }
   }
 }

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -63,9 +63,6 @@
     "uid": {
       "description": "The unique identifier of the reported finding.",
       "requirement": "required"
-    },
-    "vendor_attributes": {
-      "requirement": "optional"
     }
   }
 }

--- a/objects/vendor_attributes.json
+++ b/objects/vendor_attributes.json
@@ -1,0 +1,17 @@
+{
+  "caption": "Vendor Attributes",
+  "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.",
+  "extends": "object",
+  "name": "vendor_attributes",
+  "attributes": {
+    "severity": {
+      "description": "The finding severity, as reported by the Vendor (Finding Provider). The value should be normalized to the caption of the <code>severity_id</code> value. In the case of 'Other', it is defined by the source.",
+      "requirement": "optional"
+    },
+    "severity_id": {
+      "description": "The finding severity ID, as reported by the Vendor (Finding Provider).",
+      "requirement": "optional"
+    }
+  }
+}
+

--- a/objects/vendor_attributes.json
+++ b/objects/vendor_attributes.json
@@ -1,6 +1,6 @@
 {
   "caption": "Vendor Attributes",
-  "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.",
+  "description": "The Vendor Attributes object can be used to represent values of attributes populated by the Vendor/Finding Provider. It can help distinguish between the vendor-prodvided values and consumer-updated values, of key attributes like <code>severity_id</code>.<br>The original finding producer should not populate this object. It should be populated by consuming systems that support data mutability.",
   "extends": "object",
   "name": "vendor_attributes",
   "attributes": {


### PR DESCRIPTION
#### Scenario that this change aims to support

Consider an finding vendor/producer emits a Finding event. The event is consumed by a different system which allow mutability of events, effectively, allowing end-users to update values in the finding. Case in point, consider `severity`. In such a case, how do you ensure the original vendor/producer's severity value is not lost? -> By utilizing this object to store the original values. The end-user can the simply update the top level values in the finding, as the system would maintain the original values in this object.

#### Description of changes:

1. Adding a new object `vendor_attributes` as an optional attribute to all Findings category classes (except the deprecated Security Finding class).
2. Relevant dictionary entries.
3. Fixing missing PR number from a previous changelog entry. #1249 

Object Details - 
![Screenshot 2024-11-20 at 10 58 52](https://github.com/user-attachments/assets/b28988b3-7d19-4a22-97de-38f8b14f20ea)

