### PR TITLE
Added Managed Entity Zone type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Thankyou! -->
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
   1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
   1. Added `algorithm` to `analytic` object. #1358
+  1. Added 'Network Zone' type to the `managed_entity` object enum list. #1364
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -1,6 +1,6 @@
 {
   "caption": "Managed Entity",
-  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  For types in the <code>type_id</code> enum list, an associated attribute should be populated.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute and the <code>type</code> attribute should identify the entity.",
+  "description": "The Managed Entity object describes the type and version of an entity, such as a user, device, or policy.  For types in the <code>type_id</code> enum list, an associated attribute should be populated.  If the type of entity is not in the <code>type_id</code> list, information can be put into the <code>data</code> attribute, <code>type_id</code> should be 'Other' and the <code>type</code> attribute should label the entity type.",
   "extends": "_entity",
   "name": "managed_entity",
   "attributes": {
@@ -31,7 +31,7 @@
       "requirement": "recommended"
     },
     "type": {
-      "description": "The managed entity type. For example: <code>policy</code>, <code>user</code>, <code>organizational unit</code>, <code>device</code>.",
+      "description": "The managed entity type. For example: <code>Policy</code>, <code>User</code>, <code>Organization</code>, <code>Device</code>.",
       "requirement": "recommended"
     },
     "type_id": {
@@ -63,7 +63,7 @@
         },
         "7": {
           "caption": "Network Zone",
-          "description": "A managed Network Zone entity. Populate the <code>name</code> attribute with the zone name and/or the <code>uid</code> attribute with the zone ID."
+          "description": "A managed Network Zone entity. Populate the <code>name</code> attribute with the zone name and/or the <code>uid</code> attribute with the zone ID. Additional zone information can be added to the <code>data</code> attribute."
         }
       },
       "requirement": "recommended"

--- a/objects/managed_entity.json
+++ b/objects/managed_entity.json
@@ -21,7 +21,7 @@
       "requirement": "optional"
     },
     "name": {
-      "description": "The name of the managed entity."
+      "description": "The name of the managed entity. It should match the name of the specific entity object's name if populated, or the name of the managed entity if the <code>type_id</code> is 'Other'."
     },
     "org": {
       "requirement": "recommended"
@@ -60,12 +60,16 @@
         "6": {
           "caption": "Email",
           "description": "A managed Email entity.  This item corresponds to population of the <code>email</code> attribute."
+        },
+        "7": {
+          "caption": "Network Zone",
+          "description": "A managed Network Zone entity. Populate the <code>name</code> attribute with the zone name and/or the <code>uid</code> attribute with the zone ID."
         }
       },
       "requirement": "recommended"
     },
     "uid": {
-      "description": "The identifier of the managed entity."
+      "description": "The identifier of the managed entity. It should match the <code>uid</code> of the specific entity's object UID if populated, or the source specific ID if the <code>type_id</code> is 'Other'."
     },
     "user": {
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: Supersedes PR #1181

#### Description of changes:
Added 'Network Zone' to the types of managed entities.

This PR supersedes PR #1181 which can be closed. After group discussion, there was a conflict with an existing `zone` attribute whose caption and usage was 'Network Zone', the same type of zone as in PR #1181. 

Managed Entity extends `_entity` and has a `name` and `uid` so there was no need to add another name and uid (e.g. `zone` (existing) and `zone_uid` (new)). The descriptions have been updated to reflect the proper usage of the object's `name` and `uid` for use with the 'Network Zone' type, as well as when other specific types with their own objects are chosen, for example `user` or `device`, which are entities that have their own `name` and `uid` which should match the `name` and `uid` of the Managed Entity object instance.