### PR TITLE
ISP & ISP Org related changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Thankyou! -->
   1. Added `fix_coverage` as `string_t` and `fix_coverage_id` as `int_t`. #1350
   1. Added `eid`, `iccid`, and `meid` as `string_t`. #1346
   1. Added `is_backed_up`, `is_mobile_account_active`, and `is_shared` as `boolean_t`. #1346
+  1. Added `isp_org` as `string_t`. #1351
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
   1. Added `node`, `edge`, `graph` objects. #1343
@@ -73,8 +74,14 @@ Thankyou! -->
   1. Added `fix_coverage`, `fix_coverage_id` to `vulnerability` object. #1350
   1. Added `eid`, `iccid`, `is_backed_up`, `is_mobile_account_active`, `is_shared`, and `meid` to `device`. #1346
   1. Added `is_backed_up` to `resource_details`. #1346
+  1. Added `isp`, `isp_org` to `network_endpoint` & `whois` objects. #1351
+
+### Deprecated
+1. Deprecated usage of `isp` attribute in the `location` object. #1351
+
+
 ### Misc
-  1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
+1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
 
 
 ## [v1.4.0] - January 31st, 2025

--- a/dictionary.json
+++ b/dictionary.json
@@ -2986,6 +2986,11 @@
       "description": "The name of the Internet Service Provider (ISP).",
       "type": "string_t"
     },
+    "isp_org": {
+      "caption": "ISP Org",
+      "description": "The organization name of the Internet Service Provider (ISP).",
+      "type": "string_t"
+    },
     "issuer": {
       "caption": "Issuer Details",
       "description": "The identifier of the issuer. See specific usage.",

--- a/objects/location.json
+++ b/objects/location.json
@@ -40,7 +40,11 @@
       "requirement": "optional"
     },
     "isp": {
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Utilize <code>isp</code> attribute available in <code>network_endpoint, whois</code> objects according to your use-case.",
+        "since": "1.5.0"
+      }
     },
     "lat": {
       "requirement": "optional"

--- a/objects/network_endpoint.json
+++ b/objects/network_endpoint.json
@@ -10,6 +10,12 @@
     "intermediate_ips": {
       "requirement": "optional"
     },
+    "isp": {
+      "requirement": "optional"
+    },
+    "isp_org": {
+      "requirement": "optional"
+    },
     "port": {
       "description": "The port used for communication within the network connection.",
       "requirement": "recommended"

--- a/objects/whois.json
+++ b/objects/whois.json
@@ -31,6 +31,12 @@
       "description": "The email address for the registrar's abuse contact",
       "requirement": "optional"
     },
+    "isp": {
+      "requirement": "optional"
+    },
+    "isp_org": {
+      "requirement": "optional"
+    },
     "last_seen_time": {
       "caption": "Last Updated At",
       "description": "When the WHOIS record was last updated or seen at.",


### PR DESCRIPTION
#### Related Issue: 
Currently, `isp` is present as a part of the `location` object in the schema. Conceptually, `isp` is not an attribute of a location. Having this attr in the location object isn't intuitive. This is more suitable in the `whois` object and directly in the network_endpoint object (similar to how we have `autonomous_system` in there. Ideally, IP characteristics should can be collected together in a separate object, which can then be a part of the endpoint object. We can consider it for the next major version of OCSF.
Additionally, we were also missing an attribute to represent organization name of an ISP. Adding that attribute as well.

#### Description of changes:
1. Deprecate `isp` in the location object
2. Add `isp`, `isp_org` in network endpoint & whois object
