### PR TITLE
Added  drive_type and drive_type_id for file object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Thankyou! -->
     1. Added `vendor_attributes` object. #1257
     1. Added `aircraft` object. #1253
     1. Added `software_component` and `sbom` objects. #1262
+    1. Added `drive_type` and `drive_type_id` objects. #1286
 
 ### Improved
 * #### Event Classes
@@ -156,6 +157,7 @@ Thankyou! -->
     1. Added `cloud_partition` to the `cloud` object. #1271
     1. Added `product`, `related_events_count`, `uid_alt`, `tags` to `finding_info` object. #1271
     1. Added `count`, `created_time`, `desc`, `first_seen_time`, `last_seen_time`, `modified_time`, `product`, `severity`, `severity_id`, `tags` & `title` to `related_event` object. #1271
+    1. Added `drive_type` and `drive_type_id` to the `file` object. #1286
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@ Thankyou! -->
     1. Added `vendor_attributes` object. #1257
     1. Added `aircraft` object. #1253
     1. Added `software_component` and `sbom` objects. #1262
-    1. Added `drive_type` and `drive_type_id` objects. #1286
+    1. Added `drive_type` and `drive_type_id` objects. #1287
 
 ### Improved
 * #### Event Classes
@@ -157,7 +157,7 @@ Thankyou! -->
     1. Added `cloud_partition` to the `cloud` object. #1271
     1. Added `product`, `related_events_count`, `uid_alt`, `tags` to `finding_info` object. #1271
     1. Added `count`, `created_time`, `desc`, `first_seen_time`, `last_seen_time`, `modified_time`, `product`, `severity`, `severity_id`, `tags` & `title` to `related_event` object. #1271
-    1. Added `drive_type` and `drive_type_id` to the `file` object. #1286
+    1. Added `drive_type` and `drive_type_id` to the `file` object. #1287
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -1820,12 +1820,12 @@
     },
     "drive_type": {
       "caption": "Drive Type",
-      "description": "The type of drive where the file is located. For example: <code>unknown</code>, <code>removable</code>, <code>fixed</code>, <code>remote</code>, or <code>other</code>.",
+      "description": "The drive type, normalized to the caption of the <code>drive_type_id</code> value. In the case of <code>Other</code>, it is defined by the source.",
       "type": "string_t"
     },
     "drive_type_id" : {
       "caption": "Drive Type ID",
-      "description": "The drive type id where the file is located.",
+      "description": "Identifies the type of a disk drive, i.e. fixed, removable, etc.",
       "sibling": "drive_type",
       "type": "integer_t",
       "enum": {
@@ -1835,19 +1835,23 @@
         },
         "1": {
           "caption": "Removable",
-          "description": "File is located on removable media like a USB stick."
+          "description": "The drive has removable media; for example, a floppy drive, thumb drive, or flash card reader."
         },
         "2": {
           "caption": "Fixed",
-          "description": "File is located on a fixed drive, such as a hard disk."
+          "description": "The drive has fixed media; for example, a hard disk drive or flash drive."
         },
         "3": {
           "caption": "Remote",
-          "description": "File is located on a remote drive, such as a network share."
+          "description": "The drive is a remote (network) drive."
         },
         "4": {
-          "caption": "Ram Disk",
-          "description": "File resides on a RAM disk."
+          "caption": "CD-ROM",
+          "description": "The drive is a CD-ROM drive."
+        },
+        "5": {
+          "caption": "RAM Disk",
+          "description": "The drive is a RAM disk."
         },
         "99": {
           "caption": "Other",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1818,6 +1818,47 @@
       "type": "string_t",
       "is_array": true
     },
+    "drive_type": {
+      "caption": "Drive Type",
+      "description": "The type of drive where the file is located. For example: <code>unknown</code>, <code>removable</code>, <code>fixed</code>, <code>remote</code>, or <code>other</code>.",
+      "type": "string_t"
+    },
+    "drive_type_id" : {
+      "caption": "Drive Type ID",
+      "description": "The drive type id where the file is located.",
+      "sibling": "drive_type",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The drive type is unknown."
+        },
+        "1": {
+          "caption": "Removable",
+          "description": "File is located on removable media like a USB stick."
+        },
+        "2": {
+          "caption": "Fixed",
+          "description": "File is located on a fixed drive, such as a hard disk."
+        },
+        "3": {
+          "caption": "Remote",
+          "description": "File is located on a remote drive, such as a network share."
+        },
+        "4": {
+          "caption": "CD-ROM",
+          "description": "File is located on a CD-ROM drive."
+        },
+        "5": {
+          "caption": "Ram Disk",
+          "description": "File resides on a RAM disk."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The drive type is not mapped. See the <code>drive_type</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "driver": {
       "caption": "Kernel Driver",
       "description": "The driver that was loaded/unloaded into the kernel",

--- a/dictionary.json
+++ b/dictionary.json
@@ -1846,10 +1846,6 @@
           "description": "File is located on a remote drive, such as a network share."
         },
         "4": {
-          "caption": "CD-ROM",
-          "description": "File is located on a CD-ROM drive."
-        },
-        "5": {
           "caption": "Ram Disk",
           "description": "File resides on a RAM disk."
         },

--- a/objects/file.json
+++ b/objects/file.json
@@ -42,6 +42,12 @@
       "description": "The description of the file, as returned by file system. For example: the description as returned by the Unix file command or the Windows file type.",
       "requirement": "optional"
     },
+    "drive_type": {
+      "requirement": "optional"
+    },
+    "drive_type_id" : {
+      "requirement": "optional"
+    },
     "encryption_details": {
       "description": "The encryption details of the file. Should be populated if the file is encrypted.",
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: 
1286 - Add drive_type and drive_type_id under File Object https://github.com/ocsf/ocsf-schema/issues/1286
#### Description of changes:
The proposal is to extend the File Object by adding details about the type of drive where the file is located. This enrichment would offer greater security insight, assisting the SOC team in determining whether files are created off a network drive or say a USB thumb drive.

The below list was inspired by a Win32 API : https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getdrivetypea

I have added two optional fields called drive_type and drive_type_id under File Object to take care of this.
drive_type_id can take one of the following values :
```0 = "Unknown", 1 = "Removable", 2 = "Fixed", 3 = "Remote", 4 = "CD-ROM", 5 = "RAM Disk", 99 = "Other" ```
and the drive_type would be string equivalent.

<img width="1297" alt="Screenshot 2024-12-12 at 9 03 49 PM" src="https://github.com/user-attachments/assets/ff14b6b6-94f3-4efe-a635-c711180ba993" />


