### PR TITLE
Add references to process parentage guidance

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -190,7 +190,8 @@
       "caption": "Ancestry",
       "description": "An array of Process Entities describing the extended parentage of this process object. Direct parent information sould be expressed through the <code>parent_process</code> attribute. The first array element is the direct parent of this process object. Subsequent list elements go up the process parentage hierarchy. That is, the array is sorted from newest to oldest process. It is recommended to only populate this field for the top-level process object.",
       "type": "process_entity",
-      "is_array": true
+      "is_array": true,
+      "references": [{"url": "https://github.com/ocsf/ocsf-docs/blob/main/Articles/Representing Process Parentage.md", "description": "Guidance on Representing Process Parentage"}]
     },
     "answers": {
       "caption": "DNS Answer",
@@ -3711,7 +3712,8 @@
     "parent_process": {
       "caption": "Parent Process",
       "description": "The parent process of this process object. It is recommended to only populate this field for the top-level process object, to prevent deep nesting. Additional ancestry information can be supplied in the <code>ancestry</code> attribute.",
-      "type": "process"
+      "type": "process",
+      "references": [{"url": "https://github.com/ocsf/ocsf-docs/blob/main/Articles/Representing Process Parentage.md", "description": "Guidance on Representing Process Parentage"}]
     },
     "parent_uid": {
       "caption": "Parent Unique ID",


### PR DESCRIPTION
Reference added to the two main parentage attributes

I added the references to the attributes instead of the process object because I think it stands out a bit more in the UI if one is already considering process parentage.
Therefore people will be less likely to miss it.

![image](https://github.com/user-attachments/assets/362d84e3-0e22-4068-bbd3-c28a4d60730d)

