### PR TITLE
Fixed the description for Security Control action_id

### DIFF
--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -14,7 +14,7 @@
     },
     "action_id": {
       "caption": "Action ID",
-      "description": "The action taken by a control or other policy-based system leading to an outcome or disposition. Dispositions conform to an action of <code>1</code> 'Allowed' or <code>2</code> 'Denied' in most cases. Note that <code>99</code> 'Other' is not an option. No action would equate to <code>1</code> 'Allowed'. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.",
+      "description": "The action taken by a control or other policy-based system leading to an outcome or disposition. An unknown action may still correspond to a known disposition. Refer to <code>disposition_id</code> for the outcome of the action.",
       "enum": {
         "0": {
           "caption": "Unknown",


### PR DESCRIPTION
#### Related PR: 1265 

#### Description of changes:
After adding Observed, Modified, and Other as enum options for `action_id` within the `Security Control` profile, the description for `action_id` needed to be updated (missed when updating with PR# 1265).