### PR TITLE
Add new observables (type change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ Thankyou! -->
   1. Added `reg_value.name` as an Observable type - `type_id: 43`. #1380
   1. Added `advisory.uid` as Observable type `type_id: 44`. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
   1. Updated `resource_details.uid`, `web_resource.uid`, and `win_resource.uid` to be observable `type_id: 10` #1394
+  1. Added `file_path_t` as an Observable type - `type_id: 45` and marked fields as this type #1381
+     - `lineage` dictionary attribute
+     - `affected_package.path` object attribute
+     - `file.path` object attribute
+     - `image.path` object attribute
+     - `kernel.path` object attribute
+     - `malware.path` object attribute
+     - `process_entity.path` object attribute
+  1. Added `extensions/windows/reg_key_path_t` as an Observable type - `type_id: 46` and marked fields as this type #1381
+     - `reg_key.path` object attribute
+     - `reg_value.path` object attribute 
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -3361,7 +3361,7 @@
     "lineage": {
       "caption": "Lineage",
       "description": "The lineage of the process, represented by a list of paths for each ancestor process. For example: <code>['/usr/sbin/sshd', '/usr/bin/bash', '/usr/bin/whoami']</code>.",
-      "type": "string_t",
+      "type": "file_path_t",
       "is_array": true
     },
     "load_balancer": {
@@ -6118,6 +6118,13 @@
         "observable": 7,
         "caption": "File Name",
         "description": "File name. For example:<br><code>text-file.txt</code>.",
+        "type": "string_t",
+        "type_name": "String"
+      },
+      "file_path_t": {
+        "observable": 45,
+        "caption": "File Path",
+        "description": "The full path to the file. For example: For example:<br><code>c:\\windows\\system32\\svchost.exe</code>.",
         "type": "string_t",
         "type_name": "String"
       },

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -198,5 +198,18 @@
       "description": "The Windows service.",
       "type": "win_service"
     }
+  },
+  "types": {
+    "caption": "Data Types",
+    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
+    "attributes": {
+      "reg_key_path_t": {
+        "observable": 46,
+        "caption": "Registry Key Path",
+        "description": "Full path of registry key.",
+        "type": "string_t",
+        "type_name": "String"
+      }
+    }
   }
 }

--- a/extensions/windows/objects/registry_key.json
+++ b/extensions/windows/objects/registry_key.json
@@ -15,7 +15,8 @@
     "path": {
       "caption": "Path",
       "description": "The full path to the registry key.",
-      "requirement": "required"
+      "requirement": "required",
+      "type": "reg_key_path_t"
     },
     "security_descriptor": {
       "caption": "Security Descriptor",

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -26,7 +26,8 @@
     },
     "path": {
       "description": "The full path to the registry key, where the value is located.",
-      "requirement": "required"
+      "requirement": "required",
+      "type": "reg_key_path_t"
     },
     "type": {
       "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a>.",

--- a/objects/affected_package.json
+++ b/objects/affected_package.json
@@ -9,7 +9,8 @@
     },
     "path": {
       "description": "The installation path of the affected package.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "remediation": {
       "requirement": "optional"

--- a/objects/file.json
+++ b/objects/file.json
@@ -100,7 +100,8 @@
     },
     "path": {
       "description": "The full path to the file. For example: <code>c:\\windows\\system32\\svchost.exe</code>.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "type": "file_path_t"
     },
     "product": {
       "description": "The product that created or installed the file.",

--- a/objects/image.json
+++ b/objects/image.json
@@ -13,7 +13,8 @@
     },
     "path": {
       "description": "The full path to the image file.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "tag": {
       "requirement": "optional"

--- a/objects/kernel.json
+++ b/objects/kernel.json
@@ -13,7 +13,8 @@
     },
     "path": {
       "description": "The full path of the kernel resource.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "type": "file_path_t"
     },
     "system_call": {
       "requirement": "optional"

--- a/objects/malware.json
+++ b/objects/malware.json
@@ -104,7 +104,8 @@
         "since": "1.5.0"
       },
       "description": "The filesystem path of the malware that was observed.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "type": "file_path_t"
     },
     "provider": {
       "description": "The name or identifier of the security solution or service that provided the malware detection information.",


### PR DESCRIPTION
This breaks-out cases with type-change from the https://github.com/ocsf/ocsf-schema/pull/1326 - please see the discussion there for the concerns.

#### Related Issue: N/A

#### Description of changes:

We are populating the observables with values which are notable for correlation or display to the users. There are several values, which we think make good observables, but are not marked as such. However, these fields already use overly generic `path` dictionary attribute. To selectively mark some of them observables, this PR first introduces more fine grained types for some `path` attributes.

These are the details:

  1. Added `file_path_t` as an Observable type - `type_id: 44` and marked fields as this type
    - `lineage` dictionary attribute
    - `affected_package.path` object attribute
    - `file.path` object attribute
    - `image.path` object attribute
    - `kernel.path` object attribute
    - `malware.path` object attribute
    - `process_entity.path` object attribute
  1. Added `extensions/windows/reg_key_path_t` as an Observable type - `type_id: 45` and marked fields as this type
    - `reg_key.path` object attribute
    - `reg_value.path` object attribute

I have updated CHANGELOG.md with the same granularity of the information it already uses.

##### Note On Compatibility

There is a failing compatibility validator, as I changed some fields from `string_t` to the new `file_path_t` and `reg_key_path_t` - as this seem to be the only way to mark several different fields as same observable. Since both old and new types are strings (the new one just adds semantics) I don't see how this could break type compatibility (e.g. in generated classes). But I am happy to learn about any concerns and also whether there is a better (more compatible) way to mark multiple fields with the same observable type.