### PR TITLE
Bumping default version of backwards compatibility validator

### DIFF
--- a/.github/workflows/validate-compatibility.yml
+++ b/.github/workflows/validate-compatibility.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.11'
 
     - name: Install validator
-      run: python -m pip install "ocsf-lib>=${{ vars.COMPATIBILITY_VALIDATOR_VERSION || '0.8,<0.9' }}"
+      run: python -m pip install "ocsf-lib>=${{ vars.COMPATIBILITY_VALIDATOR_VERSION || '0.10.0' }}"
 
     - name: Run validator
       shell: bash


### PR DESCRIPTION
This bumps the default version of the backwards compatibility version to `>=0.10.0`.