### PR TITLE
Issue #1303: Add debug information in metadata.debug field

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1441,6 +1441,12 @@
       "description": "Decision/outcome of the authorization mechanism (e.g. Approved, Denied)",
       "type": "string_t"
     },
+    "debug": {
+      "caption": "Debug Information",
+      "description": "Debug information about non-fatal issues with this OCSF event. Each issue is a line in this string array.",
+      "type": "string_t",
+      "is_array": true
+    },
     "delay": {
       "caption": "Root Delay",
       "description": "The total round-trip delay to the reference clock in milliseconds.",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -11,6 +11,9 @@
     "correlation_uid": {
       "requirement": "optional"
     },
+    "debug": {
+      "requirement": "optional"
+    },
     "event_code": {
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1303

#### Description of changes:
Add new `debug` attribute as a string array. Add `debug` attribute to `metadata` object.

See related issue for motivation.

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
