### PR TITLE
Add `security_control` profile to base_event.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,11 +109,14 @@ Thankyou! -->
     1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1274
     1. Add `host` profile to base_event.json and remove this profile elsewhere in the event hierarchy. #1280
     1. Add the `actor` attribute to the IAM base event. #1280
+    1. Add `security_control` profile to base_event.json and remove this profile elsewhere in the event hierarchy. #1281
+
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
     1. Added `policy` attribute to the `security_control` profile. #1178
     1. Added enum values to `action_id` of 'Observed', 'Modified', and 'Unknown'. #1265
+    1. Update `action_id` optionality to `recommended` in the `security_control` profile #1281
 * #### Objects
     1. Added `phone_number` to `user` and `ldap_person` objects. #1155
     1. Added `has_mfa` to `user` object. #1155

--- a/dictionary.json
+++ b/dictionary.json
@@ -234,7 +234,7 @@
     },
     "attacks": {
       "caption": "MITRE ATT&CK® Details",
-      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques identified by a security control or finding.",
+      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing identified tactics, techniques & sub-techniques.",
       "type": "attack",
       "is_array": true
     },

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -5,9 +5,6 @@
     "extends": "application",
     "name": "datastore_activity",
     "attributes": {
-        "$include": [
-            "profiles/security_control.json"
-        ],
         "activity_id": {
             "enum": {
                 "1": {
@@ -129,8 +126,5 @@
             "databucket",
             "table"
         ]
-    },
-    "profiles": [
-        "security_control"
-    ]
+    }
 }

--- a/events/application/scan_activity.json
+++ b/events/application/scan_activity.json
@@ -101,7 +101,8 @@
     "policy": {
       "description": "The policy associated with this Scan event; required if the scan was initiated by a policy.",
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "scan": {
       "description": "The Scan object describes characteristics of the scan job.",

--- a/events/application/web_resources_activity.json
+++ b/events/application/web_resources_activity.json
@@ -6,8 +6,7 @@
     "name": "web_resources_activity",
     "attributes": {
         "$include": [
-            "profiles/network_proxy.json",
-            "profiles/security_control.json"
+            "profiles/network_proxy.json"
         ],
         "activity_id": {
             "enum": {
@@ -80,7 +79,6 @@
         }
     },
     "profiles": [
-        "network_proxy",
-        "security_control"
+        "network_proxy"
     ]
 }

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -8,7 +8,8 @@
       "profiles/cloud.json",
       "profiles/datetime.json",
       "profiles/host.json",
-      "profiles/osint.json"
+      "profiles/osint.json",
+      "profiles/security_control.json"
     ],
     "activity_id": {
       "group": "classification",
@@ -140,6 +141,7 @@
     "cloud",
     "datetime",
     "host",
-    "osint"
+    "osint",
+    "security_control"
   ]
 }

--- a/events/findings/data_security_finding.json
+++ b/events/findings/data_security_finding.json
@@ -5,9 +5,6 @@
     "extends": "finding",
     "name": "data_security_finding",
     "attributes": {
-        "$include": [
-            "profiles/security_control.json"
-        ],
         "activity_id": {
             "description": "The normalized identifier of the Data Security Finding activity.",
             "requirement": "required",
@@ -143,8 +140,5 @@
             "group": "primary",
             "requirement": "recommended"
         }
-    },
-    "profiles": [
-        "security_control"
-    ]
+    }
 }

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -5,9 +5,6 @@
   "extends": "finding",
   "name": "detection_finding",
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "confidence": {
       "profile": null,
       "group": "context",
@@ -81,8 +78,5 @@
       "group": "context",
       "requirement": "optional"
     }
-  },
-  "profiles": [
-    "security_control"
-  ]
+  }
 }

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -32,15 +32,18 @@
     },
     "confidence": {
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "confidence_id": {
       "group": "context",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "confidence_score": {
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "device": {
       "description": "Describes the affected device/host. It can be used in conjunction with <code>Affected Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -39,7 +39,8 @@
     "attacks": {
       "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Incident.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "comment": {
       "description": "Additional user supplied details for updating or closing the incident.",
@@ -48,15 +49,18 @@
     },
     "confidence": {
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "confidence_id": {
       "group": "context",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "confidence_score": {
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "desc": {
       "description": "The short description of the Incident.",

--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -31,9 +31,10 @@
       "requirement": "recommended"
     },
     "attacks": {
-      "description": "The attack object describes the technique and associated tactics as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK Matrix<sup>TM</sup></a>.",
+      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Finding.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "cis_csc": {
       "group": "context",
@@ -45,16 +46,19 @@
     },
     "confidence": {
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "confidence_id": {
       "group": "primary",
       "requirement": "recommended",
-      "sibling": "confidence"
+      "sibling": "confidence",
+      "profile": null
     },
     "confidence_score": {
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "data_sources": {
       "group": "context",
@@ -87,7 +91,8 @@
     },
     "malware": {
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "nist": {
       "group": "context",
@@ -103,16 +108,19 @@
     },
     "risk_level": {
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "risk_level_id": {
       "group": "primary",
       "requirement": "recommended",
-      "sibling": "risk_level"
+      "sibling": "risk_level",
+      "profile": null
     },
     "risk_score": {
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "profile": null
     },
     "state": {
       "description": "The normalized state of a security finding.",

--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -56,7 +56,8 @@
     "policy": {
       "description": "Details about the IAM policy associated to the Attach/Detach Policy activities.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "profile": null
     },
     "user": {
       "description": "The user that was a target of an activity.",

--- a/events/network/email_activity.json
+++ b/events/network/email_activity.json
@@ -6,9 +6,6 @@
   "extends": "base_event",
   "name": "email_activity",
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "activity_id": {
       "requirement": "optional",
       "enum": {
@@ -99,8 +96,5 @@
       "group": "primary",
       "requirement": "recommended"
     }
-  },
-  "profiles": [
-    "security_control"
-  ]
+  }
 }

--- a/events/network/email_file_activity.json
+++ b/events/network/email_file_activity.json
@@ -10,9 +10,6 @@
     "since": "1.3.0"
   },
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "activity_id": {
       "requirement": "optional",
       "enum": {
@@ -37,8 +34,5 @@
       "group": "primary",
       "requirement": "required"
     }
-  },
-  "profiles": [
-    "security_control"
-  ]
+  }
 }

--- a/events/network/email_url_activity.json
+++ b/events/network/email_url_activity.json
@@ -10,9 +10,6 @@
     "since": "1.3.0"
   },
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "activity_id": {
       "requirement": "optional",
       "enum": {
@@ -37,8 +34,5 @@
       "group": "primary",
       "requirement": "required"
     }
-  },
-  "profiles": [
-    "security_control"
-  ]
+  }
 }

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -7,7 +7,6 @@
   "attributes": {
     "$include": [
       "profiles/network_proxy.json",
-      "profiles/security_control.json",
       "profiles/load_balancer.json"
     ],
     "app_name": {
@@ -53,7 +52,6 @@
   },
   "profiles": [
     "network_proxy",
-    "security_control",
     "load_balancer"
   ]
 }

--- a/events/system/system.json
+++ b/events/system/system.json
@@ -13,9 +13,6 @@
     ]
   },
   "attributes": {
-    "$include": [
-      "profiles/security_control.json"
-    ],
     "actor": {
       "group": "primary",
       "requirement": "required",
@@ -26,8 +23,5 @@
       "requirement": "required",
       "profile": null
     }
-  },
-  "profiles": [
-    "security_control"
-  ]
+  }
 }

--- a/profiles/security_control.json
+++ b/profiles/security_control.json
@@ -41,7 +41,7 @@
           "description": "The action is not mapped. See the <code>action</code> attribute which contains a data source specific value."
         }
       },
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "attacks": {
       "requirement": "optional"


### PR DESCRIPTION
Remove this profile elsewhere in the event hierarchy. 
Set `"profile": null` according to "partially native profiles" approach within the event hierarchy. 
Update `attacks` description
Update `action_id` optionality to recommended to make profile more easily applicable if only a subset of security control fields are desired
