### PR TITLE
Added count, start_time, end_time to timespan as optional attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Thankyou! -->
   1. Updated MITRE `attack`, `tactic`, `technique`, `subtechnique` captions, descriptions, references to include MITRE ATLAS. Used standard requirements for `_entity` extended objects. #1355.
   1. Added `name`, `resources`, `uid`, `verdict`, and `verdict_id` to `evidences`. #1337
   1. Added `algorithm` to `analytic` object. #1358
+  1. Added 'count' `start_time` `end_time` to `timespan` object. #1365
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/objects/timespan.json
+++ b/objects/timespan.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "timespan",
   "attributes": {
+    "count": {
+      "description": "The number of items measured in the timespan duration, if any.",
+      "requirement":"optional"
+    },
     "duration": {
       "description": "The duration of the time span in milliseconds.",
       "requirement": "recommended"
@@ -35,6 +39,14 @@
     "duration_years": {
       "description": "The duration of the time span in years.",
       "requirement": "recommended"
+    },
+    "end_time": {
+      "description": "The end time or conclusion of the timespan's duration.",
+      "requirement": "optional"
+    },
+    "start_time": {
+      "description": "The start time or beginning of the timespan's duration.",
+      "requirement": "optional"
     },
     "type": {
       "caption": "Time Span Type",


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:
Added `start_time` `end_time` and `count` as optional attributes to mark the duration of the timespan, and count any items measured in the timespan (if any).

This update followed discussion around baseline and observation windows for the `Anomaly Analysis` set of objects where a `baseline` and `observation` object each have windows or timespans. New attributes of type `timespan` can now be created to specify those windows.