### PR TITLE
Expand `evidences`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,12 +78,12 @@ Thankyou! -->
   1. Added `isp`, `isp_org` to `network_endpoint` & `whois` objects. #1351
   1. Reduced requirement of `standards` to recommended in the `compliance` object. #1352
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
-  1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
 
 ### Misc
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
   1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
   1. Updated dictionary descriptions and references of MITRE `attacks`, `tactic`, `technique`, `subtechnique`. #1355
+  1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
 
 ### Deprecated
 1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,14 +79,14 @@ Thankyou! -->
   1. Reduced requirement of `standards` to recommended in the `compliance` object. #1352
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
 
+### Deprecated
+1. Deprecated usage of `isp` attribute in the `location` object. #1351
+
 ### Misc
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
   1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
   1. Updated dictionary descriptions and references of MITRE `attacks`, `tactic`, `technique`, `subtechnique`. #1355
   1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
-
-### Deprecated
-1. Deprecated usage of `isp` attribute in the `location` object. #1351
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Thankyou! -->
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
 
 ### Deprecated
-1. Deprecated usage of `isp` attribute in the `location` object. #1351
+  1. Deprecated usage of `isp` attribute in the `location` object. #1351
 
 ### Misc
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  2. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. ##1337
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Thankyou! -->
   1. Added `isp`, `isp_org` to `network_endpoint` & `whois` objects. #1351
   1. Reduced requirement of `standards` to recommended in the `compliance` object. #1352
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
+  1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351
@@ -86,7 +87,6 @@ Thankyou! -->
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
   1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
   1. Updated dictionary descriptions and references of MITRE `attacks`, `tactic`, `technique`, `subtechnique`. #1355
-  1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -106,11 +106,11 @@
     },
     "verdict": {
       "description": "The normalized verdict of the evidence associated with the security detection. ",
-      "requirement": "recommended"
+      "requirement": "optional"
     },
     "verdict_id": {
       "description": "The normalized verdict (or status) ID of the evidence associated with the security detection. For example, Microsoft Graph Security Alerts contain a <code>verdict</code> enumeration for each type of <code>evidence</code> associated with the Alert.",
-      "requirement": "recommended"
+      "requirement": "optional"
     }
   },
   "constraints": {

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -76,7 +76,7 @@
       "description": "Describes details about the DNS query associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
-    "resource_details": {
+    "resources": {
       "description": "Describes details about the cloud resources associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -64,6 +64,10 @@
       "description": "Describes details about the scheduled job that was associated with the activity that triggered the detection.",
       "requirement": "recommended"
     },
+    "name": {
+      "description": "The naming convention of the evidence associated with the security detection. For example, the <code>@odata.type</code> from Microsoft Graph Alerts V2 or <code>display_name</code> from CrowdStrike Falcon Incident Behaviors.",
+      "requirement": "optional"
+    },
     "process": {
       "description": "Describes details about the process associated to the activity that triggered the detection.",
       "requirement": "recommended"
@@ -87,6 +91,10 @@
     "tls": {
       "description": "Describes details about the Transport Layer Security (TLS) activity that triggered the detection.",
       "requirement": "recommended"
+    },
+    "uid": {
+      "description": "The unique identifier of the evidence associated with the security detection. For example, the <code>activity_id</code> from CrowdStrike Falcon Alerts or <code>behavior_id</code> from CrowdStrike Falcon Incident Behaviors.",
+      "requirement": "optional"
     },
     "url": {
       "description": "The URL object that pertains to the event or object associated to the activity that triggered the detection.",

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -77,7 +77,7 @@
       "requirement": "recommended"
     },
     "resources": {
-      "description": "Describes details about the cloud resources associated to the activity that triggered the detection.",
+      "description": "Describes details about the cloud resources directly related to, or responsible for, the activity that triggered the detection. Uses <code>Resource Details</code> at the top-level of the finding to capture details about cloud resources impacted by the activity.",
       "requirement": "recommended"
     },
     "script": {
@@ -127,7 +127,7 @@
       "file",
       "process",
       "query",
-      "resource_details",
+      "resources",
       "src_endpoint",
       "url",
       "user",

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -78,7 +78,7 @@
     },
     "resources": {
       "caption": "Cloud Resources",
-      "description": "Describes details about the cloud resources directly related to, or responsible for, the activity that triggered the detection. Uses <code>Resource Details</code> at the top-level of the finding to capture details about cloud resources impacted by the activity.",
+      "description": "Describes details about the cloud resources directly related to activity that triggered the detection. For resources impacted by the detection, use <code>Affected Resources</code> at the top-level of the finding.",
       "requirement": "recommended"
     },
     "script": {

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -1,7 +1,7 @@
 {
   "caption": "Evidence Artifacts",
   "description": "A collection of evidence artifacts associated to the activity/activities that triggered a security detection.",
-  "extends": "object",
+  "extends": "_entity",
   "name": "evidences",
   "attributes": {
     "actor": {
@@ -77,6 +77,7 @@
       "requirement": "recommended"
     },
     "resources": {
+      "caption": "Cloud Resources",
       "description": "Describes details about the cloud resources directly related to, or responsible for, the activity that triggered the detection. Uses <code>Resource Details</code> at the top-level of the finding to capture details about cloud resources impacted by the activity.",
       "requirement": "recommended"
     },
@@ -129,11 +130,11 @@
         },
         "4": {
           "caption": "Suspicious",
-          "description": "The verdict for the evidence has been identified as Suspicious."
+          "description": "The verdict for the evidence is that the behavior has been identified as Suspicious."
         },
         "5": {
           "caption": "Benign",
-          "description": "The verdict for the evidence has been identified as Benign."
+          "description": "The verdict for the evidence is that the behavior has been identified as Benign."
         },
         "6": {
           "caption": "Test",
@@ -145,7 +146,7 @@
         },
         "8": {
           "caption": "Security Risk",
-          "description": "The verdict for the evidence has been identified as a Security Risk."
+          "description": "The verdict for the evidence is that the behavior has been identified as a Security Risk."
         },
         "9": {
           "caption": "Managed Externally",

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -109,8 +109,59 @@
       "requirement": "optional"
     },
     "verdict_id": {
-      "description": "The normalized verdict (or status) ID of the evidence associated with the security detection. For example, Microsoft Graph Security Alerts contain a <code>verdict</code> enumeration for each type of <code>evidence</code> associated with the Alert.",
-      "requirement": "optional"
+      "description": "The normalized verdict (or status) ID of the evidence associated with the security detection. For example, Microsoft Graph Security Alerts contain a <code>verdict</code> enumeration for each type of <code>evidence</code> associated with the Alert. This is typically set by an automated investigation process or an analyst/investigator assigned to the finding.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The type is unknown."
+        },
+        "1": {
+          "caption": "False Positive",
+          "description": "The verdict for the evidence has been identified as a False Positive."
+        },
+        "2": {
+          "caption": "True Positive",
+          "description": "The verdict for the evidence has been identified as a True Positive."
+        },
+        "3": {
+          "caption": "Disregard",
+          "description": "The verdict for the evidence is that is should be Disregarded."
+        },
+        "4": {
+          "caption": "Suspicious",
+          "description": "The verdict for the evidence has been identified as Suspicious."
+        },
+        "5": {
+          "caption": "Benign",
+          "description": "The verdict for the evidence has been identified as Benign."
+        },
+        "6": {
+          "caption": "Test",
+          "description": "The evidence is part of a Test, or other sanctioned behavior(s)."
+        },
+        "7": {
+          "caption": "Insufficient Data",
+          "description": "There is insufficient data to render a verdict on the evidence."
+        },
+        "8": {
+          "caption": "Security Risk",
+          "description": "The verdict for the evidence has been identified as a Security Risk."
+        },
+        "9": {
+          "caption": "Managed Externally",
+          "description": "The verdict for the evidence is Managed Externally, such as in a case management tool."
+        },
+        "10": {
+          "caption": "Duplicate",
+          "description": "This evidence duplicates existing evidence related to this finding."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The type is not mapped. See the <code>type</code> attribute, which contains a data source specific value."
+        }
+      },
+      "requirement": "optional",
+      "sibling": "type"
     }
   },
   "constraints": {

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -65,7 +65,7 @@
       "requirement": "recommended"
     },
     "name": {
-      "description": "The naming convention of the evidence associated with the security detection. For example, the <code>@odata.type</code> from Microsoft Graph Alerts V2 or <code>display_name</code> from CrowdStrike Falcon Incident Behaviors.",
+      "description": "The naming convention or type identifier of the evidence associated with the security detection. For example, the <code>@odata.type</code> from Microsoft Graph Alerts V2 or <code>display_name</code> from CrowdStrike Falcon Incident Behaviors.",
       "requirement": "optional"
     },
     "process": {
@@ -102,6 +102,14 @@
     },
     "user": {
       "description": "Describes details about the user that was the target or somehow else associated with the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
+    "verdict": {
+      "description": "The normalized verdict of the evidence associated with the security detection. ",
+      "requirement": "recommended"
+    },
+    "verdict_id": {
+      "description": "The normalized verdict (or status) ID of the evidence associated with the security detection. For example, Microsoft Graph Security Alerts contain a <code>verdict</code> enumeration for each type of <code>evidence</code> associated with the Alert.",
       "requirement": "recommended"
     }
   },

--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -72,6 +72,10 @@
       "description": "Describes details about the DNS query associated to the activity that triggered the detection.",
       "requirement": "recommended"
     },
+    "resource_details": {
+      "description": "Describes details about the cloud resources associated to the activity that triggered the detection.",
+      "requirement": "recommended"
+    },
     "script": {
       "description": "Describes details about the script that was associated with the activity that triggered the detection.",
       "requirement": "recommended"
@@ -107,6 +111,7 @@
       "file",
       "process",
       "query",
+      "resource_details",
       "src_endpoint",
       "url",
       "user",


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

* Adds `resource_details` to `evidences`. This allows producers/mappers to account for cloud-based resources and other generic resources that does not fit well within `device` or `network_endpoint`. For instance, the [`amazonResourceEvidence`](https://learn.microsoft.com/en-us/graph/api/resources/security-amazonresourceevidence?view=graph-rest-1.0) evidence type in the Microsoft Graph Security List Alerts V2 API.
* Adds `name` to `evidences`. In various upstream platforms such as Microsoft Graph and CrowdStrike, there are either naming conventions for the *type* of evidence (e.g., `amazonResourceEvidence`) or an actual display name or direct name such as the `display_name` value within Behaviors associated with Incidents in CrowdStrike Falcon. Microsoft Defender also has an array of `evidence` associated with their alerts that each contain the `entityType` key which identities the name of the evidence.
* Adds `uid` to `evidences` much for the same reason as `name`. Platforms often have a GUID of some sort identifying the specific evidence associated with an alert such as `activity_id` associated with Crowdstrike Falcon Alerts which is the smallest "unit" of alerting/detection data. Likewise, the Behaviors associated with CrowdStrike Falcon Incidents each have their own `behavior_id` which ties them to the Incident ID itself.
* Adds `verdict` and `verdict_id` to `evidences` to normalize similar values in other systems. In every single Evidence type within Microsoft Graph Security Alerts, there is a `verdict` enumeration. Likewise, Microsoft Defender for Graph Alerts have `evidence` arrays with each one containing a `DetectionStatus` to denotes if something was a FP, TP, or otherwise.
