### PR TITLE
General Updates to compliance object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Thankyou! -->
   1. Added `eid`, `iccid`, `is_backed_up`, `is_mobile_account_active`, `is_shared`, and `meid` to `device`. #1346
   1. Added `is_backed_up` to `resource_details`. #1346
   1. Added `isp`, `isp_org` to `network_endpoint` & `whois` objects. #1351
+  1. Reduced requirement of `standards` to recommended in the `compliance` object. #1352
 
 ### Deprecated
 1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/dictionary.json
+++ b/dictionary.json
@@ -246,7 +246,7 @@
     },
     "assessments": {
       "caption": "Assessments",
-      "description": "A list of <code>assessment</code> objects.",
+      "description": "A list of <code>assessment</code> objects. See specific usage.",
       "type": "assessment",
       "is_array": true
     },
@@ -2982,13 +2982,13 @@
       "type": "boolean_t"
     },
     "isp": {
-      "caption": "ISP",
+      "caption": "ISP Name",
       "description": "The name of the Internet Service Provider (ISP).",
       "type": "string_t"
     },
     "isp_org": {
       "caption": "ISP Org",
-      "description": "The organization name of the Internet Service Provider (ISP).",
+      "description": "The organization name of the Internet Service Provider (ISP). This represents the parent organization or company that owns/operates the ISP. For example, Comcast Corporation would be the ISP org for Xfinity internet service. This attribute helps identify the ultimate provider when ISPs operate under different brand names.",
       "type": "string_t"
     },
     "issuer": {

--- a/objects/compliance.json
+++ b/objects/compliance.json
@@ -1,12 +1,11 @@
 {
   "caption": "Compliance",
-  "description": "The Compliance object contains information about Industry and Regulatory Framework standards, controls and requirements.",
+  "description": "The Compliance object contains information about Industry and Regulatory Framework standards, controls and requirements or details about custom assessments utilized in a compilance evaluation.",
   "extends": "object",
   "name": "compliance",
   "attributes": {
     "assessments": {
-      "caption": "Related Assessments",
-      "description": "A list of assessments associated with the compliance requirements evaluation",
+      "description": "A list of assessments associated with the compliance requirements evaluation.",
       "requirement": "optional"
     },
     "compliance_references": {
@@ -25,7 +24,7 @@
       "requirement": "optional"
     },
     "standards": {
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "status": {
       "description": "The resultant status of the compliance check  normalized to the caption of the <code>status_id</code> value. In the case of 'Other', it is defined by the event source.",
@@ -64,6 +63,6 @@
         }
       },
       "requirement": "recommended"
-    }
+    } 
   }
 }


### PR DESCRIPTION
#### Description of changes:
1. Reducing requirement of standards to recommended, to allow independent usage of the newly added `assessments` attribute.
2. General description cleanup in the compliance object.
3. Unrelated change- Description update for isp_org, followup to #1351 
