### PR TITLE
Updating the default version for compatibility check

### DIFF
--- a/.github/workflows/validate-compatibility.yml
+++ b/.github/workflows/validate-compatibility.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run validator
       shell: bash
-      run: export FORCE_COLOR=1 && python -m ocsf.validate.compatibility ${{ vars.LATEST_STABLE || '1.3.0' }} .
+      run: export FORCE_COLOR=1 && python -m ocsf.validate.compatibility ${{ vars.LATEST_STABLE || '1.4.0' }} .
         #      with:
         #repository: ocsf/ocsf-schema
         #path: schema


### PR DESCRIPTION
Note: The version is dynamically pulled from a github repo var. That has been separately updated.

This PR simply updates the `default` version string in the workflow file, to the latest stable version. 
