### PR TITLE
Add countermeasures to the MITRE mitigation object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,7 @@ Thankyou! -->
   1. Added `category`, `dependency_chain`, `exploit_ref_url`, `exploit_requirement`, and `exploit_type` to `vulnerability` object. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
   1. Added `status`, `status_id`, `status_details` to `ticket` object; `uid_alt`, `created_time` to `_resource` object; `traits` to `finding_info` object. #1402
   1. Added `modified_time` to `_resource` object; `zone` to `resource_details` object. #1403
+  1. Added `countermeasures` to `mitigation` object. #1348
 * #### Profiles
   1. Added `malware_scan_info` to `security_control` profile. #1373
   1. Added `campaign`, `category`, `created_time`, `creator`, `desc`, `expiration_time`, `external_id`, `labels`, `malware`, `modified_time`, `name`, `detection_pattern`, `detection_pattern_type`, `detection_pattern_type_id`, `intrusion_sets`, `risk_score`, `references`, `uploaded_time`, `severity`, `uid` and `threat_actor` to `osint` object. #1310

--- a/objects/mitigation.json
+++ b/objects/mitigation.json
@@ -5,7 +5,7 @@
   "name": "mitigation",
   "attributes": {
     "name": {
-      "description": "The Mitigation name that is associated with the attack technique. For example: <code>Password Policies</code> or <code>Code Signing</code>."
+      "description": "The Mitigation name that is associated with the attack technique. For example: <code>Password Policies</code>, or <code>Code Signing</code>."
     },
     "src_url": {
       "description": "The versioned permalink of the Mitigation. For example: <code>https://attack.mitre.org/versions/v14/mitigations/M1027</code>.",
@@ -13,6 +13,10 @@
     },
     "uid": {
       "description": "The Mitigation ID that is associated with the attack technique. For example: <code>M1027</code>, or <code>AML.M0013</code>."
+    },
+    "countermeasures": {
+      "description": "The D3FEND countermeasures that are associated with the attack technique. For example: ATT&CK Technique <code>T1003</code> is addressed by Mitigation <code>M1027</code>, and D3FEND Technique <code>D3-OTP</code>.",
+      "requirement": "optional"
     }
   },
   "references": [
@@ -23,6 +27,10 @@
     {
       "description": "ATLAS™ Matrix",
       "url": "https://atlas.mitre.org/matrices/ATLAS"
+    },
+    {
+      "description": "ATT&CK® Mitigation to D3FEND™ Technique Mappings",
+      "url": "https://d3fend.mitre.org/mappings/attack-mitigations/"
     }
   ]
 }


### PR DESCRIPTION
#### Related Issue: 

https://github.com/ocsf/ocsf-schema/issues/1348

#### Description of changes:

Added a countermeasures attribute to the mitigations object. The new attribute will capture 0 or more D3FEND techniques or tactics that relate to the mitigation.