### PR TITLE
fix D3FEND typos

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -1321,7 +1321,7 @@
     },
     "countermeasures": {
       "caption": "Countermeasures",
-      "description": "The MITRE DEFEND™ Matrix Countermeasures associated with a remediation.",
+      "description": "The MITRE D3FEND™ Matrix Countermeasures associated with a remediation.",
       "type": "d3fend",
       "is_array": true
     },
@@ -1483,7 +1483,7 @@
       }
     },
     "d3f_tactic": {
-      "caption": "MITRE DEFEND™ Tactic",
+      "caption": "MITRE D3FEND™ Tactic",
       "description": "The D3FEND Tactic object describes the defensive tactic name associated with a countermeasure.",
       "references": [
         {
@@ -1494,7 +1494,7 @@
       "type": "d3f_tactic"
     },
     "d3f_technique": {
-      "caption": "MITRE DEFEND™ Technique",
+      "caption": "MITRE D3FEND™ Technique",
       "description": "The D3FEND Technique object describes the defensive technique ID and/or name associated with a countermeasure.",
       "references": [
         {


### PR DESCRIPTION
Thanks for fixing all the mistakes in the attributes' names for D3FEND. I found a few extra typos in the descriptions of some of those values. I did a search for the whole repo and I believe this is the end of the mitre typos.
