### PR TITLE
Update the Security Control action_id enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Thankyou! -->
     1. Added `is_alert`, `confidence_id`, `confidence`,  `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
     1. Added `policy` attribute to the `security_control` profile. #1178
+    1. Added enum values to `action_id` of 'Observed', 'Modified', and 'Unknown'. #1265
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     1. Added `has_mfa` to `user` object. #1155

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -1,5 +1,5 @@
 {
-  "description": "The attributes including disposition that represent the outcome of a security control including but not limited to access control, malware or policy violation, network proxy, firewall, or data control.  The profile is intended to augment activities or findings with an outcome where a security control has intervened. If the control detected a security violation, the <code>is_detection</code> flag should be set to <code>true</code>.",
+  "description": "The attributes including disposition that represent the outcome of a security control including but not limited to access control, malware or policy violation, network proxy, intrusion detection, firewall, or data control.  The profile is intended to augment activities or findings with an outcome when a security control has observed or intervened. If the control detected a security violation, and the <code>disposition_id</code> or <code>action_id</code> is an alertable outcome or action, the <code>is_alert</code> flag may be set to <code>true</code>.",
   "meta": "profile",
   "caption": "Security Control",
   "name": "security_control",
@@ -18,7 +18,7 @@
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The action was unknown. The <code>disposition_id</code> attribute may still be set to a non-unknown value, for example 'Count', 'Uncorrected', 'Isolated', 'Quarantined' or 'Exonerated'."
+          "description": "The action was unknown. The <code>disposition_id</code> attribute may still be set to a non-unknown value, for example 'Custom Action', 'Challenge'."
         },
         "1": {
           "caption": "Allowed",
@@ -27,6 +27,18 @@
         "2": {
           "caption": "Denied",
           "description": "The attempted activity was denied. The <code>disposition_id</code> attribute should be set to a value that conforms to this action, for example 'Blocked', 'Rejected', 'Quarantined', 'Isolated', 'Dropped', 'Access Revoked, etc."
+        },
+        "3": {
+          "caption": "Observed",
+          "description": "The activity was observed, but neither explicitly allowed nor denied. This is common with IDS and EDR controls that report additional information on observed behavior such as TTPs. The <code>disposition_id</code> attribute should be set to a value that conforms to this action, for example 'Logged', 'Alert', 'Detected', 'Count', etc."
+        },
+        "4": {
+          "caption": "Modified",
+          "description": "The activity was modified, adjusted, or corrected. The <code>disposition_id</code> attribute should be set appropriately, for example 'Restored', 'Corrected', 'Delayed', 'Captcha', 'Tagged'."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The action is not mapped. See the <code>action</code> attribute which contains a data source specific value."
         }
       },
       "requirement": "required"


### PR DESCRIPTION
#### Related Issue: Slack discussion 11/25/2024

#### Description of changes:
Security Control had been modified to add a required `action_id` with only two values, `Allowed` and `Denied`.
This PR adds Observed and Modified for cases where the control or monitor doesn't explicitly allow or deny but observes and reports or in some cases modified the activity.

Also corrected a previous error in the profile's description and added the standard `Other` enum that was omitted, possibly on purpose.