### PR TITLE
Adding `traits` to `related_event` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ Thankyou! -->
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
   1. Added `node`, `edge`, `graph` objects. #1343
   1. Added `anomaly`, `anomaly_analysis`, `baseline`, `observation` objects. #1358
+  1. Added `trait` object. #1363
   
 ### Improved
 * #### Event Classes
@@ -84,6 +85,7 @@ Thankyou! -->
   1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
   1. Added `algorithm` to `analytic` object. #1358
   1. Added 'count' `start_time` `end_time` to `timespan` object. #1365
+  1. Added `traits` to `related_event` object. #1363
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/dictionary.json
+++ b/dictionary.json
@@ -5801,6 +5801,12 @@
       "caption": "Network Zone",
       "description": "The network zone or LAN segment.",
       "type": "string_t"
+    },
+    "traits": {
+      "caption": "Traits",
+      "description": "The traits that describe describe characteristics, features of an enrity. See specific usage.",
+      "type": "trait",
+      "is_array": true
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -5862,11 +5862,6 @@
       "description": "The traits that describe characteristics, features of an entity. See specific usage.",
       "type": "trait",
       "is_array": true
-    },
-    "rank": {
-      "caption": "Rank",
-      "description": "The rank of an entity. See specific usage.",
-      "type": "integer_t"
     }
   },
   "types": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -5859,7 +5859,7 @@
     },
     "traits": {
       "caption": "Traits",
-      "description": "The traits that describe describe characteristics, features of an enrity. See specific usage.",
+      "description": "The traits that describe characteristics, features of an entity. See specific usage.",
       "type": "trait",
       "is_array": true
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -5807,6 +5807,11 @@
       "description": "The traits that describe describe characteristics, features of an enrity. See specific usage.",
       "type": "trait",
       "is_array": true
+    },
+    "rank": {
+      "caption": "Rank",
+      "description": "The rank of an entity. See specific usage.",
+      "type": "integer_t"
     }
   },
   "types": {

--- a/objects/related_event.json
+++ b/objects/related_event.json
@@ -59,6 +59,10 @@
       "description": "A title or a brief phrase summarizing the related event/finding.",
       "requirement": "optional"
     },
+    "traits": {
+      "description": "The list of key traits or characteristics extracted from the related event/finding that influenced or contributed to the overall finding's outcome.",
+      "requirement": "optional"
+    },
     "type": {
       "description": "The type of the related event/finding.</p>Populate if the related event/finding is <code>NOT</code> in OCSF. If it is in OCSF, then utilize <code>type_name, type_uid</code> instead.",
       "requirement": "optional"

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -1,6 +1,7 @@
 {
   "caption": "Trait",
   "description": "Describes a characteristic or feature of an entity that was observed. For example, this object can be used to represent specific characteristics derived from events or findings that can be surfaced as distinguishing traits of the entity in question.",
+  "extends": "_entity",
   "name": "trait",
   "attributes": {
     "category": {

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -11,6 +11,10 @@
     "name": {
       "description": "The name of the trait"
     },
+    "rank": {
+      "description": "The numeric rank of the trait. This value can be used to sort and prioritize traits within the array attribute <code>traits</code>. Higher values indicate higher priority/importance.",
+      "requirement": "optional"
+    },
     "type": {
       "description": "The type of the trait. Example, contributing, mitigating or contextual.",
       "requirement": "optional"

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -11,10 +11,6 @@
     "name": {
       "description": "The name of the trait."
     },
-    "rank": {
-      "description": "The numeric rank of the trait. This value can be used to sort and prioritize traits within the array attribute <code>traits</code>. Higher values indicate higher priority/importance.",
-      "requirement": "optional"
-    },
     "type": {
       "description": "The type of the trait. For example, this can be used to indicate if the trait acts as a contributing factor (increases risk/severity) or a mitigating factor (decreases risk/severity), in the context of the related finding.",
       "requirement": "optional"

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -1,7 +1,6 @@
 {
   "caption": "Trait",
-  "description": "Describes a characteristic or feature of an entity that was observed. For example, this object can be used to represent specific characteristics derived from an event, finding to be surfaced as traits of a related event.",
-  "extends": "_entity",
+  "description": "Describes a characteristic or feature of an entity that was observed. For example, this object can be used to represent specific characteristics derived from events or findings that can be surfaced as distinguishing traits of the entity in question.",
   "name": "trait",
   "attributes": {
     "category": {
@@ -20,7 +19,7 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier for the trait."
+      "description": "The unique identifier of the trait."
     },
     "values": {
       "description": "The values of the trait.",

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -16,7 +16,7 @@
       "requirement": "optional"
     },
     "type": {
-      "description": "The type of the trait. Example, contributing, mitigating or contextual.",
+      "description": "The type of the trait. For example, this can be used to indicate if the trait acts as a contributing factor (increases risk/severity) or a mitigating factor (decreases risk/severity), in the context of the related finding.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -1,6 +1,6 @@
 {
   "caption": "Trait",
-  "description": "Describes a characteristic or feature of an entity that was observed.",
+  "description": "Describes a characteristic or feature of an entity that was observed. For example, this object can be used to represent specific characteristics derived from an event, finding to be surfaced as traits of a related event.",
   "extends": "_entity",
   "name": "trait",
   "attributes": {
@@ -9,7 +9,7 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The name of the trait"
+      "description": "The name of the trait."
     },
     "rank": {
       "description": "The numeric rank of the trait. This value can be used to sort and prioritize traits within the array attribute <code>traits</code>. Higher values indicate higher priority/importance.",

--- a/objects/trait.json
+++ b/objects/trait.json
@@ -1,0 +1,26 @@
+{
+  "caption": "Trait",
+  "description": "Describes a characteristic or feature of an entity that was observed.",
+  "extends": "_entity",
+  "name": "trait",
+  "attributes": {
+    "category": {
+      "description": "The high-level grouping or classification this trait belongs to.",
+      "requirement": "optional"
+    },
+    "name": {
+      "description": "The name of the trait"
+    },
+    "type": {
+      "description": "The type of the trait. Example, contributing, mitigating or contextual.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The unique identifier for the trait."
+    },
+    "values": {
+      "description": "The values of the trait.",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:

1. Adding `traits` to the framework
2. Adding a `trait` object to represent, high level features/characteristics/traits derived from an event/finding in the context of a `related_event`. Think of these as companion fields that can be used alongside `observables` in a related finding. Purposefully, keeping the descriptions and attribute names generic, for potential re-use down the road.

Sample use-case of the proposed structure, representing a Detection Finding which utilizes `finding_info.related_events` and represents "traits" extracted from these related findings. 

```
{
  "finding_info": {
    ...
    "related_events": [
      {
      ...
      "traits": [
          {
            "category": "Misconfiguration",
            "name": "The IAM User has weak password policies",
            "type": "Contributing Trait"
          }
        ],
      ...
      "uid": "arn:aws:securityhub:us-east-1:111111111111:security-control/IAM.7/finding/example"
      },
      {
      ...
      "traits": [
          {
            "category": "Misconfiguration",
            "name": "The IAM User has a policy with administrative access to AWS Service(s)",
            "type": "Contributing Trait",
            "values": [
              "s3",
              "iam"
            ]
          },
          {
            "category": "Configuration",
            "name": "There's an Organization SCP applicable to this IAM User",
            "type": "Mitigating Trait"
          }
        ],
      ...
      "uid": "arn:aws:securityhub:us-east-1:111111111111:security-control/IAM.21/finding/example"
      }
    ],
    "related_events_count": 2,
    "title": "",
    "uid": "arn:aws:securityhub:us-east-1:111111111111:example:example"
  }
  ...
}
```