### PR TITLE
Issue-1311: Add 'keyboard_info' object to the RDP class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Thankyou! -->
     1. Add `policies` to `Account Change` class. #1282
     1. Add `Unlock` activity to `account_change` class. #1285
     1. Add `incident` profile to `finding` to affect classes that extend it. #1293
+    1. Add `keyboard_info` object to RDP event class. #1313
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/events/network/rdp_activity.json
+++ b/events/network/rdp_activity.json
@@ -34,6 +34,7 @@
       }
     },
     "capabilities": {
+      "group": "context",
       "requirement": "optional"
     },
     "certificate_chain": {
@@ -55,6 +56,10 @@
       "group": "context",
       "requirement": "optional"
     },
+    "keyboard_info": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "protocol_ver": {
       "caption": "RDP Version",
       "description": "The Remote Desktop Protocol version.",
@@ -62,6 +67,7 @@
       "requirement": "recommended"
     },
     "remote_display": {
+      "group": "context",
       "requirement": "optional"
     },
     "request": {


### PR DESCRIPTION
- Add `keyboard_info` to the RDP event class
- Add missing group to two attributes

#### Related Issue: 
#1311 
<img width="1170" alt="image" src="https://github.com/user-attachments/assets/52de55de-c5a7-4c85-bd7d-8048f2978b9c" />

