### PR TITLE
Issue 1273: Relax dst_endpoint, http_request, http_response in network and http event classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,8 +105,8 @@ Thankyou! -->
     1. Added a `Trace`, `activity_id` to the `Email Activity` class. #1252
     1. Added `vendor_attributes` to all `Findings` Category classes. #1257
     1. Added `sbom` to `Software Inventory Info` class. #1262
-    1. Relaxed requirements on the `dst_endpoint` attribute in the `network_activity` event class and added an `at_least_one` constraint with `src_endpoint` and `dst_endpoint`. #1273
-    1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1273
+    1. Relaxed requirements on the `dst_endpoint` attribute in the `network_activity` event class and added an `at_least_one` constraint with `src_endpoint` and `dst_endpoint`. #1274
+    1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1274
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ Thankyou! -->
     1. Added a `Trace`, `activity_id` to the `Email Activity` class. #1252
     1. Added `vendor_attributes` to all `Findings` Category classes. #1257
     1. Added `sbom` to `Software Inventory Info` class. #1262
+    1. Relaxed requirements on the `dst_endpoint` attribute in the `network_activity` event class and added an `at_least_one` constraint with `src_endpoint` and `dst_endpoint`. #1273
+    1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1273
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/events/network/http_activity.json
+++ b/events/network/http_activity.json
@@ -55,16 +55,22 @@
     },
     "http_request": {
       "group": "primary",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "http_response": {
       "group": "primary",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "http_status": {
       "group": "primary",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "http_response",
+      "http_status"
+    ]
   },
   "profiles": [
     "trace"

--- a/events/network/http_activity.json
+++ b/events/network/http_activity.json
@@ -68,8 +68,8 @@
   },
   "constraints": {
     "at_least_one": [
-      "http_response",
-      "http_status"
+      "http_request",
+      "http_response"
     ]
   },
   "profiles": [

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -22,7 +22,7 @@
     "dst_endpoint": {
       "description": "The responder (server) in a network connection.",
       "group": "primary",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "ja4_fingerprint_list": {
       "group": "context",
@@ -45,6 +45,12 @@
       "group": "primary",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "dst_endpoint",
+      "src_endpoint"
+    ]
   },
   "profiles": [
     "host",


### PR DESCRIPTION
#### Related Issue: 
#1273 

#### Description of changes:

- Relax `dst_endpoint` requirement and add an at least one constraint to the `network_activity` class.
- Relax `http_request` and `http_response` requirements and add an at least one constraint to the `http_activity` class

<img width="593" alt="image" src="https://github.com/user-attachments/assets/9f787637-4e09-4271-b627-a96971992bba">

<img width="588" alt="image" src="https://github.com/user-attachments/assets/95dea567-d156-4c20-8821-7f48047b19a3">

