### PR TITLE
Add `display_name` to `user` and `ldap_person`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Thankyou! -->
   1. Added `raw_data_size` as a `long_t`. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
   1. Added `assessments` as an array of `assessment` objects. #1343
   1. Added `meets_criteria` as a `boolean_t`. #1343
+  1. Added `display_name` attribute as a `string_t`. [#1341](https://github.com/ocsf/ocsf-schema/pull/1341)
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
 
@@ -58,6 +59,7 @@ Thankyou! -->
   1. Added `meets_criteria` and `policy` to `assessment` object. #1343
   1. Added `assessments` to `compliance` object. #1343
   1. Added `data` to `policy` object. #1343
+  1. Added `display_name` attribute to the `user` and `ldap_person` objects. [#1341](https://github.com/ocsf/ocsf-schema/pull/1341)
 
 ### Misc
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  1. Added `full_name` to `ldap_person` object. [#1341](https://github.com/ocsf/ocsf-schema/pull/1341)
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -2373,7 +2373,7 @@
     },
     "full_name": {
       "caption": "Full Name",
-      "description": "The full name of the person, as per the LDAP Common Name attribute (cn).",
+      "description": "The display name. See specific usage.",
       "type": "string_t"
     },
     "function_keys": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1692,6 +1692,11 @@
       "description": "The dispersion in the NTP protocol is the estimated time error or uncertainty relative to the reference clock in milliseconds.",
       "type": "integer_t"
     },
+    "display_name": {
+      "caption": "Display Name",
+      "description": "The display name. See specific usage.",
+      "type": "string_t"
+    },
     "disposition": {
       "caption": "Disposition",
       "description": "The disposition name, normalized to the caption of the disposition_id value. In the case of 'Other', it is defined by the event source.",
@@ -2373,7 +2378,7 @@
     },
     "full_name": {
       "caption": "Full Name",
-      "description": "The display name. See specific usage.",
+      "description": "The full name. See specific usage.",
       "type": "string_t"
     },
     "function_keys": {

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -20,6 +20,10 @@
     "employee_uid": {
       "requirement": "optional"
     },
+    "full_name": {
+      "description": "The full name of the person, as per the LDAP Common Name attribute (cn).",
+      "requirement": "optional"
+    },
     "given_name": {
       "requirement": "optional"
     },

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -14,6 +14,20 @@
     "deleted_time": {
       "requirement": "optional"
     },
+    "display_name": {
+      "description": "The display name of the LDAP person. According to RFC 2798, this is the preferred name of a person to be used when displaying entries.",
+      "references": [
+        {
+          "description": "RFC 2798",
+          "url": "https://www.rfc-editor.org/rfc/rfc2798.html#section-2.3"
+        },
+        {
+          "description": "Microsoft AD Schema",
+          "url": "https://learn.microsoft.com/en-us/windows/win32/adschema/a-displayname"
+        }
+      ],
+      "requirement": "optional"
+    },
     "email_addrs": {
       "requirement": "optional"
     },

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -34,10 +34,6 @@
     "employee_uid": {
       "requirement": "optional"
     },
-    "full_name": {
-      "description": "The full name of the person, as per the LDAP Common Name attribute (cn).",
-      "requirement": "optional"
-    },
     "given_name": {
       "requirement": "optional"
     },

--- a/objects/user.json
+++ b/objects/user.json
@@ -23,6 +23,7 @@
       "requirement": "optional"
     },
     "full_name": {
+      "description": "The display name of the user, as reported by the product.",
       "requirement": "optional"
     },
     "groups": {

--- a/objects/user.json
+++ b/objects/user.json
@@ -12,6 +12,10 @@
     "credential_uid": {
       "requirement": "optional"
     },
+    "display_name": {
+      "description": "The display name of the user, as reported by the product.",
+      "requirement": "optional"
+    },
     "domain": {
       "description": "The domain where the user is defined. For example: the LDAP or Active Directory domain.",
       "requirement": "optional"
@@ -23,7 +27,7 @@
       "requirement": "optional"
     },
     "full_name": {
-      "description": "The display name of the user, as reported by the product.",
+      "description": "The full name of the user, as reported by the product.",
       "requirement": "optional"
     },
     "groups": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

This PR:

- Adds the `display_name` attribute to the dictionary.
- Adds the `display_name` attribute to the `user` and `ldap_person` objects.
- Relaxes the description of the `full_name` attribute so it can be used with a broader range of products, technologies, and implementations. In the attribute dictionary, the `See specific usage.` convention is applied.

<img width="919" alt="image" src="https://github.com/user-attachments/assets/f0a620a9-345b-4667-a18b-fa21cb57caf1" />

<img width="900" alt="image" src="https://github.com/user-attachments/assets/0b9a5ba3-6218-49ee-89a7-5e8660a666c7" />

<img width="934" alt="image" src="https://github.com/user-attachments/assets/db500c7c-5e55-434c-9bc3-24e6e4168b0f" />

<img width="896" alt="image" src="https://github.com/user-attachments/assets/c361cca5-470f-4824-80b4-c437d6414226" />

<img width="886" alt="image" src="https://github.com/user-attachments/assets/261eaca3-41a9-46a7-b27e-f34ff4d5f36e" />

