### PR TITLE
Add missing PR number to kernel_release changes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Thankyou! -->
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
     1. Added `values` as an array of `string_t`. #1251
-    1. Added `kernel_release` as a `string_t`.
+    1. Added `kernel_release` as a `string_t`. #1249
 * #### Objects
     1. Added `environment_variable` object. #1172
     1. Added `advisory` object. #1176
@@ -126,7 +126,7 @@ Thankyou! -->
     1. Added `auth_factors`, `domain`, `fingerprint`, `has_mfa`, `issuer`, `protocol_name`, `scim`, `sso`, `state`, `state_id`, `tenant_uid`, and `uid` to `idp`. #1239
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
-    1. Added `kernel_release` to `os` object.
+    1. Added `kernel_release` to `os` object. #1249
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/1242

#### Description of changes:

Changes for kernel_release went in with this PR: https://github.com/ocsf/ocsf-schema/pull/1249

Changelog was updated in that previous PR, but the PR # is missing from the added lines in the changelog. This PR just adds those missing PR links.
