### PR TITLE
Adding tls.certificate.sans array, deprecate tls.sans array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Thankyou! -->
     1. Added `drive_type` and `drive_type_id` objects. #1287
     1. Added `cpu_architecture` and `cpu_architecture_id` objects. #1278
     1. Added `process_entity` object. #1317
+    1. Added `tls.certificate.sans` array, deprecated `tls.sans` array. #1325
 
 * ### Profiles
     1. Added `incident` profile. #1293

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,6 @@ Thankyou! -->
     1. Added `drive_type` and `drive_type_id` objects. #1287
     1. Added `cpu_architecture` and `cpu_architecture_id` objects. #1278
     1. Added `process_entity` object. #1317
-    1. Added `tls.certificate.sans` array, deprecated `tls.sans` array. #1325
 
 * ### Profiles
     1. Added `incident` profile. #1293
@@ -189,6 +188,7 @@ Thankyou! -->
     1. Added `ancestry` to the `process` object. #1317
     1. Added `internal_name` to the `file` object. #1322
     1. Added `cc_mailboxes`, `from_mailbox`, `to_mailboxes`, `delivered_to_list`  and `reply_to_mailboxes` to `email` object. #1307
+    1. Added `sans` array to `certificate` object. #1325
 
 ### Bugfixes
 1. Added sibling definition to `confidence_id` in dictionary, accurately associating `confidence` as its sibling. #1180
@@ -212,6 +212,7 @@ Thankyou! -->
 1. Deprecated `policy` in favor of `policies` in `Account Change` class. #1282
 1. Deprecated `lineage` in the `process` object. #1317
 1. Deprecated `smtp_hello`, `smtp_from`, `smtp_to`, `delivered_to` and `reply_to` in favor of `command`, `from`, `to`, `delivered_to_list` and `reply_to_mailboxes` respectively. #1307
+1. Deprecated `tls.sans` array in favor of added `tls.certificate.sans` array. #1325
 
 ### Misc
 1. Added `user.uid` as an Observable type - `type_id: 31`. #1155

--- a/objects/certificate.json
+++ b/objects/certificate.json
@@ -25,6 +25,11 @@
     "is_self_signed": {
       "requirement": "recommended"
     },
+    "sans": {
+      "description": "The list of subject alternative names that are secured by a specific certificate.",
+      "caption": "Subject Alternative Names",
+      "requirement": "optional"
+    },
     "serial_number": {
       "description": "The serial number of the certificate used to create the digital signature.",
       "caption": "Certificate Serial Number",

--- a/objects/tls.json
+++ b/objects/tls.json
@@ -38,6 +38,10 @@
       "requirement": "optional"
     },
     "sans": {
+      "@deprecated": {
+        "message": "Use <code>tls.certificate.sans</code> attribute instead.",
+        "since": "1.4.0"
+      },
       "requirement": "optional"
     },
     "server_ciphers": {


### PR DESCRIPTION
#### Description of changes:
Notable from Tenzir on tls.sans: "This is actually a schema bug.
The SAN array should be part of the certificate object in theory, as it's part of the cert."