### PR TITLE
Adding attributes to inidicate fix coverage in the vulnerability object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Thankyou! -->
     1. Added `display_name` attribute as a `string_t`. [#1341](https://github.com/ocsf/ocsf-schema/pull/1341)
     1. Added `is_directed` as a `boolean_t`, `relation` as a `string_t`, `query_language` & `query_language_id` a sibling pair. #1343
     1. Added `resource_relationship` of type `graph`, `nodes` of type `node`, `edges` of type `edge`. #1343
+    1. Added `fix_coverage` as `string_t` and `fix_coverage_id` as `int_t`. #1350
 * #### Objects
     1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
     1. Added `node`, `edge`, `graph` objects. #1343
@@ -67,6 +68,7 @@ Thankyou! -->
     1. Added `data` to `policy` object. #1343
     1. Added `display_name` attribute to the `user` and `ldap_person` objects. [#1341](https://github.com/ocsf/ocsf-schema/pull/1341)
     1. Added `resource_relationship` to `resource_details` object. #1343
+    1. Added `fix_coverage`, `fix_coverage_id` to `vulnerability` object. #1350
   
 ### Misc
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343

--- a/dictionary.json
+++ b/dictionary.json
@@ -2300,6 +2300,26 @@
         "since": "1.1.0"
       }
     },
+    "fix_coverage": {
+      "caption": "Fix Coverage",
+      "description": "The fix coverage, normalized to the caption of the <code>fix_coverage_id</code> value. See specific usage.",
+      "type": "string_t"
+    },
+    "fix_coverage_id": {
+      "caption": "Fix Coverage ID",
+      "description": "The normalized identifier for fix coverage. See specific usage.",
+      "type": "integer_t",
+      "enum":{
+        "0": {
+          "caption": "Unknown",
+          "description": "The fix coverage is unknown."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The fix coverage is not mapped. See the <code>fix_coverage</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "fixed_in_version": {
       "caption": "Fixed In Version",
       "description": "The software package version in which a reported vulnerability was patched/fixed.",

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -35,6 +35,28 @@
     "fix_available": {
       "requirement": "optional"
     },
+    "fix_coverage": {
+      "description": "The fix coverage, normalized to the caption of the <code>fix_coverage_id</code> value.",
+      "requirement": "optional"
+    },
+    "fix_coverage_id": {
+      "description": "The normalized identifier for fix coverage, applicable to this vulnerability. Typically useful, when there are multiple affected packages but only a subset have available fixes.",
+      "requirement": "optional",
+      "enum":{
+        "1": {
+          "caption": "Complete",
+          "description": "All affected packages and components have available fixes or patches to remediate the vulnerability."
+        },
+        "2": {
+          "caption": "Partial", 
+          "description": "Only some of the affected packages and components have available fixes or patches, while others remain vulnerable."
+        },
+        "3": {
+          "caption": "None",
+          "description": "No fixes or patches are currently available for any of the affected packages and components."
+        }
+      }
+    },
     "is_exploit_available": {
       "requirement": "optional"
     },


### PR DESCRIPTION
1. Adding `fix_coverage` & `fix_coverage_id` enum to the dictionary
2. Updating the `vulnerability` object with these attributes. 

This change is useful to represent fix availability when a single vulnerability affects multiple packages, and only a subset of those packages have a fix/patch available. This field works in parallel the existing boolean field - `is_fix_available`


