### PR TITLE
Add several new observable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,22 @@ Thankyou! -->
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
 
+### Misc
+1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 39` and `type_id: 40`. #1326
+1. Added `process_entity.uid` as an Observable type - `type_id: 41` #1326
+1. Added `file_path_t` as an Observable type - `type_id: 42` and marked fields as this type #1326
+    - `lineage` dictionary attribute
+    - `affected_package.path` object attribute
+    - `file.path` object attribute
+    - `image.path` object attribute
+    - `kernel.path` object attribute
+    - `malware.path` object attribute
+    - `process_entity.path` object attribute
+1. Added `extensions/windows/reg_key_path_t` as an Observable type - `type_id: 43` and marked fields as this type #1326
+    - `reg_key.path` object attribute
+    - `reg_value.path` object attribute
+1. Added `reg_value.name` as an Observable type - `type_id: 44`  #1326
+
 ## [v1.4.0] - January 31st, 2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Thankyou! -->
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
 
 ### Misc
-1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 39` and `type_id: 40`. #1326
+1. Added `email.subject` and `email.uid` and `message_uid` as an Observable types - `type_id: 39`, `type_id: 40` and `type_id: 45`. #1326
 1. Added `process_entity.uid` as an Observable type - `type_id: 41` #1326
 1. Added `file_path_t` as an Observable type - `type_id: 42` and marked fields as this type #1326
     - `lineage` dictionary attribute

--- a/dictionary.json
+++ b/dictionary.json
@@ -3075,7 +3075,7 @@
     "lineage": {
       "caption": "Lineage",
       "description": "The lineage of the process, represented by a list of paths for each ancestor process. For example: <code>['/usr/sbin/sshd', '/usr/bin/bash', '/usr/bin/whoami']</code>.",
-      "type": "string_t",
+      "type": "file_path_t",
       "is_array": true
     },
     "load_balancer": {
@@ -5631,6 +5631,13 @@
         "observable": 7,
         "caption": "File Name",
         "description": "File name. For example:<br><code>text-file.txt</code>.",
+        "type": "string_t",
+        "type_name": "String"
+      },
+      "file_path_t": {
+        "observable": 42,
+        "caption": "File Path",
+        "description": "The full path to the file. For example: For example:<br><code>c:\\windows\\system32\\svchost.exe</code>.",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3323,7 +3323,8 @@
           "description": "RFC 5322",
           "url": "https://www.rfc-editor.org/rfc/rfc5322"
         }
-      ]
+      ],
+      "observable": 45
     },
     "metadata": {
       "caption": "Metadata",

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -198,5 +198,18 @@
       "description": "The Windows service.",
       "type": "win_service"
     }
+  },
+  "types": {
+    "caption": "Data Types",
+    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
+    "attributes": {
+      "reg_key_path_t": {
+        "observable": 43,
+        "caption": "Registry Key Path",
+        "description": "Full path of registry key.",
+        "type": "string_t",
+        "type_name": "String"
+      }
+    }
   }
 }

--- a/extensions/windows/objects/registry_key.json
+++ b/extensions/windows/objects/registry_key.json
@@ -15,7 +15,8 @@
     "path": {
       "caption": "Path",
       "description": "The full path to the registry key.",
-      "requirement": "required"
+      "requirement": "required",
+      "type": "reg_key_path_t"
     },
     "security_descriptor": {
       "caption": "Security Descriptor",

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -21,11 +21,13 @@
     },
     "name": {
       "description": "The name of the registry value.",
-      "requirement": "required"
+      "requirement": "required",
+      "observable": 44
     },
     "path": {
       "description": "The full path to the registry key, where the value is located.",
-      "requirement": "required"
+      "requirement": "required",
+      "type": "reg_key_path_t"
     },
     "type": {
       "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a>.",

--- a/objects/affected_package.json
+++ b/objects/affected_package.json
@@ -12,7 +12,8 @@
     },
     "path": {
       "description": "The installation path of the affected package.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "remediation": {
       "requirement": "optional"

--- a/objects/email.json
+++ b/objects/email.json
@@ -80,7 +80,8 @@
           "url": "https://www.rfc-editor.org/rfc/rfc5322"
         }
       ],
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 39
     },
     "to": {
       "requirement": "recommended"
@@ -91,7 +92,8 @@
     "uid": {
       "caption": "Email Thread UID",
       "description": "The unique identifier of the email thread.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 40
     },
     "urls": {
       "description": "The URLs embedded in the email.",

--- a/objects/file.json
+++ b/objects/file.json
@@ -100,7 +100,8 @@
     },
     "path": {
       "description": "The full path to the file. For example: <code>c:\\windows\\system32\\svchost.exe</code>.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "type": "file_path_t"
     },
     "product": {
       "description": "The product that created or installed the file.",

--- a/objects/image.json
+++ b/objects/image.json
@@ -13,7 +13,8 @@
     },
     "path": {
       "description": "The full path to the image file.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "tag": {
       "requirement": "optional"

--- a/objects/kernel.json
+++ b/objects/kernel.json
@@ -13,7 +13,8 @@
     },
     "path": {
       "description": "The full path of the kernel resource.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "system_call": {
       "requirement": "optional"

--- a/objects/malware.json
+++ b/objects/malware.json
@@ -85,7 +85,8 @@
     },
     "path": {
       "description": "The filesystem path of the malware that was observed.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "type": "file_path_t"
     },
     "provider": {
       "description": "The provider of the malware information.",

--- a/objects/process_entity.json
+++ b/objects/process_entity.json
@@ -23,7 +23,8 @@
       "requirement": "recommended"
     },
     "uid": {
-      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process."
+      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process.",
+      "observable": 41
     }
   },
   "constraints": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

We are populating the observables with values which are notable for correlation or display to the users. There are several values, which we think make good observables, but are not marked as such. This PR tries to add them.

These are the details:

1. Added `email.subject`, `email.uid` and `message_uid` as an Observable types - `type_id: 39`, `type_id: 40` and `45`.
1. Added `process_entity.uid` as an Observable type - `type_id: 41`
1. Added `file_path_t` as an Observable type - `type_id: 42` and marked fields as this type
    - `lineage` dictionary attribute
    - `affected_package.path` object attribute
    - `file.path` object attribute
    - `image.path` object attribute
    - `kernel.path` object attribute
    - `malware.path` object attribute
    - `process_entity.path` object attribute
1. Added `extensions/windows/reg_key_path_t` as an Observable type - `type_id: 43` and marked fields as this type
    - `reg_key.path` object attribute
    - `reg_value.path` object attribute
1. Added `reg_value.name` as an Observable type - `type_id: 44` 

I have updated CHANGELOG.md with the same granularity of the information it already uses, but it's not a "single-line" description. Should I reduce the detail to make it single line?

##### Note On Compatibility

There is a failing compatibility validator, as I changed some fields from `string_t` to the new `file_path_t` and `reg_key_path_t` - as this seem to be the only way to mark several different fields as same observable. Since both old and new types are strings (the new one just adds semantics) I don't see how this could break type compatibility (e.g. in generated classes). But I am happy to learn about any concerns and also whether there is a better (more compatible) way to mark multiple fields with the same observable type.