### PR TITLE
Relaxed constraint to provide certain attributes for auth_factor object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#????]
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
-  1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#????]
+  1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/objects/auth_factor.json
+++ b/objects/auth_factor.json
@@ -44,12 +44,5 @@
       "group": "context",
       "requirement": "optional"
     }
-  },
-  "constraints": {
-    "just_one": [
-      "email_addr",
-      "phone_number",
-      "security_questions"
-    ]
   }
 }


### PR DESCRIPTION
#### Related Issue: #1338 

#### Description of changes:

This PR relaxes the `just_one` constraint on the `auth_factor` object.  For more on motivation, see issue #1338.
