### PR TITLE
Add is_read to Email object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Thankyou! -->
   1. Added `transformation_info_list` #1392
   1. Added `authentication_token` as `authentication_token`, `kerberos_flags` as `string_t` and `is_renewable` as `boolean_t`. [#1391](https://github.com/ocsf/ocsf-schema/pull/1391)
   1. Added `tickets` as an array of `ticket` objects. #1402
+  1. Added `is_read` as `boolean_t`. #1406
 * #### Objects
   1. Added `assessment` object to capture evaluations/assessments of configurations/signals. #1343
   1. Added `node`, `edge`, `graph` objects. #1343
@@ -128,6 +129,7 @@ Thankyou! -->
   1. Added `status`, `status_id`, `status_details` to `ticket` object; `uid_alt`, `created_time` to `_resource` object; `traits` to `finding_info` object. #1402
   1. Added `modified_time` to `_resource` object; `zone` to `resource_details` object. #1403
   1. Added `countermeasures` to `mitigation` object. #1348
+  1. Added `is_read` to `email` object. #1406
 * #### Profiles
   1. Added `malware_scan_info` to `security_control` profile. #1373
   1. Added `campaign`, `category`, `created_time`, `creator`, `desc`, `expiration_time`, `external_id`, `labels`, `malware`, `modified_time`, `name`, `detection_pattern`, `detection_pattern_type`, `detection_pattern_type_id`, `intrusion_sets`, `risk_score`, `references`, `uploaded_time`, `severity`, `uid` and `threat_actor` to `osint` object. #1310

--- a/dictionary.json
+++ b/dictionary.json
@@ -3099,6 +3099,11 @@
       "description": "Determination of the public accessibility. See specific usage.",
       "type": "boolean_t"
     },
+    "is_read": {
+      "caption": "Read",
+      "description": "The indication of whether the email has been read.",
+      "type": "boolean_t"
+    },
     "is_remote": {
       "caption": "Remote",
       "description": "The indication of whether the session is remote.",

--- a/objects/email.json
+++ b/objects/email.json
@@ -37,6 +37,9 @@
     "http_headers": {
       "requirement": "optional"
     },
+    "is_read": {      
+      "requirement": "optional"
+    },
     "message_uid": {
       "requirement": "recommended"
     },


### PR DESCRIPTION
Boolean attribute created for is_read.
Attribute added to the email object.

#### Related Issue: 
#1405 

#### Description of changes:
By introducing the `is_read` field, the schema now allows for the representation of an email's read status.

