### PR TITLE
Discovery Class info rename

### DIFF
--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -1,6 +1,6 @@
 {
   "uid": 19,
-  "caption": "Device Config State Change",
+  "caption": "Device Config State Change Info",
   "description": "Device Config State Change events report state changes that impact the security of the device.",
   "extends": "discovery",
   "name": "device_config_state_change",

--- a/events/discovery/device_config_state_change.json
+++ b/events/discovery/device_config_state_change.json
@@ -1,7 +1,7 @@
 {
   "uid": 19,
   "caption": "Device Config State Change Info",
-  "description": "Device Config State Change events report state changes that impact the security of the device.",
+  "description": "Device Config State Change Info events report state changes that impact the security of the device.",
   "extends": "discovery",
   "name": "device_config_state_change",
   "attributes": {

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -1,6 +1,6 @@
 {
   "uid": 4,
-  "caption": "Operating System Patch State",
+  "caption": "Operating System Patch State Info",
   "description": "Operating System Patch State reports the installation of an OS patch to a device and any associated knowledgebase articles.",
   "extends": "discovery",
   "name": "patch_state",

--- a/events/discovery/patch_state.json
+++ b/events/discovery/patch_state.json
@@ -1,7 +1,7 @@
 {
   "uid": 4,
   "caption": "Operating System Patch State Info",
-  "description": "Operating System Patch State reports the installation of an OS patch to a device and any associated knowledgebase articles.",
+  "description": "Operating System Patch State Info reports the installation of an OS patch to a device and any associated knowledgebase articles.",
   "extends": "discovery",
   "name": "patch_state",
   "attributes": {


### PR DESCRIPTION
#### Description of changes:
1. Add the term `info` to `Device Config State Change` and `Operating System Patch State` descriptions and captions to align with the other classes within the Discovery Category.
2. A number of soon to be deprecated classes within Discovery are left unmodified. 

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
Note yet!