### PR TITLE
Adding an event uid to the logger object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Thankyou! -->
     1. Added `os_machine_uuid` as a `uuid_t`.  #1268
     1. Added `sbom`, `author`, `related_component`, `relationship`, `relationship_id` and `software_component` to support SBOMs. #1262
     1. Added `related_events_count` as an `int_t`. #1271
+    1. Added `event_uid` as a `string_t`. #1312
 * #### Objects
     1. Added `environment_variable` object. #1172, #1288
     1. Added `advisory` object. #1176
@@ -169,6 +170,7 @@ Thankyou! -->
     1. Added `cpu_architecture` and `cpu_architecture_id` to `device_hw_info` object. #1278
     1. Added `name` to `script` object. #1284
     1. Relax requirement of `fingerprints` in `certificate` object. #1302
+    1. Added `event_uid` to the `logger` object. #1312
 
 
 ### Bugfixes

--- a/dictionary.json
+++ b/dictionary.json
@@ -2040,6 +2040,11 @@
       "description": "The <code>Event ID, Code, or Name</code> that the product uses to primarily identify the event.",
       "type": "string_t"
     },
+    "event_uid": {
+      "caption": "Event UID",
+      "description": "The unique identifier of an event. See specific usage.",
+      "type": "string_t"
+    },
     "evidence": {
       "caption": "Evidence",
       "description": "The data the finding exposes to the analyst.",

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -1,47 +1,51 @@
 {
-    "caption": "Logger",
-    "description": "The Logger object represents the device and product where events are stored with times for receipt and transmission.  This may be at the source device where the event occurred, a remote scanning device, intermediate hops, or the ultimate destination.",
-    "name": "logger",
-    "extends": "_entity",
-    "attributes": {
-        "device": {
-            "description": "The device where the events are logged.",
-            "requirement": "recommended"
-        },
-        "log_level": {
-            "requirement": "optional"
-        },
-        "log_name": {
-            "requirement": "recommended"
-        },
-        "log_provider": {
-            "requirement": "recommended"
-        },
-        "log_version": {
-            "requirement": "optional"
-        },
-        "logged_time": {
-            "requirement": "recommended"
-        },
-        "name": {
-            "description": "The name of the logging product instance.",
-            "requirement": "recommended"
-        },
-        "product": {
-            "description": "The product logging the event.  This may be the event source product, a management server product, a scanning product, a SIEM, etc.",
-            "requirement": "recommended"
-        },
-        "transmit_time": {
-            "description": "The time when the event was transmitted from the logging device to it's next destination.",
-            "requirement": "optional"
-        },
-        "uid": {
-            "description": "The unique identifier of the logging product instance.",
-            "requirement": "recommended"
-          },      
-        "version": {
-            "description": "The version of the logging product.",
-            "requirement": "optional"
-        }
+  "caption": "Logger",
+  "description": "The Logger object represents the device and product where events are stored with times for receipt and transmission.  This may be at the source device where the event occurred, a remote scanning device, intermediate hops, or the ultimate destination.",
+  "name": "logger",
+  "extends": "_entity",
+  "attributes": {
+    "device": {
+      "description": "The device where the events are logged.",
+      "requirement": "recommended"
+    },
+    "event_uid": {
+      "description": "The unique identifier of the event assigned by the logger.",
+      "requirement": "optional"
+    },
+    "log_level": {
+      "requirement": "optional"
+    },
+    "log_name": {
+      "requirement": "recommended"
+    },
+    "log_provider": {
+      "requirement": "recommended"
+    },
+    "log_version": {
+      "requirement": "optional"
+    },
+    "logged_time": {
+      "requirement": "recommended"
+    },
+    "name": {
+      "description": "The name of the logging product instance.",
+      "requirement": "recommended"
+    },
+    "product": {
+      "description": "The product logging the event.  This may be the event source product, a management server product, a scanning product, a SIEM, etc.",
+      "requirement": "recommended"
+    },
+    "transmit_time": {
+      "description": "The time when the event was transmitted from the logging device to it's next destination.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The unique identifier of the logging product instance.",
+      "requirement": "recommended"
+    },
+    "version": {
+      "description": "The version of the logging product.",
+      "requirement": "optional"
     }
-}  
+  }
+}


### PR DESCRIPTION
#### Related Issue: Currently, the logger object doesn't have an attribute to represent event id that can be potentially assigned by a "logger" persona, imagine an aggregator. This PR adds such an attribute to the framework and to the logger object.

#### Description of changes:
1. Added `event_uid` to the `logger` object.
2. Indent correction for the `logger` object.
