### PR TITLE
Change _resource.uid to have observable type 10 (Resource UID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ Thankyou! -->
   1. Added `message_uid` as Observable type - `type_id: 42`. #1380
   1. Added `reg_value.name` as an Observable type - `type_id: 43`. #1380
   1. Added `advisory.uid` as Observable type `type_id: 44`. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
+  1. Updated `resource_details.uid`, `web_resource.uid`, and `win_resource.uid` to be observable `type_id: 10` #1394
 
 ## [v1.4.0] - January 31st, 2025
 

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -27,7 +27,8 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "The unique identifier of the resource."
+      "description": "The unique identifier of the resource.",
+      "type": "resource_uid_t"
     }
   },
   "profiles": [


### PR DESCRIPTION
#### Description of changes:

Change `resource_details.uid`, `web_resource.uid` and `win_resource.uid` to have observable type 10 ("Resource UID").

<img width="565" alt="Screenshot 2025-04-09 at 5 51 46 PM" src="https://github.com/user-attachments/assets/bdcc797a-4205-42c3-b133-8df80e91de18" />
