### PR TITLE
[bug fix] Correcting the sibling name used for verdict_id in evidences object

### DIFF
--- a/objects/evidences.json
+++ b/objects/evidences.json
@@ -162,7 +162,7 @@
         }
       },
       "requirement": "optional",
-      "sibling": "type"
+      "sibling": "verdict"
     }
   },
   "constraints": {


### PR DESCRIPTION
#### A minor bug was introduced in https://github.com/ocsf/ocsf-schema/pull/1337 

#### Description of changes:
1. Fixing the `sibling` name used for `verdict_id` attr introduced in the evidences object