### PR TITLE
Updated `OSINT` object

### DIFF
--- a/objects/osint.json
+++ b/objects/osint.json
@@ -192,6 +192,11 @@
       "description":"Any pertinent file information related to an indicator or OSINT analysis.",
       "requirement":"optional"
     },
+    "related_analytics": {
+      "caption": "Related Analytics",
+      "description": "Any analytics related to an indicator or OSINT analysis.",
+      "requirement": "optional"
+    },
     "reputation":{
       "description":"Related reputational analysis from third-party engines and analysts for a given indicator or OSINT analysis.",
       "requirement":"optional"

--- a/objects/osint.json
+++ b/objects/osint.json
@@ -107,6 +107,10 @@
         "CLEAR":{
           "caption":"TLP:CLEAR",
           "description":"TLP:CLEAR denotes that recipients can spread this to the world, there is no limit on disclosure. Sources may use TLP:CLEAR when information carries minimal or no foreseeable risk of misuse, in accordance with applicable rules and procedures for public release. Subject to standard copyright rules, TLP:CLEAR information may be shared without restriction."
+        },
+        "WHITE":{
+          "caption":"TLP:WHITE",
+          "description":"TLP:WHITE and TLP:CLEAR may be used interchangeably, TLP:WHITE is the most up to date (as of TLP 2.0) usage."
         }
       },
 			"requirement":"recommended",

--- a/objects/osint.json
+++ b/objects/osint.json
@@ -57,6 +57,18 @@
           "caption":"File",
           "description":"A file or metadata about a file."
         },
+        "12":{
+          "caption": "Registry Key",
+          "description": "A Windows Registry Key."
+        },
+        "13": {
+          "caption": "Registry Value",
+          "description": "A Windows Registry Value."
+        },
+        "14": {
+          "caption": "Command Line",
+          "description": "A partial or full Command Line used to invoke scripts or other remote commands."
+        },
         "99":{
           "caption":"Other",
           "description":"The indicator type is not directly listed."


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

- Add new `osint.type_id` enums for Registry Key, Registry Value, and Command Line
- Added new `tlp` enum for TLP:White which is the same as TLP:Clear
- Add `related_analytics` to `osint`
