### PR TITLE
Improve Application Error event class description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Thankyou! -->
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)
+  1. Improved description of the `Application Error` class. [#1424](https://github.com/ocsf/ocsf-schema/pull/1424)
 
 ## [v1.5.0] - April 28th, 2025
 

--- a/events/application/application_error.json
+++ b/events/application/application_error.json
@@ -1,7 +1,7 @@
 {
   "uid": 8,
   "caption": "Application Error",
-  "description": "Application Error events describe issues with an applications. The error message should be put in the event's <code>message</code> attribute. The <code>metadata.product</code> attribute can be used to capture the originating application information. The <code>host</code> profile can used to include the generating device information. This class is helpful (and originally intended for) applications that generate and/or handle OCSF events. This class can also be used for errors in upstream products and services.",
+  "description": "Application Error events describe issues with an applications. The error message should be put in the event's <code>message</code> attribute. The <code>metadata.product</code> attribute can be used to capture the originating application information. The <code>host</code> profile can used to include the generating device information. This class is helpful for applications that generate or handle OCSF events and can also be used for errors in upstream products and services.",
   "extends": "application",
   "name": "application_error",
   "attributes": {


### PR DESCRIPTION
Remove "originally intended for" wording in Application Error event class description.

#### Related Issue: 
None.

#### Description of changes:
Reword the Application Error event class description, removing the historical intention and tightening up the last part of the description.
