### PR TITLE
Added `Detect` value for `activity_id` in Remediation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Thankyou! -->
   1. Added `assessments` to `config_state`. #1343
   1. Added `raw_data_size` to `base_event`. [#1347](https://github.com/ocsf/ocsf-schema/pull/1347)
   1. Added `anomaly_analyses` to `detection_finding`. #1358
+  1. Added `Detect` value for `activity_id` in Remediation events. [#1362](https://github.com/ocsf/ocsf-schema/pull/1362)
 * #### Objects
   1. Added `boot_uid` to `device` object. [#1335](https://github.com/ocsf/ocsf-schema/pull/1335)
   1. Relaxed constraint to provide `email_addr`, `phone_number`, or `security_questions` on `auth_factor`. [#1339](https://github.com/ocsf/ocsf-schema/pull/1339)

--- a/events/remediation/remediation_activity.json
+++ b/events/remediation/remediation_activity.json
@@ -11,19 +11,23 @@
       "enum": {
         "1": {
           "caption": "Isolate",
-          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/d3f:Isolate/'>d3f:Isolate</a>."
+          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Isolate/'>d3f:Isolate</a>."
         },
         "2": {
           "caption": "Evict",
-          "description": "Removes an adversary or malicious resource from a device or computer network. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/d3f:Evict/'>d3f:Evict</a>."
+          "description": "Removes an adversary or malicious resource from a device or computer network. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Evict/'>d3f:Evict</a>."
         },
         "3": {
           "caption": "Restore",
-          "description": "Returns the system to a better state. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/d3f:Restore/'>d3f:Restore</a>."
+          "description": "Returns the system to a better state. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Restore/'>d3f:Restore</a>."
         },
         "4": {
           "caption": "Harden",
-          "description": " Increases the opportunity cost of computer network exploitation. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/d3f:Harden/'>d3f:Harden</a>."
+          "description": "Increases the opportunity cost of computer network exploitation. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Harden/'>d3f:Harden</a>."
+        },
+        "5": {
+          "caption": "Detect",
+          "description": "Further identify adversary access to or unauthorized activity on computer networks. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Detect/'>d3f:Detect</a>."
         }
       }
     },


### PR DESCRIPTION
In Cisco Endpoint Security (and other EDRs), a common response to a detection is uploading a file to a dynamic analysis sandbox. This action is covered in the Detect MITRE D3FEND Tactic with [Dynamic Analysis](https://d3fend.mitre.org/technique/d3f:DynamicAnalysis/).

This PR adds Detect as an `activity_id` in Remediation activity to accurately model the above situation (and others).

