### PR TITLE
Minor updates to ticket, _resource & finding_info objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Thankyou! -->
   1. Added `exploit_ref_url`, `license_url`, `package_manager_url`, and `uri` as `url_t`. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
   1. Added `transformation_info_list` #1392
   1. Added `authentication_token` as `authentication_token`, `kerberos_flags` as `string_t` and `is_renewable` as `boolean_t`. [#1391](https://github.com/ocsf/ocsf-schema/pull/1391)
+  1. Added `tickets` as an array of `ticket` objects. #1402
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
   1. Added `node`, `edge`, `graph` objects. #1343
@@ -124,14 +125,17 @@ Thankyou! -->
   1. Added `license_url`, `package_manager`, `package_manager_url`, `src_url`, and `uid` to `package` object. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
   1. Added `type`, `type_id`, `uid`, and `version` to `sbom` object. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
   1. Added `category`, `dependency_chain`, `exploit_ref_url`, `exploit_requirement`, and `exploit_type` to `vulnerability` object. [#1357](https://github.com/ocsf/ocsf-schema/pull/1357)
+  1. Added `status`, `status_id`, `status_details` to `ticket` object; `uid_alt`, `created_time` to `_resource` object; `traits` to `finding_info` object. #1402
 * #### Profiles
   1. Added `malware_scan_info` to `security_control` profile. #1373
   1. Added `campaign`, `category`, `created_time`, `creator`, `desc`, `expiration_time`, `external_id`, `labels`, `malware`, `modified_time`, `name`, `detection_pattern`, `detection_pattern_type`, `detection_pattern_type_id`, `intrusion_sets`, `risk_score`, `references`, `uploaded_time`, `severity`, `uid` and `threat_actor` to `osint` object. #1310
+  1. Added `tickets` to `incident` profile. #1402
 
 ### Deprecated
   1. Deprecated usage of `isp` attribute in the `location` object. #1351
   1. Deprecated usage of `occurrence_details` in favor of `occurrences` in `discovery_details` object. #1358
   1. Deprecated usage of `resource` in favor of `resources` in the `user_access` class. #1374
+  1. Deprecated usage of `ticket` in favor of `tickets` in `incident` profile and `incident_finding` event class. #1402
 
 ### Misc
   1. Updated description of `config_state` to reflect the addition of the `assessments` object. #1343

--- a/dictionary.json
+++ b/dictionary.json
@@ -5623,7 +5623,7 @@
     },
     "tickets": {
       "caption": "Tickets",
-      "description": "The linked ticket(s) in the ticketing system.",
+      "description": "The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status etc.",
       "type": "ticket",
       "is_array": true
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -5621,6 +5621,12 @@
       "description": "The linked ticket in the ticketing system.",
       "type": "ticket"
     },
+    "tickets": {
+      "caption": "Tickets",
+      "description": "The linked ticket(s) in the ticketing system.",
+      "type": "ticket",
+      "is_array": true
+    },
     "tid": {
       "caption": "Thread ID",
       "description": "The Identifier of the thread associated with the event, as returned by the operating system.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -5623,7 +5623,7 @@
     },
     "tickets": {
       "caption": "Tickets",
-      "description": "The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status etc.",
+      "description": "The associated ticket(s) in the ticketing system. Each ticket contains details like ticket ID, status, etc.",
       "type": "ticket",
       "is_array": true
     },

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -141,6 +141,14 @@
       }
     },
     "ticket": {
+      "@deprecated": {
+          "message": "Use <code>tickets</code> instead.",
+          "since": "1.5.0"
+      },
+      "group": "context",
+      "requirement": "optional"
+    },
+    "tickets": {
       "group": "context",
       "requirement": "optional"
     },

--- a/events/network/dhcp_activity.json
+++ b/events/network/dhcp_activity.json
@@ -55,6 +55,7 @@
       "requirement": "recommended"
     },
     "is_renewal": {
+      "description": "Indicates whether this is a lease/session renewal event.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -7,6 +7,10 @@
     "$include": [
       "profiles/data_classification.json"
     ],
+    "created_time": {
+      "description": "The time when the resource was created.",
+      "type": "timestamp"
+    },
     "data": {
       "description": "Additional data describing the resource.",
       "requirement": "optional"

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -9,7 +9,7 @@
     ],
     "created_time": {
       "description": "The time when the resource was created.",
-      "type": "timestamp"
+      "requirement": "optional"
     },
     "data": {
       "description": "Additional data describing the resource.",

--- a/objects/_resource.json
+++ b/objects/_resource.json
@@ -33,6 +33,11 @@
     "uid": {
       "description": "The unique identifier of the resource.",
       "type": "resource_uid_t"
+    },
+    "uid_alt": {
+      "description": "The alternative unique identifier of the resource.",
+      "requirement": "optional",
+      "type": "resource_uid_t"
     }
   },
   "profiles": [

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -67,6 +67,10 @@
       "description": "A title or a brief phrase summarizing the reported finding.",
       "requirement": "recommended"
     },
+    "traits": {
+      "description": "The list of key traits or characteristics extracted from the finding.",
+      "requirement": "optional"
+    },
     "types": {
       "description": "One or more types of the reported finding.",
       "requirement": "optional"

--- a/objects/ticket.json
+++ b/objects/ticket.json
@@ -4,14 +4,6 @@
   "extends": "object",
   "name": "ticket",
   "attributes": {
-    "connector": {
-      "description": "",
-      "requirement": "optional"
-    },
-    "connector_uid": {
-      "description": "",
-      "requirement": "optional"
-    },
     "src_url": {
       "description": "The url of a ticket in the ticket system.",
       "requirement": "recommended"
@@ -50,8 +42,8 @@
           "description": "The ticket has been completed and closed."
         },
         "7": {
-          "caption": "Cancelled",
-          "description": "The ticket has been cancelled and will not be processed."
+          "caption": "Canceled",
+          "description": "The ticket has been canceled and will not be processed."
         },
         "8": {
           "caption": "Reopened",
@@ -93,7 +85,7 @@
       "requirement": "optional"
     },
     "uid": {
-      "description": "Unique ticket identifier like ticket id.",
+      "description": "Unique identifier of the ticket.",
       "requirement": "recommended"
     }
   },

--- a/objects/ticket.json
+++ b/objects/ticket.json
@@ -27,11 +27,11 @@
       "enum": {
         "1": {
           "caption": "New",
-          "description": "A newly created ticket that has not been processed yet."
+          "description": "The ticket is new and yet to be reviewed."
         },
         "2": {
           "caption": "In Progress",
-          "description": "Ticket is actively being worked on."
+          "description": "The ticket is actively being worked on."
         },
         "3": {
           "caption": "Notified", 
@@ -43,7 +43,7 @@
         },
         "5": {
           "caption": "Resolved",
-          "description": "The ticket issue has been resolved but pending confirmation."
+          "description": "The ticket issue has been resolved and a solution has been implemented, but awaiting final confirmation or verification from the requestor."
         },
         "6": {
           "caption": "Closed",
@@ -55,7 +55,7 @@
         },
         "8": {
           "caption": "Reopened",
-          "description": "A previously closed ticket that has been reopened."
+          "description": "The ticket was previously closed, but has been reopened."
         }
       },
       "requirement": "optional"

--- a/objects/ticket.json
+++ b/objects/ticket.json
@@ -1,6 +1,6 @@
 {
   "caption": "Ticket",
-  "description": "The Ticket object represents ticket in the customer's IT Service Management (ITSM) systems like ServiceNow, Jira etc.",
+  "description": "The Ticket object represents ticket in the customer's IT Service Management (ITSM) systems like ServiceNow, Jira, etc.",
   "extends": "object",
   "name": "ticket",
   "attributes": {
@@ -35,7 +35,7 @@
         },
         "5": {
           "caption": "Resolved",
-          "description": "The ticket issue has been resolved and a solution has been implemented, but awaiting final confirmation or verification from the requestor."
+          "description": "The ticket is resolved and a solution is implemented, pending confirmation or verification from the requestor."
         },
         "6": {
           "caption": "Closed",

--- a/objects/ticket.json
+++ b/objects/ticket.json
@@ -1,12 +1,68 @@
 {
   "caption": "Ticket",
-  "description": "The Ticket object represents ticket in the customer's systems like Salesforce, jira etc.",
+  "description": "The Ticket object represents ticket in the customer's IT Service Management (ITSM) systems like ServiceNow, Jira etc.",
   "extends": "object",
   "name": "ticket",
   "attributes": {
+    "connector": {
+      "description": "",
+      "requirement": "optional"
+    },
+    "connector_uid": {
+      "description": "",
+      "requirement": "optional"
+    },
     "src_url": {
       "description": "The url of a ticket in the ticket system.",
       "requirement": "recommended"
+    },
+    "status": {
+      "caption": "Ticket Status",
+      "description": "The status of the ticket normalized to the caption of the <code>status_id</code> value. In the case of <code>99</code>, this value should as defined by the source.",
+      "requirement": "optional"
+    },
+    "status_id": {
+      "caption": "Ticket Status ID",
+      "description": "The normalized identifier for the ticket status.",
+      "enum": {
+        "1": {
+          "caption": "New",
+          "description": "A newly created ticket that has not been processed yet."
+        },
+        "2": {
+          "caption": "In Progress",
+          "description": "Ticket is actively being worked on."
+        },
+        "3": {
+          "caption": "Notified", 
+          "description": "Relevant parties have been notified about the ticket."
+        },
+        "4": {
+          "caption": "On Hold",
+          "description": "Work on the ticket is temporarily suspended."
+        },
+        "5": {
+          "caption": "Resolved",
+          "description": "The ticket issue has been resolved but pending confirmation."
+        },
+        "6": {
+          "caption": "Closed",
+          "description": "The ticket has been completed and closed."
+        },
+        "7": {
+          "caption": "Cancelled",
+          "description": "The ticket has been cancelled and will not be processed."
+        },
+        "8": {
+          "caption": "Reopened",
+          "description": "A previously closed ticket that has been reopened."
+        }
+      },
+      "requirement": "optional"
+    },
+    "status_details": {
+      "description": "A list of contextual descriptions of the <code>status, status_id</code> values.",
+      "requirement": "optional"
     },
     "title": {
       "description": "The title of the ticket.",

--- a/profiles/incident.json
+++ b/profiles/incident.json
@@ -45,6 +45,14 @@
             "requirement": "recommended"
         },
         "ticket": {
+            "@deprecated": {
+                "message": "Use <code>tickets</code> instead.",
+                "since": "1.5.0"
+            },
+            "group": "context",
+            "requirement": "optional"
+        },
+        "tickets": {
             "group": "context",
             "requirement": "optional"
         },


### PR DESCRIPTION
#### Description of changes:
1. Adding `tickets`, an array of `ticket` objects to the framework.
2. Deprecating `ticket` in favor of `tickets` in `incident` profile & `incident_finding` class. - Generally, a single finding can have more than 1 tickets associated to it, current structure doesn't allow its representation.
3. Adding `status` trio to the `ticket` object - Useful to indicate ticket status, the status_id enum is built by consolidating values from ServiceNow and Jira.
4. Adding `traits` to the `finding_info` object - Useful to represent key traits/characteristics of the finding, similar to related_events.traits
5. Adding `uid_alt`, `created_time` to `_resource` object.
6. Unrelated -
    1. Fixing server warning regarding usage of generic description for `is_renewal`
