### PR TITLE
Update environment variable for compatibility validation to 1.4.0

### DIFF
--- a/.github/workflows/validate-compatibility.yml
+++ b/.github/workflows/validate-compatibility.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Run validator
       shell: bash
-      run: export FORCE_COLOR=1 && python -m ocsf.validate.compatibility ${{ vars.LATEST_STABLE || '1.3.0' }} .
+      run: export FORCE_COLOR=1 && python -m ocsf.validate.compatibility ${{ vars.LATEST_STABLE || '1.4.0' }} .
         #      with:
         #repository: ocsf/ocsf-schema
         #path: schema


### PR DESCRIPTION
Along with the `1.4.0` release and public server update, our compatibility testing has been updated to look at the latest stable release version.
