### PR TITLE
Relax `action_id` attribute requirement in `security_control` profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ Thankyou! -->
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
     1. Added `policy` attribute to the `security_control` profile. #1178
+    1. Relaxed `action_id` attribute requirement in the `security_control` profile from `required` to `recommended`. #1263
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     1. Added `has_mfa` to `user` object. #1155

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -29,7 +29,7 @@
           "description": "The attempted activity was denied. The <code>disposition_id</code> attribute should be set to a value that conforms to this action, for example 'Blocked', 'Rejected', 'Quarantined', 'Isolated', 'Dropped', 'Access Revoked, etc."
         }
       },
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "attacks": {
       "requirement": "optional"


### PR DESCRIPTION
The `security_control` profile has become the primary mechanism for applying useful attributes to event classes.

There are sitatuions where some of these fields are desired, but requiring `action_id` does not make sense.