### PR TITLE
Add attributes to File Hosting Activity for the file share access chec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ Thankyou! -->
     1. Add `Unlock` activity to `account_change` class. #1285
     1. Add `incident` profile to `finding` to affect classes that extend it. #1293
     1. Add `keyboard_info` object to RDP event class. #1313
-    1. Added attributes and a new Activity ID to the `File Hosting Activity` class for network file share services and authorization check result. Activity ID added: `17` - "Access Check". Optional `context` group attributes added: `access_list`, `access_mask`, `access_result`, `share`, `share_type`, and `share_type_id`. #xxxx
+    1. Added attributes and a new Activity ID to the `File Hosting Activity` class for network file share services and authorization check result. Activity ID added: `17` - "Access Check". Optional `context` group attributes added: `access_list`, `access_mask`, `access_result`, `share`, `share_type`, and `share_type_id`. #1315
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178
@@ -173,7 +173,7 @@ Thankyou! -->
     1. Added `name` to `script` object. #1284
     1. Relax requirement of `fingerprints` in `certificate` object. #1302
     1. Added `event_uid` to the `logger` object. #1312
-
+    1. Added optional `url` attribute to the `file` object. This was allows capturing a file's URL in the File Hosting Activity (6006) event class. #1289
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Thankyou! -->
     1. Add `Unlock` activity to `account_change` class. #1285
     1. Add `incident` profile to `finding` to affect classes that extend it. #1293
     1. Add `keyboard_info` object to RDP event class. #1313
+    1. Added attributes and a new Activity ID to the `File Hosting Activity` class for network file share services and authorization check result. Activity ID added: `17` - "Access Check". Optional `context` group attributes added: `access_list`, `access_mask`, `access_result`, `share`, `share_type`, and `share_type_id`. #xxxx
 * #### Profiles
     1. Added `is_alert`, `confidence_id`, `confidence`, `confidence_score` attributes to the `security_control` profile. #1178
     1. Added `risk_level_id`, `risk_level`, `risk_score`, `risk_details` attributes to the `security_control` profile.  #1178

--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -1,10 +1,23 @@
 {
   "uid": 6,
   "caption": "File Hosting Activity",
-  "description": "File Hosting Activity events report the actions taken by file management applications, including file sharing servers like Sharepoint and services such as Box, MS OneDrive, or Google Drive.",
+  "description": "File Hosting Activity events report the actions taken by file management applications, including file sharing servers like Sharepoint and services such as Box, MS OneDrive, Google Drive, or network file share services.",
   "extends": "application",
   "name": "file_hosting",
   "attributes": {
+    "access_list": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "access_mask": {
+      "description": "The sum of hexadecimal values of requested access rights.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "access_result": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "activity_id": {
       "enum": {
         "1": {
@@ -70,6 +83,10 @@
         "16": {
           "caption": "Unsync",
           "description": "Mark a file or folder to not sync with a computer."
+        },
+        "17": {
+          "caption": "Access Check",
+          "description": "Access check for a file. The <code>security_control</code> profile can be used to add the access check results."
         }
       }
     },
@@ -99,6 +116,19 @@
     },
     "file_result": {
       "description": "The resulting file object when the activity was allowed and successful.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "share": {
+      "description": "The share name.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "share_type": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "share_type_id": {
       "group": "context",
       "requirement": "optional"
     },


### PR DESCRIPTION
#### Related Issue: 
https://github.com/ocsf/ocsf-schema/issues/1296

#### Description of changes:
The existing File Hosting Activity class has attributes added to cover the file sharing access check case. A new "Access Check" Activity ID is added, and optional group context attributes are added..

This PR include a line in `CHANGELIST.md` for PR https://github.com/ocsf/ocsf-schema/issues/1291, which was merged before the `CHANGELOG.md` was updated.

NOTE: This PR replaces https://github.com/ocsf/ocsf-schema/pull/1297, which was closed as it got mess up somehow.
