### PR TITLE
Issue #1294: Add a generic event class for each category

### DIFF
--- a/events/application/application.json
+++ b/events/application/application.json
@@ -1,5 +1,7 @@
 {
+  "uid": 0,
   "caption": "Application Activity",
+  "description": "The Application Activity event is a generic event for application activity events. As a generic event, it could be used to log events that are not otherwise defined by the Application Activity category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "category": "application",
   "extends": "base_event",
   "name": "application",

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -1,7 +1,7 @@
 {
   "caption": "Base Event",
   "category": "other",
-  "description": "The base event is a generic and concrete event. It also defines a set of attributes available in most event classes. As a generic event that does not belong to any event category, it could be used to log events that are not otherwise defined by the schema.",
+  "description": "The base event is a generic and concrete event. It also defines a set of attributes available in most event classes. As a generic event that does not belong to any event category, it could be used to log events that are not otherwise defined by the schema. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "name": "base_event",
   "attributes": {
     "$include": [

--- a/events/discovery/discovery.json
+++ b/events/discovery/discovery.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "Discovery",
   "category": "discovery",
-  "description": "The Discovery event is a generic event that defines a set of attributes available in Discovery category events. As a generic event, it could be used to log events that are not otherwise defined by the Discovery specific event classes.",
+  "description": "The Discovery event is a generic event that defines a set of attributes available in Discovery category events. As a generic event, it could be used to log events that are not otherwise defined by the Discovery specific event classes. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "discovery",
   "attributes": {

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "Finding",
   "category": "findings",
-  "description": "The Finding event is a generic event that defines a set of attributes available in the Findings category.",
+  "description": "The Finding event is a generic event that defines a set of attributes available in the Findings category. As a generic event, it could be used to log events that are not otherwise defined by the Findings category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "finding",
   "attributes": {

--- a/events/iam/iam.json
+++ b/events/iam/iam.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "Identity & Access Management",
   "category": "iam",
-  "description": "The Identity & Access Management event is a generic event that defines a set of attributes available in the access control events. As a generic event, it could be used to log events that are not otherwise defined by the IAM category.",
+  "description": "The Identity & Access Management (IAM) event is a generic event that defines a set of attributes available in the access control events. As a generic event, it could be used to log events that are not otherwise defined by the IAM category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "iam",
   "attributes": {

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "Network",
   "category": "network",
-  "description": "Network event is a generic event that defines a set of attributes available in the Network category.",
+  "description": "Network event is a generic event that defines a set of attributes available in the Network category. As a generic event, it could be used to log events that are not otherwise defined by the Network category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "network",
   "attributes": {

--- a/events/system/system.json
+++ b/events/system/system.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "System Activity",
   "category": "system",
-  "description": "The System Activity event is a generic event that defines a set of attributes available in the system activity events. As a generic event, it could be used to log events that are not otherwise defined by the System Activity category.",
+  "description": "The System Activity event is a generic event that defines a set of attributes available in the system activity events. As a generic event, it could be used to log events that are not otherwise defined by the System Activity category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "system",
   "associations": {

--- a/events/unmanned_systems/unmanned_systems.json
+++ b/events/unmanned_systems/unmanned_systems.json
@@ -1,7 +1,8 @@
 {
+  "uid": 0,
   "caption": "Unmanned Systems",
   "category": "unmanned_systems",
-  "description": "The Unmanned Systems event is a generic event that defines a set of attributes available in the Unmanned Systems category.",
+  "description": "The Unmanned Systems event is a generic event that defines a set of attributes available in the Unmanned Systems category. As a generic event, it could be used to log events that are not otherwise defined by the Unmanned Systems category. <b>Note:</b> this event class should not be used a final solution. This generic event class should only be used temporarily until time can be spent mapping to a specific event class.",
   "extends": "base_event",
   "name": "unmanned_systems",
   "attributes": {


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1294

#### Description of changes:
A generic event class for each category is helpful when mapping existing event logs to OCSF in situations where the category of an event is clear but the work to fully map events is not yet complete.

The alternative is loss of fidelity or just dropping the raw event (not mapping it at all while running in production), neither of which is desirable. The loss of fidelity arises from the use of the Base Event class instead of a generic category-specific class, and thus losing both the category and activity IDs for the generic class.

There should be a warning in the event class descriptions of these generic classes saying exactly why they exist, and steering people away from their use a final solution. The same warning should be added to Base Event.

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
TBD

