### PR TITLE
Added `status_detail_id` as an `integer_t` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,11 @@ Thankyou! -->
 ### Added
 * #### Dictionary Attributes 
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
-	
+  1. Added `status_detail_id` as an `integer_t` enum. [#1340](https://github.com/ocsf/ocsf-schema/pull/1340)
+
 ### Improved
+* #### Event Classes
+  1. Added `status_detail_id` to the Base Event. [#1340](https://github.com/ocsf/ocsf-schema/pull/1340)
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -4998,8 +4998,24 @@
     },
     "status_detail": {
       "caption": "Status Detail",
-      "description": "The status detail contains additional information about the event/finding outcome.",
+      "description": "Additional information about the event/finding outcome, as defined by <code>status_detail_id</code>.",
       "type": "string_t"
+    },
+    "status_detail_id": {
+      "caption": "Status Detail ID",
+      "description": "A normalized identifier for additional information about the event/finding outcome.",
+      "sibling": "status_detail",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The status detail is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The status detail is not mapped. See the <code>status_detail</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "status_details": {
       "caption": "Status Details",

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -112,6 +112,10 @@
       "group": "primary",
       "requirement": "recommended"
     },
+    "status_detail_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "status_id": {
       "group": "primary",
       "requirement": "recommended"

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -107,8 +107,37 @@
       "group": "primary",
       "requirement": "recommended"
     },
-    "status_detail": {
-      "description": "The details about the authentication request. For example, possible details for Windows logon or logoff events are:<ul><li>Success</li><ul><li>LOGOFF_USER_INITIATED</li><li>LOGOFF_OTHER</li></ul><li>Failure</li><ul><li>USER_DOES_NOT_EXIST</li><li>INVALID_CREDENTIALS</li><li>ACCOUNT_DISABLED</li><li>ACCOUNT_LOCKED_OUT</li><li>PASSWORD_EXPIRED</li></ul></ul>"
+    "status_detail_id": {
+      "enum": {
+        "1": {
+          "caption": "LOGOFF_USER_INITIATED",
+          "description": "The user initiated logoff succeeded."
+        },
+        "2": {
+          "caption": "LOGOFF_OTHER",
+          "description": "Logoff succeeded."
+        },
+        "3": {
+          "caption": "USER_DOES_NOT_EXIST",
+          "description": "Logon failed because the user does not exist."
+        },
+        "4": {
+          "caption": "INVALID_CREDENTIALS",
+          "description": "Logon failed because of invalid credentials."
+        },
+        "5": {
+          "caption": "ACCOUNT_DISABLED",
+          "description": "Logon failed because the account was disabled."
+        },
+        "6": {
+          "caption": "ACCOUNT_LOCKED_OUT",
+          "description": "Logon failed because the account is locked out."
+        },
+        "7": {
+          "caption": "PASSWORD_EXPIRED",
+          "description": "Logon failed because because of an expired password."
+        }
+      }
     },
     "user": {
       "description": "The subject (user/role or account) to authenticate.",

--- a/events/system/event_log_activity.json
+++ b/events/system/event_log_activity.json
@@ -99,10 +99,22 @@
       "group": "primary",
       "requirement": "recommended"
     },
-    "status_detail": {
-      "description": "The status detail contains additional information about the event outcome.<br />Example: <code>Success</code>, <code>Privilege Missing</code>, or <code>Invalid Parameter</code> for <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/desktop/eventlogprov/cleareventlog-method-in-class-win32-nteventlogfile'>Windows ClearEventLog</a>.",
-      "group": "primary",
-      "requirement": "recommended"
+    "status_detail_id": {
+      "description": "A normalized identifier for additional information about the event outcome. Examples are String renderings for <a target='_blank' href='https://learn.microsoft.com/en-us/previous-versions/windows/desktop/eventlogprov/cleareventlog-method-in-class-win32-nteventlogfile'>Windows ClearEventLog</a>.",
+      "enum": {
+        "1": {
+          "caption": "Success"
+        },
+        "2": {
+          "caption": "Privilege"
+        },
+        "3": {
+          "caption": "Missing"
+        },
+        "4": {
+          "caption": "Invalid Parameter"
+        }
+      }
     }
   },
   "constraints": {


### PR DESCRIPTION
#### Related Issue: 

https://github.com/ocsf/ocsf-schema/issues/1024

#### Description of changes:

Add a `status_detail_id` attribute as a sibling of `status_detail` to events so `status_detail` is the string rendering of `status_detail_id`.
