### PR TITLE
Add `history` and `missing_bytes` attributes to network class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Thankyou! -->
     1. Added `ancestry` as a list of `process_entity`. #1317
     1. Added `internal_name` as a `string_t`. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes`. #1307
+    1. Added `history` and `missing_bytes` attributes. #1316
 
 * #### Objects
     1. Added `environment_variable` object. #1172, #1288
@@ -188,6 +189,8 @@ Thankyou! -->
     1. Added `ancestry` to the `process` object. #1317
     1. Added `internal_name` to the `file` object. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes` to `email` object. #1307
+    1. Added `history` attribute to the `network_connection_info` object. #1316
+    1. Added `missing_bytes` attribute to the `network_traffic` object. #1316
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Thankyou! -->
     1. Added `ancestry` as a list of `process_entity`. #1317
     1. Added `internal_name` as a `string_t`. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes`. #1307
-    1. Added `history` and `missing_bytes` attributes. #1316
+    1. Added `flag_history` and `missed_bytes` attributes. #1316
 
 * #### Objects
     1. Added `environment_variable` object. #1172, #1288
@@ -189,7 +189,7 @@ Thankyou! -->
     1. Added `ancestry` to the `process` object. #1317
     1. Added `internal_name` to the `file` object. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes` to `email` object. #1307
-    1. Added `history` attribute to the `network_connection_info` object. #1316
+    1. Added `flag_history` attribute to the `network_connection_info` object. #1316
     1. Added `missed_bytes` attribute to the `network_traffic` object. #1316
 
 ### Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ Thankyou! -->
     1. Added `internal_name` to the `file` object. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes` to `email` object. #1307
     1. Added `history` attribute to the `network_connection_info` object. #1316
-    1. Added `missing_bytes` attribute to the `network_traffic` object. #1316
+    1. Added `missed_bytes` attribute to the `network_traffic` object. #1316
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ Thankyou! -->
     1. Added `ancestry` as a list of `process_entity`. #1317
     1. Added `internal_name` as a `string_t`. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes`. #1307
-    1. Added `flag_history` and `missed_bytes` attributes. #1316
+    1. Added `flag_history` and `bytes_missed` attributes. #1316
 
 * #### Objects
     1. Added `environment_variable` object. #1172, #1288
@@ -190,7 +190,7 @@ Thankyou! -->
     1. Added `internal_name` to the `file` object. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes` to `email` object. #1307
     1. Added `flag_history` attribute to the `network_connection_info` object. #1316
-    1. Added `missed_bytes` attribute to the `network_traffic` object. #1316
+    1. Added `bytes_missed` attribute to the `network_traffic` object. #1316
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180

--- a/dictionary.json
+++ b/dictionary.json
@@ -2294,6 +2294,11 @@
       "description": "The software package version in which a reported vulnerability was patched/fixed.",
       "type": "string_t"
     },
+    "flag_history": {
+      "caption": "Connection Flag History",
+      "description": "The Connection Flag History summarizes events in a network connection. For example flags <code> ShAD </code> representing SYN, SYN/ACK, ACK and Data exchange.",
+      "type": "string_t"
+    },
     "flag_ids": {
       "caption": "Communication Flag IDs",
       "description": "The list of normalized identifiers of the communication flag IDs. See specific usage.",
@@ -2429,11 +2434,6 @@
       "caption": "Hire Time",
       "description": "The timestamp when the user was or will be hired by the organization.",
       "type": "timestamp_t"
-    },
-    "history": {
-      "caption": "Connection History",
-      "description": "The Connection History summarizes events in a network connection. For example <code> ShAD </code> representing SYN, SYN/ACK, ACK and Data exchange.",
-      "type": "string_t"
     },
     "horizontal_accuracy": {
       "caption": "Horizontal Accuracy",

--- a/dictionary.json
+++ b/dictionary.json
@@ -486,6 +486,11 @@
       "description": "The number of bytes sent from the destination to the source.",
       "type": "long_t"
     },
+    "bytes_missed": {
+      "caption": "Bytes Missed",
+      "description": "Indicates the number of bytes missed, which is representative of packet loss.",
+      "type": "long_t"
+    },
     "bytes_out": {
       "caption": "Bytes Out",
       "description": "The number of bytes sent from the source to the destination.",
@@ -2297,6 +2302,12 @@
     "flag_history": {
       "caption": "Connection Flag History",
       "description": "The Connection Flag History summarizes events in a network connection. For example flags <code> ShAD </code> representing SYN, SYN/ACK, ACK and Data exchange.",
+      "references": [
+        {
+          "description": "Zeek History",
+          "url": "https://docs.zeek.org/en/master/scripts/base/protocols/conn/main.zeek.html#detailed-interface:~:text=Records%20the%20state%20history%20of%20connections%20as%20a%20string%20of%20letters.%20The%20meaning%20of%20those%20letters%20is"
+        }
+      ],
       "type": "string_t"
     },
     "flag_ids": {
@@ -2551,8 +2562,16 @@
       "sibling": "impact",
       "type": "integer_t",
       "source": "impact value; impact level",
-      "references": [{"description": "NIST SP 800-172 from FIPS 199", "url": "https://doi.org/10.6028/NIST.FIPS.199"}, 
-                     {"description": "NIST Computer Security Resource Center", "url": "https://doi.org/10.6028/NIST.FIPS.199"}],
+      "references": [
+        {
+          "description": "NIST SP 800-172 from FIPS 199",
+          "url": "https://doi.org/10.6028/NIST.FIPS.199"
+        },
+        {
+          "description": "NIST Computer Security Resource Center",
+          "url": "https://doi.org/10.6028/NIST.FIPS.199"
+        }
+      ],
       "enum": {
         "0": {
           "caption": "Unknown",
@@ -3320,11 +3339,6 @@
       "caption": "MIME type",
       "description": "The Multipurpose Internet Mail Extensions (MIME) type of the file, if applicable.",
       "type": "string_t"
-    },
-    "missed_bytes":  {
-      "caption": "Missed Bytes",
-      "description": "The number of bytes lost or unanalyzed due to incomplete data capture.",
-      "type": "long_t"
     },
     "model": {
       "caption": "Model",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2329,7 +2329,7 @@
     },
     "flags": {
       "caption": "Flags",
-      "description": "The list of communication flags, normalized to the captions of the flag_ids values. In the case of 'Other', they are defined by the event source.",
+      "description": "The list of communication flags, normalized to the captions of the flag_ids values. See specific usage.",
       "type": "string_t",
       "is_array": true
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -2430,6 +2430,11 @@
       "description": "The timestamp when the user was or will be hired by the organization.",
       "type": "timestamp_t"
     },
+    "history": {
+      "caption": "Connection History",
+      "description": "The Connection History summarizes events in a network connection. For example <code> ShAD </code> representing SYN, SYN/ACK, ACK and Data exchange.",
+      "type": "string_t"
+    },
     "horizontal_accuracy": {
       "caption": "Horizontal Accuracy",
       "description": "Provides quality/containment on horizontal position. This is based on ADS-B NACp. Measured in meters.",
@@ -3315,6 +3320,11 @@
       "caption": "MIME type",
       "description": "The Multipurpose Internet Mail Extensions (MIME) type of the file, if applicable.",
       "type": "string_t"
+    },
+    "missed_bytes":  {
+      "caption": "Missed Bytes",
+      "description": "The number of bytes lost or unanalyzed due to incomplete data capture.",
+      "type": "long_t"
     },
     "model": {
       "caption": "Model",

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -20,7 +20,7 @@
     "direction_id": {
       "requirement": "required"
     },
-    "history": {
+    "flag_history": {
       "requirement": "optional"
     },
     "protocol_name": {

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -20,6 +20,9 @@
     "direction_id": {
       "requirement": "required"
     },
+    "history": {
+      "requirement": "optional"
+    },
     "protocol_name": {
       "caption": "Protocol Name",
       "description": "The IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). For example: <code>tcp</code> or <code>udp</code>.",

--- a/objects/network_traffic.json
+++ b/objects/network_traffic.json
@@ -14,15 +14,6 @@
     "bytes_out": {
       "requirement": "optional"
     },
-    "packets": {
-      "requirement": "recommended"
-    },
-    "packets_in": {
-      "requirement": "optional"
-    },
-    "packets_out": {
-      "requirement": "optional"
-    },
     "chunks": {
       "description": "The total number of chunks (in and out).",
       "requirement": "optional"
@@ -33,6 +24,18 @@
     },
     "chunks_out": {
       "description": "The number of chunks sent from the source to the destination.",
+      "requirement": "optional"
+    },
+    "missed_bytes": {
+      "requirement": "optional"
+    },
+    "packets": {
+      "requirement": "recommended"
+    },
+    "packets_in": {
+      "requirement": "optional"
+    },
+    "packets_out": {
       "requirement": "optional"
     }
   }

--- a/objects/network_traffic.json
+++ b/objects/network_traffic.json
@@ -11,6 +11,9 @@
     "bytes_in": {
       "requirement": "optional"
     },
+    "bytes_missed": {
+      "requirement": "optional"
+    },
     "bytes_out": {
       "requirement": "optional"
     },
@@ -24,9 +27,6 @@
     },
     "chunks_out": {
       "description": "The number of chunks sent from the source to the destination.",
-      "requirement": "optional"
-    },
-    "missed_bytes": {
       "requirement": "optional"
     },
     "packets": {

--- a/objects/request.json
+++ b/objects/request.json
@@ -12,6 +12,7 @@
       "requirement": "optional"
     },
     "flags": {
+      "description": "The communication flags that are associated with the api request.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/response.json
+++ b/objects/response.json
@@ -21,6 +21,7 @@
       "requirement": "recommended"
     },
     "flags": {
+      "description": "The communication flags that are associated with the api response.",
       "requirement": "optional"
     },
     "message": {


### PR DESCRIPTION
#### Related Issue: 
#1314 
#### Description of changes:

- Add `flag_history` to `network_connection` object
- Add `bytes_missed` to `network_traffic` object
<img width="1330" alt="image" src="https://github.com/user-attachments/assets/5487fe73-4690-4548-b13f-7feac9827ae2" />

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/8a9cb8d7-ca4c-42e7-a18a-fdc8b826561a" />


