### PR TITLE
More d3fend references for objects (based on PR 1173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Thankyou! -->
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
     1. Added `kernel_release` to `os` object. #1249
+    1. Added `references` meta data for `win/reg_key`, `account`, `container`, `database`, `fingerprint`, `group`, `http_cookie`, `job`, `script` objects. #1266
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,7 +144,7 @@ Thankyou! -->
     1. Added `os_machine_uuid` to the `device` object. #1268
     1. Added `uuid` to the `device_hw_info` object. #1268
     1. `unmanned_aerial_system` now extends from `aircraft`. #1253
-    1. Added `references` meta data for `win/reg_key`, `account`, `container`, `database`, `fingerprint`, `group`, `http_cookie`, `job`, `script` objects. #1266
+    1. Added `references` meta data for `win/reg_key`, `win/reg_value`, `account`, `container`, `database`, `fingerprint`, `group`, `http_cookie`, `job`, `script` objects. #1266
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -53,11 +53,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "constraints": {
-    "at_least_one": [
-      "privileges",
-      "user"
-    ]
   }
 }

--- a/extensions/windows/objects/registry_key.json
+++ b/extensions/windows/objects/registry_key.json
@@ -2,7 +2,8 @@
   "caption": "Registry Key",
   "observable": 28,
   "name": "reg_key",
-  "description": "The registry key object describes a Windows registry key. Defined by D3FEND <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistryKey/'>d3f:WindowsRegistryKey</a>.",
+  "description": "The registry key object describes a Windows registry key.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistryKey/", "description": "D3FEND™ Ontology d3f:WindowsRegistryKey."}],
   "extends": "object",
   "attributes": {
     "is_system": {

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -1,6 +1,7 @@
 {
   "caption": "Registry Value",
   "description": "The registry value object describes a Windows registry value.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:WindowsRegistryValue/", "description": "D3FEND™ Ontology d3f:WindowsRegistryValue."}],
   "extends": "object",
   "name": "reg_value",
   "observable": 29,

--- a/objects/account.json
+++ b/objects/account.json
@@ -1,6 +1,7 @@
 {
   "caption": "Account",
   "description": "The Account object contains details about the account that initiated or performed a specific activity within a system or application. Additionally, the Account object refers to logical Cloud and Software-as-a-Service (SaaS) based containers such as AWS Accounts, Azure Subscriptions, Oracle Cloud Compartments, Google Cloud Projects, and otherwise.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:UserAccount/", "description": "D3FEND™ Ontology d3f:UserAccount."}, {"url": "https://d3fend.mitre.org/dao/artifact/d3f:CloudUserAccount/", "description": "D3FEND™ Ontology d3f:CloudUserAccount."}],
   "extends": "_entity",
   "name": "account",
   "attributes": {

--- a/objects/container.json
+++ b/objects/container.json
@@ -2,6 +2,7 @@
   "observable": 27,
   "caption": "Container",
   "description": "The Container object describes an instance of a specific container. A container is a prepackaged, portable system image that runs isolated on an existing system using a container runtime like containerd.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ContainerProcess/", "description": "D3FEND™ Ontology d3f:ContainerProcess."}],
   "extends": "object",
   "name": "container",
   "attributes": {

--- a/objects/database.json
+++ b/objects/database.json
@@ -1,6 +1,7 @@
 {
   "caption": "Database",
   "description": "The database object is used for databases which are typically datastore services that contain an organized collection of structured and unstructured data or a types of data.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:Database/", "description": "D3FEND™ Ontology d3f:Database."}],
   "extends": "_entity",
   "name": "database",
   "profiles": [

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -1,6 +1,7 @@
 {
   "caption": "Fingerprint",
   "description": "The Fingerprint object provides detailed information about a digital fingerprint, which is a compact representation of data used to identify a longer piece of information, such as a public key or file content. It contains the algorithm and value of the fingerprint, enabling efficient and reliable identification of the associated data.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:DigitalFingerprint/", "description": "D3FEND™ Ontology d3f:DigitalFingerprint."}],
   "extends": "object",
   "name": "fingerprint",
   "observable": 30,

--- a/objects/group.json
+++ b/objects/group.json
@@ -1,6 +1,7 @@
 {
   "caption": "Group",
-  "description": "The Group object represents a collection or association of entities, such as users, policies, or devices. It serves as a logical grouping mechanism to organize and manage entities with similar characteristics or permissions within a system or organization.",
+  "description": "The Group object represents a collection or association of entities, such as users, policies, or devices. It serves as a logical grouping mechanism to organize and manage entities with similar characteristics or permissions within a system or organization, including but not limited to purposes of access control.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:AccessControlGroup/", "description": "D3FEND™ Ontology d3f:AccessControlGroup."}],
   "name": "group",
   "extends": "_entity",
   "attributes": {

--- a/objects/http_cookie.json
+++ b/objects/http_cookie.json
@@ -1,6 +1,7 @@
 {
   "caption": "HTTP Cookie",
   "description": "The HTTP Cookie object, also known as a web cookie or browser cookie, contains details and values pertaining to a small piece of data that a server sends to a user's web browser. This data is then stored by the browser and sent back to the server with subsequent requests, allowing the server to remember and track certain information about the user's browsing session or preferences.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:SessionCookie/", "description": "D3FEND™ Ontology d3f:SessionCookie."}],
   "extends": "object",
   "name": "http_cookie",
   "attributes": {

--- a/objects/http_header.json
+++ b/objects/http_header.json
@@ -1,6 +1,6 @@
 {
   "caption": "HTTP Header",
-  "description": "TThe HTTP Header object represents the headers sent in an HTTP request or response. HTTP headers are key-value pairs that convey additional information about the HTTP message, including details about the content, caching, authentication, encoding, and other aspects of the communication.",
+  "description": "The HTTP Header object represents the headers sent in an HTTP request or response. HTTP headers are key-value pairs that convey additional information about the HTTP message, including details about the content, caching, authentication, encoding, and other aspects of the communication.",
   "extends": "object",
   "name": "http_header",
   "attributes": {

--- a/objects/job.json
+++ b/objects/job.json
@@ -2,6 +2,7 @@
   "caption": "Job",
   "name": "job",
   "description": "The Job object provides information about a scheduled job or task, including its name, command line, and state. It encompasses attributes that describe the properties and status of the scheduled job.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ScheduledJob/", "description": "D3FEND™ Ontology d3f:ScheduledJob."}],
   "extends": "object",
   "attributes": {
     "cmd_line": {

--- a/objects/script.json
+++ b/objects/script.json
@@ -1,6 +1,7 @@
 {
   "caption": "Script",
   "description": "The Script object describes a script or command that can be executed by a shell, script engine, or interpreter. Examples include Bash, JavsScript, PowerShell, Python, VBScript, etc. Note that the term <em>script</em> here denotes not only a script contained within a file but also a script or command typed interactively by a user, supplied on the command line, or provided by some other file-less mechanism.",
+  "references": [{"url": "https://d3fend.mitre.org/dao/artifact/d3f:ExecutableScript/", "description": "D3FEND™ Ontology d3f:ExecutableScript."}],
   "extends": "object",
   "name": "script",
   "attributes": {


### PR DESCRIPTION
#### Related PR: 1173 (should be closed in lieu of new approach for linked references)

#### Description of changes:
Added references[] meta data for MITRE d3fend artifacts: 

1. win/reg_key
2. win/reg_value
3. account
4. container
5. database
6. fingerprint
7. group
8. http_cookie
9. job
10. script