### PR TITLE
Issue-1304: Remove 'domains' attribute from 'email' object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Thankyou! -->
     1. Added new `11: Basic Authentication` enum value to `auth_protocol_id`. #1239
     1. Added `values` as an array of `string_t`. #1251
     1. Added `kernel_release` as a `string_t`.
-    1. Added `domains` `files` `urls` and `message_trace_uid`. #1259
+    1. Added `files` `urls` and `message_trace_uid`. #1259
     1. Added `kernel_release` as a `string_t`. #1249
     1. Added `os_machine_uuid` as a `uuid_t`.  #1268
     1. Added `sbom`, `author`, `related_component`, `relationship`, `relationship_id` and `software_component` to support SBOMs. #1262
@@ -155,7 +155,7 @@ Thankyou! -->
     1. Added `hostname`, `ip`, and `name` to `resource_details` for purposes of assigning an Observable number. #1250
     1. Added `values` to `key_value_object`. #1251
     1. Added `kernel_release` to `os` object.
-    1. Added `domains`, `files`, `urls`, to the `Email` object. Relaxed requirements on the `from` and `to` attributes of the object and added the `at_least_one` constraint. #1259
+    1. Added `files`, `urls`, to the `Email` object. Relaxed requirements on the `from` and `to` attributes of the object and added the `at_least_one` constraint. #1259
     1. Added `kernel_release` to `os` object. #1249
     1. Added `related_analytics` to `osint` object. #1264
     1. Added `os_machine_uuid` to the `device` object. #1268

--- a/dictionary.json
+++ b/dictionary.json
@@ -1845,12 +1845,6 @@
       "type": "domain_contact",
       "is_array": true
     },
-    "domains": {
-      "caption": "Domains",
-      "description": "The domains that pertain to the event or object. See specific usage.",
-      "type": "string_t",
-      "is_array": true
-    },
     "drive_type": {
       "caption": "Drive Type",
       "description": "The drive type, normalized to the caption of the <code>drive_type_id</code> value. In the case of <code>Other</code>, it is defined by the source.",

--- a/objects/email.json
+++ b/objects/email.json
@@ -18,10 +18,6 @@
     "delivered_to": {
       "requirement": "optional"
     },
-    "domains": {
-      "requirement": "optional",
-      "description": "The domain names seen in the email. For example <code>www.w3.org</code> or <code>ocsf.io</code>."
-    },
     "files": {
       "requirement": "optional",
       "description": "The files embedded or attached to the email."


### PR DESCRIPTION
#### Related Issue: 
#1304 
#### Description of changes:
Remove `domains` attribute from the `email` object since the `urls` attribute within the object contains `domain`.
