### PR TITLE
Fix typo in key_value_object desc

### DIFF
--- a/objects/key_value_object.json
+++ b/objects/key_value_object.json
@@ -13,7 +13,7 @@
       "requirement": "optional"
     },
     "values": {
-      "description": "Optionall, the values associated to the key. You can populate this attribute, when you have multiple values for the same key.",
+      "description": "Optional, the values associated to the key. You can populate this attribute, when you have multiple values for the same key.",
       "requirement": "optional"
     }
   },


### PR DESCRIPTION
#### Related Issue:  N/A

#### Description of changes:

This PR fixes a minor typo in the `key_value_object` that we noticed today during the System Activity call. 

Note: Because this is a description update, no update to the `CHANGELOG` is necessary.

Before:

<img width="905" alt="image" src="https://github.com/user-attachments/assets/cd35c853-6372-4328-8733-007995581a2b" />

After:

<img width="906" alt="image" src="https://github.com/user-attachments/assets/a9f2aa1b-c87f-4945-932c-3b20cc34d796" />

