### PR TITLE
Clarify usage for Apple UDID and hardware UUID fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ Thankyou! -->
 
 ### Misc
 1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
-
+1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -5498,8 +5498,14 @@
     },
     "udid": {
       "caption": "Unique Device Identifier",
-      "description": "The Apple assigned <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a> (UDID). It is the UDID for iOS, iPadOS, tvOS, watchOS, and visionOS devices. It is the Provisioning UDID for macOS devices. For example: <code>00008020-008D4548007B4F26</code>",
-      "type": "string_t"
+      "description": "The Apple assigned Unique Device Identifier (UDID). For iOS, iPadOS, tvOS, watchOS and visionOS devices, this is the UDID. For macOS devices, it is the Provisioning UDID. For example: <code>00008020-008D4548007B4F26</code>",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Apple Wiki",
+          "url": "https://theapplewiki.com/wiki/UDID"
+        }
+      ]
     },
     "uid": {
       "caption": "Unique ID",

--- a/dictionary.json
+++ b/dictionary.json
@@ -5498,7 +5498,7 @@
     },
     "udid": {
       "caption": "Unique Device Identifier",
-      "description": "The Unique Device Identifier, used for iOS and macOS devices.",
+      "description": "The Apple assigned <a href='https://theapplewiki.com/wiki/UDID'>Unique Device Identifier</a> (UDID). It is the UDID for iOS, iPadOS, tvOS, watchOS, and visionOS devices. It is the Provisioning UDID for macOS devices. For example: <code>00008020-008D4548007B4F26</code>",
       "type": "string_t"
     },
     "uid": {

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -51,8 +51,30 @@
       "requirement": "optional"
     },
     "uuid": {
-      "description": "The device manufacturer assigned universally unique hardware identifier. It is the System UUID for <a href='https://www.dmtf.org/standards/smbios'>SMBIOS</a> compatible devices such as those running Linux and Windows. It is the Hardware UUID (also known as <code>IOPlatformUUID</code>) for macOS devices.",
-      "requirement": "optional"
+      "description": "The device manufacturer assigned universally unique hardware identifier. For SMBIOS compatible devices such as those running Linux and Windows, it is the UUID member of the System Information structure in the SMBIOS information. For macOS devices, it is the Hardware UUID (also known as IOPlatformUUID in the I/O Registry).",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "SMBIOS Specification",
+          "url": "https://www.dmtf.org/standards/smbios"
+        },
+        {
+          "description": "Linux DMI Table Decoder documentation",
+          "url": "https://linux.die.net/man/8/dmidecode"
+        },
+        {
+          "description": "Windows Win32_ComputerSystemProduct documentation",
+          "url": "https://learn.microsoft.com/en-us/windows/win32/cimwin32prov/win32-computersystemproduct"
+        },
+        {
+          "description": "Apple Wiki (Mac Hardware UUID)",
+          "url": "https://theapplewiki.com/wiki/UDID#Mac"
+        },
+        {
+          "description": "macOS I/O Registry source code reference to IOPlatformUUID",
+          "url": "https://github.com/apple-oss-distributions/xnu/blob/8d741a5de7ff4191bf97d57b9f54c2f6d4a15585/iokit/IOKit/IOKitKeys.h#L264-L265"
+        }
+      ]
     },
     "vendor_name": {
       "description": "The device manufacturer.",

--- a/objects/device_hw_info.json
+++ b/objects/device_hw_info.json
@@ -51,7 +51,7 @@
       "requirement": "optional"
     },
     "uuid": {
-      "description": "The device manufacturer assigned universally unique hardware identifier. For example: The BIOS System UUID or the Apple IOPlatformUUID.",
+      "description": "The device manufacturer assigned universally unique hardware identifier. It is the System UUID for <a href='https://www.dmtf.org/standards/smbios'>SMBIOS</a> compatible devices such as those running Linux and Windows. It is the Hardware UUID (also known as <code>IOPlatformUUID</code>) for macOS devices.",
       "requirement": "optional"
     },
     "vendor_name": {


### PR DESCRIPTION
#### Related Issue: 
Fixes #1353 

#### Description of changes:

The OCSF 1.5 draft [recently introduced](https://github.com/ocsf/ocsf-schema/commit/e3efe4a87f002955ac978fa2fc2d96a4940174e5) a new `device.udid` field to store the Unique Device Identifier (UDID) for Apple devices. This proposed change adds more specific usage guidance and clarifies the difference between the new field and the existing `device.hw_info.uuid` field. The intent is to discourage misuse, such as incorrectly storing the Mac hardware UUID in the `udid` field while not populating `device.hw_info.uuid`, resulting in failure when joining data belonging to the same device.  

Before:

![image](https://github.com/user-attachments/assets/6fc4fedb-b977-455f-80fa-21408e9a72b2)

![image](https://github.com/user-attachments/assets/657819b1-e82d-40ed-8617-d373a2de9abd)

After:

![image](https://github.com/user-attachments/assets/c8619408-e48d-46bb-8fde-8755b74132e5)

![image](https://github.com/user-attachments/assets/fa8258dd-0b73-48e0-921f-ab42462b50b0)