### PR TITLE
Simplify environment variable object for more compact data representation; removes truncation indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thankyou! -->
     1. Added `Airborne Broadcast Activity` event class to the Unmanned Systems category. #1253
 * #### Dictionary Attributes
     1. Added `has_mfa` as a `boolean_t`. #1155
+    1. Added `environment_variables` as an array of `environment_variable` object. #1172
     1. Added `forward_addr` as an `email_t`. #1179
     1. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` objects respectively. #1176
     1. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
@@ -79,7 +80,7 @@ Thankyou! -->
     1. Added `sbom`, `author`, `related_component`, `relationship`, `relationship_id` and `software_component` to support SBOMs. #1262
     1. Added `related_events_count` as an `int_t`. #1271
 * #### Objects
-    1. Added `environment_variable` object. #1172
+    1. Added `environment_variable` object. #1172, #1288
     1. Added `advisory` object. #1176
     1. Added a generic `key_value_object` object. #1219
     1. Added `unmanned_aerial_system` and `unmanned_system_operating_area` objects. #1169

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@ Thankyou! -->
     1. Added `Airborne Broadcast Activity` event class to the Unmanned Systems category. #1253
 * #### Dictionary Attributes
     1. Added `has_mfa` as a `boolean_t`. #1155
-    1. Added `environment_variables` as an array of `environment_variable` object. #1172
     1. Added `forward_addr` as an `email_t`. #1179
     1. Added `related_cves`, `related_cwes` as arrays of `cve`, `cwe` objects respectively. #1176
     1. Added `exploit_last_seen_time` as a `timestamp_t`. #1176
@@ -68,7 +67,6 @@ Thankyou! -->
     1. Added `unmanned_system_operator` to the dictionary, extends `user`. #1169
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. #1169
     1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. #1169 
-    1. Added `variable_name` and `variable_value` as `long_string`. #1228
     1. Added `imei_list` as an array `string_t`. #1225
     1. Added `is_encrypted` as `boolean_t`; `column_name`, `cell_name`, `storage_class`, `key_uid`, `json_path` as `string_t` & `column_number`, `row_number`, `page_number`, `record_index_in_array` as `integer_t`. #1245
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. #1239

--- a/dictionary.json
+++ b/dictionary.json
@@ -5248,16 +5248,6 @@
       "type": "string_t",
       "is_array": true
     },
-    "variable_name": {
-      "caption": "Variable Name",
-      "description": "The name of a variable. See specific usage.",
-      "type": "long_string"
-    },
-    "variable_value": {
-      "caption": "Variable Value",
-      "description": "The value of a variable. See specific usage.",
-      "type": "long_string"
-    },
     "vector_string": {
       "caption": "Vector String",
       "description": "The CVSS vector string is a text representation of a set of CVSS metrics. It is commonly used to record or transfer CVSS metric information in a concise form. For example: <code>3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:H</code>.",

--- a/objects/environment_variable.json
+++ b/objects/environment_variable.json
@@ -4,13 +4,14 @@
     "extends": "object",
     "name": "environment_variable",
     "attributes": {
-        "variable_name": {
-            "description": "The name of the environment variable. Note that some operating systems permit environment variables to have very long names.",
+        "name": {
+            "description": "The name of the environment variable.",
             "requirement": "required"
         },
-        "variable_value": {
-            "description": "The value of the environment variable. Note that some operating systems permit environment variables to have very long values.",
+        "value": {
+            "description": "The value of the environment variable.",
             "requirement": "required"
+
         }
     }
 }


### PR DESCRIPTION
#### Related Issue: 

Fixes [ocsf-schema#1272](https://github.com/ocsf/ocsf-schema/issues/1272)

#### Description of changes:

Simplify data representation for environment variables array by changing the type of `name` and `value` from `long_string` to `string`. This removes truncation indicators from those fields but this is a worthwhile trade-off to vastly simplify to general case since truncation is a rare occurrence. `environment_variable` remains a separate class (i.e., not reuse the `Key:Value` object) so it can be extended to more elegantly handle truncation, if there turns out to be a real need, in the future.

<img width="1274" alt="Screenshot 2024-12-13 at 10 34 06 AM" src="https://github.com/user-attachments/assets/e6835dd3-63ce-46d3-a012-b9d2b7bae8e0" />

<img width="1288" alt="Screenshot 2024-12-13 at 10 33 52 AM" src="https://github.com/user-attachments/assets/84fb82b5-cf58-422f-94e8-d0ee73bdafe7" />