### PR TITLE
RDP Activity: Add new activities, enhance descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Thankyou! -->
 
 ### Improved
 
+* #### Event Classes
+  1. Added `Disconnect` and `Reconnect` activities in the `RDP Activity` class. [#1415](https://github.com/ocsf/ocsf-schema/pull/1415)
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)
 

--- a/events/network/rdp_activity.json
+++ b/events/network/rdp_activity.json
@@ -39,7 +39,13 @@
           "caption": "Reconnect",
           "description": "An RDP connection reconnect."
         }
-      }
+      },
+      "references": [
+        {
+          "url": "https://docs.suricata.io/en/latest/output/eve/eve-json-format.html#event-type-rdp",
+          "description": "Suricata Event Type: RDP"
+        }
+      ]
     },
     "capabilities": {
       "group": "context",

--- a/events/network/rdp_activity.json
+++ b/events/network/rdp_activity.json
@@ -30,6 +30,14 @@
         "6": {
           "caption": "Traffic",
           "description": "Network traffic report."
+        },
+        "7": {
+          "caption": "Disconnect",
+          "description": "An RDP connection disconnect."
+        },
+        "8": {
+          "caption": "Reconnect",
+          "description": "An RDP connection reconnect."
         }
       }
     },

--- a/events/network/rdp_activity.json
+++ b/events/network/rdp_activity.json
@@ -1,7 +1,7 @@
 {
   "uid": 5,
   "caption": "RDP Activity",
-  "description": "Remote Desktop Protocol (RDP) Activity events report remote client connections to a server as seen on the network.",
+  "description": "Remote Desktop Protocol (RDP) Activity events report remote client connections, post-authentication, between a client and server as seen on the network.",
   "extends": "network",
   "name": "rdp_activity",
   "attributes": {

--- a/events/network/rdp_activity.json
+++ b/events/network/rdp_activity.json
@@ -1,7 +1,7 @@
 {
   "uid": 5,
   "caption": "RDP Activity",
-  "description": "Remote Desktop Protocol (RDP) Activity events report remote client connections, post-authentication, between a client and server as seen on the network.",
+  "description": "Remote Desktop Protocol (RDP) Activity events report post-authentication remote client connections between clients and servers over the network.",
   "extends": "network",
   "name": "rdp_activity",
   "attributes": {
@@ -53,6 +53,11 @@
     },
     "certificate_chain": {
       "description": "The list of observed certificates in an RDP TLS connection.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "connection_info": {
+      "description": "The remote desktop connection details, either connection-based or connectionless.",
       "group": "primary",
       "requirement": "recommended"
     },


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:

This PR enhances the `RDP Activity` class:

1. Adds two new activities: `Disconnect (7)`, and `Reconnect (8)`
2. Adds [Suricata reference](https://docs.suricata.io/en/latest/output/eve/eve-json-format.html#event-type-rdp) to description.
3. Updates the description of the `RDP Activity` class for better clarity.

<img width="1173" alt="image" src="https://github.com/user-attachments/assets/3e2d7e79-57e7-4631-b449-eeac4c841209" />