### PR TITLE
issue-1366: Update 'anomaly_analysis' object to have 'analysis_targets'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,14 @@ Thankyou! -->
   1. Added `isp_org` as `string_t`. #1351
   1. Added `ldap` protocol to `auth_protocol_id` enum. [#1359](https://github.com/ocsf/ocsf-schema/pull/1359)
   1. Added `observation_parameter`, `analysis_target`, `analysis_target_type`, `observation_type`, `observed_pattern` as `string_t` and `occurrences` as an array of `occurrence_details`. #1358
+  1. Removed `analysis_target` and `analysis_target_type`. Added `analysis_targets` as an array of type `analysis_target`. #1371
+  
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
   1. Added `node`, `edge`, `graph` objects. #1343
   1. Added `anomaly`, `anomaly_analysis`, `baseline`, `observation` objects. #1358
   1. Added `trait` object. #1363
+  1. Added `analysis_target` object. #1371
   
 ### Improved
 * #### Event Classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,8 @@ Thankyou! -->
   1. Added `is_backed_up`, `is_mobile_account_active`, and `is_shared` as `boolean_t`. #1346
   1. Added `isp_org` as `string_t`. #1351
   1. Added `ldap` protocol to `auth_protocol_id` enum. [#1359](https://github.com/ocsf/ocsf-schema/pull/1359)
-  1. Added `observation_parameter`, `analysis_target`, `analysis_target_type`, `observation_type`, `observed_pattern` as `string_t` and `occurrences` as an array of `occurrence_details`. #1358
-  1. Removed `analysis_target` and `analysis_target_type`. Added `analysis_targets` as an array of type `analysis_target`. #1371
+  1. Added `observation_parameter`, `observation_type`, `observed_pattern` as `string_t` and `occurrences` as an array of `occurrence_details`. #1358
+  1. Added `analysis_targets` as an array of type `analysis_target`. #1371
   
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
@@ -91,6 +91,7 @@ Thankyou! -->
   1. Added 'count' `start_time` `end_time` to `timespan` object. #1365
   1. Added `traits` to `related_event` object. #1363
   1. Updated `timespan` to include a Time Window `type_id` and `start_time`, `end_time` to the `at_least_one` constraint. #1372
+  2. Added `timespan` object to `observation` object. #1371
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351

--- a/dictionary.json
+++ b/dictionary.json
@@ -3,6 +3,11 @@
   "description": "The Attribute Dictionary provides a comprehensive catalog of standardized attributes used across OCSF. It defines each attribute's properties, data types, and relationships. This dictionary serves as the authoritative reference for attribute definitions and ensures consistent usage throughout the schema.",
   "name": "dictionary",
   "attributes": {
+    "timespan": {
+      "caption": "Time Span",
+      "description": "The Time Span object represents different time period durations. If a timespan is fractional, i.e. crosses one period, e.g. a week and 3 days, more than one may be populated since each member is of integral type. In that case <code>type_id</code> if present should be set to <code>Other.</code><P>A timespan may also be defined by its time interval boundaries, <code>start_time</code> and <code>end_time</code>.",
+      "type": "timespan"
+    },
     "observation_parameter": {
       "caption": "Observation Parameter",
       "description": "The name of the parameter being analyzed or monitored. This generally identifies the specific characteristic or property being measured. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -8,15 +8,11 @@
       "description": "The name of the parameter being analyzed or monitored. This generally identifies the specific characteristic or property being measured. See specific usage.",
       "type": "string_t"
     },
-    "analysis_target": {
-      "caption": "Analysis Target", 
-      "description": "The specific dimension, component, or aspect of the system that is the target of the analysis. See specific usage.",
-      "type": "string_t"
-    },
-    "analysis_target_type": {
-      "caption": "Analysis Target Type", 
-      "description": "The type of dimension, component, or aspect of the system that is the target of the analysis. See specific usage.",
-      "type": "string_t"
+    "analysis_targets": {
+      "caption": "Analysis Targets",
+      "description": "The specific dimensions, components, or aspects of the system that are the targets of the analysis. See specific usage.",
+      "type": "analysis_target",
+      "is_array": true
     },
     "observations": {
       "caption": "Observations",

--- a/objects/analysis_target.json
+++ b/objects/analysis_target.json
@@ -1,0 +1,15 @@
+{
+  "caption": "Analysis Target",
+  "description": "The analysis target defines the scope of monitored activities, specifying what entity, system or process is analyzed for activity patterns.",
+  "name": "analysis_target",
+  "attributes": {
+    "name": {
+      "description": "The specific name or identifier of the analysis target, such as the username of a User Account, the name of a Kubernetes Cluster, the identifier of a Network Namespace, or the name of an Application Component.",
+      "requirement": "required"
+    },
+    "type":  {
+      "description": "The category of the analysis target, such as User Account, Kubernetes Cluster, Network Namespace, or Application Component.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/objects/anomaly_analysis.json
+++ b/objects/anomaly_analysis.json
@@ -1,15 +1,11 @@
 {
   "caption": "Anomaly Analysis",
-  "description": "Describes the analysis of activity patterns and anomalies of a target entity to identify potential security threats, performance issues, or other deviations from established baselines. This includes monitoring and analyzing user interactions, API usage, resource utilization, access patterns and other measured indicators.",
+  "description": "Describes the analysis of activity patterns and anomalies of target entities to identify potential security threats, performance issues, or other deviations from established baselines. This includes monitoring and analyzing user interactions, API usage, resource utilization, access patterns and other measured indicators.",
   "name": "anomaly_analysis",
   "attributes": {
-    "analysis_target": {
-      "description": "The specific scope or entity being analyzed for activity patterns. This could be a specific User Account, Kubernetes Cluster, Network namespace, Application component, or any other discrete unit of the system where patterns can be meaningfully analyzed. The target defines the boundary of what activities are being monitored and analyzed.",
+    "analysis_targets": {
+      "description": "The analysis targets define the scope of monitored activities, specifying what entities, systems or processes are analyzed for activity patterns.",
       "requirement": "required"
-    },
-    "analysis_target_type":  {
-      "description": "The type of the analysis target. The target type helps categorize the analysis target.",
-      "requirement": "optional"
     },
     "anomalies": {
       "description": "List of detected activities that significantly deviate from the established baselines. This can include unusual access patterns, unexpected user-agents, abnormal API usage, suspicious traffic spikes, unauthorized access attempts, and other activities that may indicate potential security threats or system issues.",

--- a/objects/observation.json
+++ b/objects/observation.json
@@ -11,6 +11,10 @@
     "count": {
       "description": "Integer representing the total number of times this specific value/event was observed across all occurrences. Helps establish prevalence and patterns.", 
       "requirement": "recommended"
+    },
+    "timespan": {
+      "description": "The time window when the value or event was first observed. It is used to analyze activity patterns, detect trends, or correlate events within a specific timeframe.",
+      "requirement": "recommended"
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: 
#1366 

#### Description of changes:

- create `analysis_target` object
- add `analysis_targets` array of type `analysis_target` to `anomaly_analysis` object
- add `timespan` object to `observation` object

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/fffb3ea0-9732-4bb4-a56e-7aecdd55b726" />
<img width="1453" alt="image" src="https://github.com/user-attachments/assets/3596990e-0fa3-435c-b6a9-6c0208d3baf4" />

<img width="1428" alt="image" src="https://github.com/user-attachments/assets/4cf63e8b-63d8-4abb-b482-7d61464a7458" />

