### PR TITLE
Add raw_data_size to base_event.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,13 +42,15 @@ Thankyou! -->
 ## [Unreleased]
 
 ### Added
-* #### Dictionary Attributes 
+* #### Dictionary Attributes
   1. Added `boot_uid` as a `string_t`. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
-	
+  1. Added `raw_data_size` as a `long_t`. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
+
 ### Improved
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)
+  1. Added `raw_data_size` to `base_event` object. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -4101,6 +4101,11 @@
       "description": "The raw event/finding data as received from the source.",
       "type": "string_t"
     },
+    "raw_data_size": {
+      "caption": "Raw Data Size",
+      "description": "The size of the raw data which was transformed into an OCSF event, in bytes.",
+      "type": "long_t"
+    },
     "raw_header": {
       "caption": "Raw Header",
       "description": "The email authentication header.",

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -87,6 +87,10 @@
       "group": "context",
       "requirement": "optional"
     },
+    "raw_data_size": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "severity": {
       "group": "classification",
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: N/A 

This is a follow on [from slack](https://opencybersecu-lz97379.slack.com/archives/C03C2QPSBPB/p1739819906117879).

#### Description of changes:

These changes add a `raw_data_size` field to `base_event`. This field can assist in answering questions related to the size of the incoming data. A key insight would be tracking situations where a system drastically increases or decreases the average size of a raw message. 

While it's possible to derive this calculation today if the underlying storage system supports counting the number of bytes in a field, it's not efficient to perform that calculation at scale (worst case: $`O(n \times m)`$). Adding this field allows for a much more efficient calculation, and also provides the ability to perform that calculation in situations where the storage system does not store the `raw_data` or stores it separate from the OCSF formatted event.