### PR TITLE
User Management: Add resources, deprecate resource

### DIFF
--- a/events/iam/user_access.json
+++ b/events/iam/user_access.json
@@ -25,6 +25,15 @@
     "resource": {
       "description": "Resource that the privileges give access to.",
       "group": "primary",
+      "requirement": "recommended",
+      "@deprecated": {
+        "message": "Use the <code>resources</code> attribute instead.",
+        "since": "1.5.0"
+      }
+    },
+    "resources": {
+      "description": "Resources that the privileges give access to.",
+      "group": "primary",
       "requirement": "recommended"
     },
     "user": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:

This PR adds the `resources` array to the `User Access Management` class. It is common for this type of log to grant/revoke user privileges for multiple resources. Okta user privilege events are one such example. Thus, the array is added and singleton deprecated, like so:

<img width="842" alt="image" src="https://github.com/user-attachments/assets/491e1cf5-ab8f-4d90-8a5e-a1425939ecf1" />

