### PR TITLE
Introduce a Mitre Mitigation object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Thankyou! -->
   1. Added `node`, `edge`, `graph` objects. #1343
   1. Added `anomaly`, `anomaly_analysis`, `baseline`, `observation` objects. #1358
   1. Added `trait` object. #1363
+  1. Added `mitigation` object. #1348
   
 ### Improved
 * #### Event Classes
@@ -88,6 +89,7 @@ Thankyou! -->
   1. Added 'count' `start_time` `end_time` to `timespan` object. #1365
   1. Added `traits` to `related_event` object. #1363
   1. Updated `timespan` to include a Time Window `type_id` and `start_time`, `end_time` to the `at_least_one` constraint. #1372
+  1. Added `mitigation` to `attack` object. #1348
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/dictionary.json
+++ b/dictionary.json
@@ -3518,6 +3518,21 @@
       "description": "The Multipurpose Internet Mail Extensions (MIME) type of the file, if applicable.",
       "type": "string_t"
     },
+    "mitigation": {
+      "caption": "MITRE Mitigation",
+      "description": "The Mitigation object describes the MITRE ATT&CK® or ATLAS™ Mitigation ID and/or name that is associated to an attack.",
+      "type": "mitigation",
+      "references": [
+        {
+          "description": "ATT&CK® Matrix",
+          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+        },
+        {
+          "description": "ATLAS™ Matrix",
+          "url": "https://atlas.mitre.org/matrices/ATLAS"
+        }
+      ]
+    },
     "model": {
       "caption": "Model",
       "description": "The model name of an entity. See specific usage.",

--- a/objects/attack.json
+++ b/objects/attack.json
@@ -1,9 +1,12 @@
 {
   "caption": "MITRE ATT&CK® & ATLAS™",
-  "description": "The MITRE ATT&CK® & ATLAS™ object describes the tactic, technique & sub-technique associated to an attack.",
+  "description": "The MITRE ATT&CK® & ATLAS™ object describes the tactic, technique, sub-technique & mitigation associated to an attack.",
   "extends": "object",
   "name": "attack",
   "attributes": {
+    "mitigation": {
+      "requirement": "optional"
+    },
     "sub_technique": {
       "requirement": "recommended"
     },

--- a/objects/mitigation.json
+++ b/objects/mitigation.json
@@ -1,0 +1,28 @@
+{
+  "caption": "MITRE Mitigation",
+  "description": "The MITRE Mitigation object describes the ATT&CK® or ATLAS™ Mitigation ID and/or name that is associated to an attack.",
+  "extends": "_entity",
+  "name": "mitigation",
+  "attributes": {
+    "name": {
+      "description": "The Mitigation name that is associated with the attack technique. For example: <code>Password Policies</code> or <code>Code Signing</code>."
+    },
+    "src_url": {
+      "description": "The versioned permalink of the Mitigation. For example: <code>https://attack.mitre.org/versions/v14/mitigations/M1027</code>.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The Mitigation ID that is associated with the attack technique. For example: <code>M1027</code>, or <code>AML.M0013</code>."
+    }
+  },
+  "references": [
+    {
+      "description": "ATT&CK® Matrix",
+      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+    },
+    {
+      "description": "ATLAS™ Matrix",
+      "url": "https://atlas.mitre.org/matrices/ATLAS"
+    }
+  ]
+}


### PR DESCRIPTION
#### Related Issue: 

https://github.com/ocsf/ocsf-schema/issues/1348

#### Description of changes:

Added a new object for representing Mitre mitigations. Added a new attribute on the Mitre attack object, for specifying the mitigation.

Mitigations are part of both the ATT&CK and ATLAS matrices.