### PR TITLE
Add several new observable types (simple cases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,10 +111,10 @@ Thankyou! -->
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
   1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
   1. Updated dictionary descriptions and references of MITRE `attacks`, `tactic`, `technique`, `subtechnique`. #1355
-  1. Added `process_entity.uid` as an Observable type - `type_id: 39`.
-  1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 40` and `type_id: 41`.
-  1. Added 'message_uid' as Observable type - `type_id: 42`.
-  1. Added `reg_value.name` as an Observable type - `type_id: 43`.
+  1. Added `process_entity.uid` as an Observable type - `type_id: 39`. #1380
+  1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 40` and `type_id: 41`. #1380
+  1. Added `message_uid` as Observable type - `type_id: 42`. #1380
+  1. Added `reg_value.name` as an Observable type - `type_id: 43`. #1380
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,10 @@ Thankyou! -->
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343
   1. Updated description of `hw_info.uuid` to clarify usage especially in presence of new `device.udid` field. #1354
   1. Updated dictionary descriptions and references of MITRE `attacks`, `tactic`, `technique`, `subtechnique`. #1355
+  1. Added `process_entity.uid` as an Observable type - `type_id: 39`.
+  1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 40` and `type_id: 41`.
+  1. Added 'message_uid' as Observable type - `type_id: 42`.
+  1. Added `reg_value.name` as an Observable type - `type_id: 43`.
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -3511,7 +3511,8 @@
           "description": "RFC 5322",
           "url": "https://www.rfc-editor.org/rfc/rfc5322"
         }
-      ]
+      ],
+      "observable": 42
     },
     "meets_criteria": {
       "caption": "Meets Criteria",

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -21,7 +21,8 @@
     },
     "name": {
       "description": "The name of the registry value.",
-      "requirement": "required"
+      "requirement": "required",
+      "observable": 43
     },
     "path": {
       "description": "The full path to the registry key, where the value is located.",

--- a/objects/email.json
+++ b/objects/email.json
@@ -80,7 +80,8 @@
           "url": "https://www.rfc-editor.org/rfc/rfc5322"
         }
       ],
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 40
     },
     "to": {
       "requirement": "recommended"
@@ -91,7 +92,8 @@
     "uid": {
       "caption": "Email Thread UID",
       "description": "The unique identifier of the email thread.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 41
     },
     "urls": {
       "description": "The URLs embedded in the email.",

--- a/objects/process_entity.json
+++ b/objects/process_entity.json
@@ -23,7 +23,8 @@
       "requirement": "recommended"
     },
     "uid": {
-      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process."
+      "description": "A unique identifier for this process assigned by the producer (tool).  Facilitates correlation of a process event with other events for that process.",
+      "observable": 39
     }
   },
   "constraints": {


### PR DESCRIPTION
This breaks-out simple cases from the https://github.com/ocsf/ocsf-schema/pull/1326

#### Related Issue: N/A

#### Description of changes:

We are populating the observables with values which are notable for correlation or display to the users. There are several values, which we think make good observables, but are not marked as such. This PR tries to add them.

These are the details:

  1. Added `process_entity.uid` as an Observable type - `type_id: 39`.
  1. Added `email.subject` and `email.uid` as an Observable types - `type_id: 40` and `type_id: 41`.
  1. Added 'message_uid' as Observable type - `type_id: 42`.
  1. Added `reg_value.name` as an Observable type - `type_id: 43`.

I have updated CHANGELOG.md with the same granularity of the information it already uses, but it's not a "single-line" description.
