### PR TITLE
Add: Unlock Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Thankyou! -->
     1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1274
     1. Add `host` profile to base_event.json and remove this profile elsewhere in the event hierarchy. #1280
     1. Add the `actor` attribute to the IAM base event. #1280
+    1. Add `Unlock` activity to `account_change` class. #1285
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -54,7 +54,7 @@
         "12": {
           "caption": "Unlock",
           "description": "A user account was unlocked."
-        },
+        }
       }
     },
     "policy": {

--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -44,17 +44,17 @@
           "description": "A user account was locked out."
         },
         "10": {
-          "caption": "Unlock",
-          "description": "A user account was unlocked."
-        },
-        "11": {
           "caption": "MFA Factor Enable",
           "description": "An authentication factor was enabled for an account."
         },
-        "12": {
+        "11": {
           "caption": "MFA Factor Disable",
           "description": "An authentication factor was disabled for an account."
-        }
+        },
+        "12": {
+          "caption": "Unlock",
+          "description": "A user account was unlocked."
+        },
       }
     },
     "policy": {

--- a/events/iam/account_change.json
+++ b/events/iam/account_change.json
@@ -44,10 +44,14 @@
           "description": "A user account was locked out."
         },
         "10": {
+          "caption": "Unlock",
+          "description": "A user account was unlocked."
+        },
+        "11": {
           "caption": "MFA Factor Enable",
           "description": "An authentication factor was enabled for an account."
         },
-        "11": {
+        "12": {
           "caption": "MFA Factor Disable",
           "description": "An authentication factor was disabled for an account."
         }


### PR DESCRIPTION
#### Related Issue: 

In Windows, I'd like to be able to distinguish an account enable event from an account unlock event.

#### Description of changes:

This change would allow for coverage of events such as Windows EID 4767 (https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4767).

There is another Windows EID for enabling an account (https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-10/security/threat-protection/auditing/event-4722) and I imagine the distinction is importing for mapping.
