### PR TITLE
Add boot_uid to device.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes 
+  1. Added `boot_uid` as a `string_t`
+	
+### Improved
+* #### Objects
+  1. Added `boot_uid` to `device` objects.
+
 ## [v1.4.0] - January 31st, 2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,11 +43,11 @@ Thankyou! -->
 
 ### Added
 * #### Dictionary Attributes 
-  1. Added `boot_uid` as a `string_t`
+  1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
 	
 ### Improved
 * #### Objects
-  1. Added `boot_uid` to `device` objects.
+  1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -401,6 +401,11 @@
       "description": "The time when the system was booted.",
       "type": "timestamp_t"
     },
+    "boot_uid": {
+      "caption": "Boot UID",
+      "description": "A unique identifier of the device that changes after every reboot. For example, the value of <code>/proc/sys/kernel/random/boot_id</code> from Linux's procfs.",
+      "type": "string_t"
+    },
     "boundary": {
       "caption": "Boundary",
       "description": "The boundary of the connection, normalized to the caption of 'boundary_id'. In the case of 'Other', it is defined by the event source. <p> For cloud connections, this translates to the traffic-boundary(same VPC, through IGW, etc.). For traditional networks, this is described as Local, Internal, or External.</p>",

--- a/dictionary.json
+++ b/dictionary.json
@@ -404,7 +404,13 @@
     "boot_uid": {
       "caption": "Boot UID",
       "description": "A unique identifier of the device that changes after every reboot. For example, the value of <code>/proc/sys/kernel/random/boot_id</code> from Linux's procfs.",
-      "type": "string_t"
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Linux kernel's documentation",
+          "url": "https://docs.kernel.org/admin-guide/sysctl/kernel.html#random"
+        }
+      ]
     },
     "boundary": {
       "caption": "Boundary",

--- a/objects/device.json
+++ b/objects/device.json
@@ -130,6 +130,10 @@
     "vendor_name": {
       "description": "The vendor for the device. For example <code>Dell</code> or <code>Lenovo</code>.",
       "requirement": "recommended"
+    },
+    "boot_uid": {
+      "description": "A unique identifier of the device that changes after every reboot. For example, the value of <code>/proc/sys/kernel/random/boot_id</code> from Linux's procfs.",
+      "requirement": "optional"
     }
   },
   "references": [

--- a/objects/device.json
+++ b/objects/device.json
@@ -132,8 +132,13 @@
       "requirement": "recommended"
     },
     "boot_uid": {
-      "description": "A unique identifier of the device that changes after every reboot. For example, the value of <code>/proc/sys/kernel/random/boot_id</code> from Linux's procfs.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "Linux kernel's documentation",
+          "url": "https://docs.kernel.org/admin-guide/sysctl/kernel.html#random"
+        }
+      ]
     }
   },
   "references": [

--- a/objects/device.json
+++ b/objects/device.json
@@ -132,13 +132,7 @@
       "requirement": "recommended"
     },
     "boot_uid": {
-      "requirement": "optional",
-      "references": [
-        {
-          "description": "Linux kernel's documentation",
-          "url": "https://docs.kernel.org/admin-guide/sysctl/kernel.html#random"
-        }
-      ]
+      "requirement": "optional"
     }
   },
   "references": [


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

On Linux systems, the procfs contains a unique per-boot identifier. Certain tools, such as EDR platforms or journald logs contain this identifier in their emitted telemetry. From an analytical perspective, it's useful to extract since it provides an analyst the ability to see activity from a given system across multiple reboots.

For more details see:
[`man 3 sd_id128_get_machine()`](https://man7.org/linux/man-pages/man3/sd_id128_get_machine.3.html)