### PR TITLE
add `evidences` to incident finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Thankyou! -->
     1. Relaxed requirements on the `http_request` and `http_response` attributes in the `http_activity` event class and added an `at_least_one` constraint with these attributes. #1274
     1. Add `host` profile to base_event.json and remove this profile elsewhere in the event hierarchy. #1280
     1. Add the `actor` attribute to the IAM base event. #1280
+    1. Add the `evidences` object to the `Incident Finding` class.
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -67,6 +67,11 @@
       "description": "The time of the most recent event included in the incident.",
       "requirement": "optional"
     },
+    "evidences": {
+      "group": "context",
+      "description": "Describes various evidence artifacts associated to the activity/activities that encompass a security incident.",
+      "requirement": "recommended"
+    },
     "finding_info_list": {
       "group": "primary",
       "requirement": "required"


### PR DESCRIPTION
(ignore the branch name...)

This PR adds `evidences` to the Incident Finding Event Class. While the Incident Finding Event Class is supposed to be a meta-findings class that contains information about downstream Detection/Compliance/Vulnerability findings - that doesn't always reflect the search patterns or customer experience from consuming the data.

Likewise, there are several named "Incidents" APIs such as within Microsoft Sentinel, Microsoft Defender XDR, and Crowdstrike Falcon that provide incidents that function like a Detection Finding AND like an Incident Finding.

For instance, all Crowdstrike Falcon Incidents contain aggregated information on implicated Hosts (devices/resources) as well as Behaviors which can enumerate command lines, process trees, file names, and more data from the sensor. See [here](https://www.falconpy.io/Service-Collections/Incidents.html) for the FalconPy implementation atop Incidents - but the details are spread across GetBehaviors and GetIncidents.

Here is a de-identified Behavior from an Incident

```json
{
      "behavior_id": "ind:123:456-557-169378",
      "cid": "111",
      "aid": "777",
      "incident_id": "inc:123:456",
      "incident_ids": [
          "inc:123:456"
      ],
      "pattern_id": 999,
      "template_instance_id": 0,
      "timestamp": "2024-12-17T20:55:08.872Z",
      "cmdline": "/bin/zsh -il",
      "filepath": "/bin/zsh",
      "pattern_disposition": 0,
      "pattern_disposition_details": {
          "indicator": false,
          "detect": false,
          "inddet_mask": false,
          "sensor_only": false,
          "rooting": false,
          "kill_process": false,
          "kill_subprocess": false,
          "quarantine_machine": false,
          "quarantine_file": false,
          "policy_disabled": false,
          "kill_parent": false,
          "operation_blocked": false,
          "process_blocked": false,
          "registry_operation_blocked": false,
          "critical_process_disabled": false,
          "bootup_safeguard_enabled": false,
          "fs_operation_blocked": false,
          "handle_operation_downgraded": false,
          "kill_action_failed": false,
          "blocking_unsupported_or_disabled": false,
          "suspend_process": false,
          "suspend_parent": false
      },
      "sha256": "12345",
      "user_name": "user",
      "tactic": "Execution",
      "tactic_id": "TA0002",
      "technique": "Command and Scripting Interpreter",
      "technique_id": "T1059",
      "display_name": "FilelessScriptExecution",
      "objective": "Follow Through",
      "compound_tto": "FollowThrough__Execution__CommandandScriptingInterpreter__0__0__0__0"
  }
```

Likewise the main Incident also contains a list of Hosts - I wont paste that since it's even longer - but it's all in the context of the Incident.

Additionally, Incidents from Sentinel and Defender XDR contain the reports of [Related Entities](https://learn.microsoft.com/en-us/rest/api/securityinsights/incidents/list-entities?view=rest-securityinsights-2024-09-01&tabs=HTTP) and [Related Alerts](https://learn.microsoft.com/en-us/rest/api/securityinsights/incidents/list-alerts?view=rest-securityinsights-2024-09-01&tabs=HTTP) that are integral to understanding the full context of a given set of Incidents.

I am sure there are other examples such as in other EDRs and XDRs. Adding `evidences` is the simplest way to extend the usefulness of Incident Finding and not confuse customers/consumers who see **Incident** Finding and immediately think to look for their own platform incidents there.

<img width="1905" alt="image" src="https://github.com/user-attachments/assets/dbc1b032-d3b6-4b9d-ba83-fd96976a84a8" />
