### PR TITLE
Bugfix, adding group prop for vendor_attributes

### DIFF
--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -102,6 +102,7 @@
       }
     },
     "vendor_attributes": {
+      "group": "context",
       "requirement": "optional"
     }
   }


### PR DESCRIPTION
#### Related Issue: https://github.com/ocsf/ocsf-schema/issues/1318

Minor addition, adding `group` property to `vendor_attributes` definition in the base finding class. No changes necessary to the Changelog

