### PR TITLE
Expand `device` with mobile device attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,11 +44,24 @@ Thankyou! -->
 ### Added
 * #### Dictionary Attributes 
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  1. Added `assessments` as an array of `assessment` objects. #1343
+  1. Added `meets_criteria` as a `boolean_t`. #1343
+  1. Added `eid`, `iccid`, and `meid` as `string_t` for expanding `device`.
+* #### Objects
+  1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
 	
 ### Improved
+* #### Event Classes
+  1. Added `assessments` to `cloud_resources_inventory_info` and `config_state`. #1343
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
+  1. Added `meets_criteria` and `policy` to `assessment` object. #1343
+  1. Added `assessments` to `compliance` object. #1343
+  1. Added `data` to `policy` object. #1343
+
+### Misc
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
+  1. Updated description of `cloud_resources_inventory_info` and `config_state` to reflect the addition of the `assessments` object. #1343
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,27 +44,19 @@ Thankyou! -->
 ### Added
 * #### Dictionary Attributes 
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
-  1. Added `assessments` as an array of `assessment` objects. #1343
-  1. Added `meets_criteria` as a `boolean_t`. #1343
   1. Added `eid`, `iccid`, and `meid` as `string_t`. #1346
   1. Added `is_backed_up`, `is_mobile_account_active`, and `is_shared` as `boolean_t`. #1346
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
 	
 ### Improved
-* #### Event Classes
-  1. Added `assessments` to `cloud_resources_inventory_info` and `config_state`. #1343
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
-  1. Added `meets_criteria` and `policy` to `assessment` object. #1343
-  1. Added `assessments` to `compliance` object. #1343
-  1. Added `data` to `policy` object. #1343
   1. Added `eid`, `iccid`, `is_backed_up`, `is_mobile_account_active`, `is_shared`, and `meid` to `device`. #1346
   1. Added `is_backed_up` to `resource_details`. #1346
 
 ### Misc
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
-  1. Updated description of `cloud_resources_inventory_info` and `config_state` to reflect the addition of the `assessments` object. #1343
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ Thankyou! -->
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Added `assessments` as an array of `assessment` objects. #1343
   1. Added `meets_criteria` as a `boolean_t`. #1343
-  1. Added `eid`, `iccid`, and `meid` as `string_t` for expanding `device`.
+  1. Added `eid`, `iccid`, and `meid` as `string_t`. #1346
+  1. Added `is_backed_up`, `is_mobile_account_active`, and `is_shared` as `boolean_t`. #1346
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
 	
@@ -58,7 +59,8 @@ Thankyou! -->
   1. Added `meets_criteria` and `policy` to `assessment` object. #1343
   1. Added `assessments` to `compliance` object. #1343
   1. Added `data` to `policy` object. #1343
-  1. Added `eid`, `iccid`, and `meid` to `device`.
+  1. Added `eid`, `iccid`, `is_backed_up`, `is_mobile_account_active`, `is_shared`, and `meid` to `device`. #1346
+  1. Added `is_backed_up` to `resource_details`. #1346
 
 ### Misc
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Thankyou! -->
   1. Added `meets_criteria` and `policy` to `assessment` object. #1343
   1. Added `assessments` to `compliance` object. #1343
   1. Added `data` to `policy` object. #1343
+  1. Added `eid`, `iccid`, and `meid` to `device`.
 
 ### Misc
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,13 +55,13 @@ Thankyou! -->
   1. Added `is_backed_up`, `is_mobile_account_active`, and `is_shared` as `boolean_t`. #1346
 
 * #### Objects
-    1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
-    1. Added `node`, `edge`, `graph` objects. #1343
+  1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
+  1. Added `node`, `edge`, `graph` objects. #1343
 	
 ### Improved
 * #### Event Classes
-    1. Added `assessments` to `config_state`. #1343
-    1. Added `raw_data_size` to `base_event` object. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
+  1. Added `assessments` to `config_state`. #1343
+  1. Added `raw_data_size` to `base_event` object. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)

--- a/dictionary.json
+++ b/dictionary.json
@@ -1992,6 +1992,11 @@
       "description": "The operating system edition. For example: <code>Professional</code>.",
       "type": "string_t"
     },
+    "eid": {
+      "caption": "EID",
+      "description": "An Embedded Identity Document, is a unique serial number that identifies an eSIM-enabled device.",
+      "type": "string_t"
+    },
     "email": {
       "caption": "Email",
       "description": "The email object.",
@@ -2515,6 +2520,11 @@
     "hypervisor": {
       "caption": "Hypervisor",
       "description": "The name of the hypervisor running on the device. For example, <code>Xen</code>, <code>VMware</code>, <code>Hyper-V</code>, <code>VirtualBox</code>, etc.",
+      "type": "string_t"
+    },
+    "iccid": {
+      "caption": "ICCID",
+      "description": "The Integrated Circuit Card Identification of a mobile device. Typically it is a unique 18 to 22 digit number that identifies a SIM card.",
       "type": "string_t"
     },
     "identifier_cookie": {
@@ -3295,6 +3305,11 @@
     "match_location": {
       "caption": "Match Location",
       "description": "The location of the matched data in the source which resulted in the triggered firewall rule. For example: HEADER.",
+      "type": "string_t"
+    },
+    "meid": {
+      "caption": "MEID",
+      "description": "The Mobile Equipment Identifier. It's a unique number that identifies a Code Division Multiple Access (CDMA) mobile device.",
       "type": "string_t"
     },
     "message": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2893,6 +2893,11 @@
       "description": "A determination based on analytics as to whether a potential breach was found.",
       "type": "boolean_t"
     },
+    "is_supervised": {
+      "caption": "Supervised Device",
+      "description": "The event occurred on a supervised device. Devices that are supervised are typically mobile devices managed by a Mobile Device Management solution and are restricted from specific behaviors such as Apple AirDrop.",
+      "type": "boolean_t"
+    },
     "is_system": {
       "caption": "System",
       "description": "The indication of whether the object is part of the operating system.",
@@ -2910,7 +2915,7 @@
     },
     "is_trusted": {
       "caption": "Trusted Device",
-      "description": "The event occurred on a trusted device, also known as a <code>supervised</code> device.",
+      "description": "The event occurred on a trusted device.",
       "type": "boolean_t"
     },
     "is_user_provisioning_enabled": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2878,6 +2878,11 @@
       "description": "Denotes whether a digital certificate is self-signed or signed by a known certificate authority (CA).",
       "type": "boolean_t"
     },
+    "is_shared": {
+      "caption": "Shared Device",
+      "description": "The event occurred on a shared device.",
+      "type": "boolean_t"
+    },
     "is_superseded": {
       "caption": "The patch is superseded.",
       "description": "The vendor patch has been replaced by another.",
@@ -2886,11 +2891,6 @@
     "is_suspected_breach": {
       "caption": "Suspected Breach",
       "description": "A determination based on analytics as to whether a potential breach was found.",
-      "type": "boolean_t"
-    },
-    "is_shared": {
-      "caption": "Shared Device",
-      "description": "The event occurred on a shared device.",
       "type": "boolean_t"
     },
     "is_system": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2895,7 +2895,7 @@
     },
     "is_trusted": {
       "caption": "Trusted Device",
-      "description": "The event occurred on a trusted device.",
+      "description": "The event occurred on a trusted device, also known as a <code>supervised</code> device.",
       "type": "boolean_t"
     },
     "is_user_provisioning_enabled": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -2768,6 +2768,11 @@
       "description": "A determination if a policy, rule, or enforcement action was applied.",
       "type": "boolean_t"
     },
+    "is_backed_up": {
+      "caption": "Back Ups Configured",
+      "description": "Indicates whether the device or resource has a backup enabled, such as an automated snapshot or a cloud backup. For example, this is indicated by the <code>cloudBackupEnabled</code> value within JAMF Pro mobile devices or the registration of an AWS ARN with the AWS Backup service.",
+      "type": "boolean_t"
+    },
     "is_cleartext": {
       "caption": "Cleartext Credentials",
       "description": "Indicates whether the credentials were passed in clear text.<p><b>Note:</b> True if the credentials were passed in a clear text protocol such as FTP or TELNET, or if Windows detected that a user's logon password was passed to the authentication package in clear text.</p>",
@@ -2828,6 +2833,11 @@
       "description": "Indicates whether Multi Factor Authentication was used during authentication.",
       "type": "boolean_t"
     },
+    "is_mobile_account_active": {
+      "caption": "Mobile Account Active",
+      "description": "Indicates whether the device has an active mobile account. For example, this is indicated by the <code>itunesStoreAccountActive</code> value within JAMF Pro mobile devices.",
+      "type": "boolean_t"
+    },
     "is_new_logon": {
       "caption": "New Logon",
       "description": "Indicates logon is from a device not seen before or a first time account logon.",
@@ -2876,6 +2886,11 @@
     "is_suspected_breach": {
       "caption": "Suspected Breach",
       "description": "A determination based on analytics as to whether a potential breach was found.",
+      "type": "boolean_t"
+    },
+    "is_shared": {
+      "caption": "Shared Device",
+      "description": "The event occurred on a shared device.",
       "type": "boolean_t"
     },
     "is_system": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -5380,6 +5380,11 @@
       "type": "string_t",
       "is_array": true
     },
+    "udid": {
+      "caption": "Unique Device Identifier",
+      "description": "The Unique Device Identifier, used for iOS and macOS devices.",
+      "type": "string_t"
+    },
     "uid": {
       "caption": "Unique ID",
       "description": "The unique identifier. See specific usage.",

--- a/objects/device.json
+++ b/objects/device.json
@@ -140,6 +140,9 @@
       "description": "The device type ID.",
       "requirement": "required"
     },
+    "udid": {
+      "requirement": "optional"
+    },
     "uid": {
       "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN.",
       "requirement": "recommended"

--- a/objects/device.json
+++ b/objects/device.json
@@ -24,6 +24,9 @@
       "description": "The network domain where the device resides. For example: <code>work.example.com</code>.",
       "requirement": "optional"
     },
+    "eid": {
+      "requirement": "optional"
+    },
     "first_seen_time": {
       "description": "The initial discovery time of the device.",
       "requirement": "optional"
@@ -41,6 +44,9 @@
     },
     "image": {
       "description": "The image used as a template to run the virtual machine.",
+      "requirement": "optional"
+    },
+    "iccid": {
       "requirement": "optional"
     },
     "imei": {
@@ -71,6 +77,9 @@
     },
     "location": {
       "description": "The geographical location of the device.",
+      "requirement": "optional"
+    },
+    "meid": {
       "requirement": "optional"
     },
     "model": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -59,13 +59,22 @@
       "description": "The device IP address, in either IPv4 or IPv6 format.",
       "requirement": "optional"
     },
+    "is_backed_up": {
+      "requirement": "optional"
+    },
     "is_compliant": {
       "requirement": "optional"
     },
     "is_managed": {
       "requirement": "optional"
     },
+    "is_mobile_account_active": {
+      "requirement": "optional"
+    },
     "is_personal": {
+      "requirement": "optional"
+    },
+    "is_shared": {
       "requirement": "optional"
     },
     "is_trusted": {

--- a/objects/device.json
+++ b/objects/device.json
@@ -77,6 +77,9 @@
     "is_shared": {
       "requirement": "optional"
     },
+    "is_supervised": {
+      "requirement": "optional"
+    },
     "is_trusted": {
       "requirement": "optional"
     },

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -27,6 +27,9 @@
       "description": "The IP address of the resource, in either IPv4 or IPv6 format.",
       "requirement": "recommended"
     },
+    "is_backed_up": {
+      "requirement": "optional"
+    },
     "name": {
       "observable": 38,
       "requirement": "recommended"


### PR DESCRIPTION
Currently `device` supports `imei` (deprecated) and `imei_list`. There are several other IDs used within mobile devices that are recorded by MDM tools such as Intune, JAMF Pro, and even CrowdStrike.

Adds `eid`, `iccid`, and `meid` to the Dictionary and to `device`.

See this example from JAMF Mobile Devices `NETWORK` attributes.

```json
"network": {
        "cellularTechnology": "Unknown",
        "voiceRoamingEnabled": false,
        "imei": "59 105109 176278 3",
        "iccid": "8991101200003204514",
        "meid": "15302309236898",
        "eid": "12547444452496388545569920380795",
        "carrierSettingsVersion": "33.1",
        "currentCarrierNetwork": "Verizon Wireless",
        "currentMobileCountryCode": "311",
        "currentMobileNetworkCode": "480",
        "homeCarrierNetwork": "Verizon",
        "homeMobileCountryCode": "US",
        "homeMobileNetworkCode": "480",
        "dataRoamingEnabled": true,
        "roaming": false,
        "personalHotspotEnabled": false,
        "phoneNumber": "555-555-5555 ext 5"
      },
```

Additionally, extra bools are added: `is_backed_up`, `is_mobile_account_active`, and `is_shared` to reflect similar attributes within JAMF Pro data, but `is_backed_up` and `is_shared` can be re-used for other use cases.