### PR TITLE
Add PATCH method to http activity and http_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ Thankyou! -->
   1. Added `is_read` to `email` object. [#1406](https://github.com/ocsf/ocsf-schema/pull/1406)
   1. Added `cis_controls` to `remediation` object [#1369](https://github.com/ocsf/ocsf-schema/pull/1369)
   1. Added `check` object to `compliance` object [#1369](https://github.com/ocsf/ocsf-schema/pull/1369)
+  1. Added `Patch` as a value of `http_method` in the `http_request` object. [#1427](https://github.com/ocsf/ocsf-schema/pull/1427)
      
 * #### Profiles
   1. Added `malware_scan_info` to `security_control` profile. [#1373](https://github.com/ocsf/ocsf-schema/pull/1373)

--- a/events/network/http_activity.json
+++ b/events/network/http_activity.json
@@ -41,6 +41,10 @@
         "8": {
           "caption": "Trace",
           "description": "The TRACE method performs a message loop-back test along the path to the target resource."
+        },
+        "9": {
+          "caption": "Patch",
+          "description": "The PATCH method applies partial modifications to a resource."
         }
       }
     },

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -50,6 +50,10 @@
         "TRACE": {
           "caption": "Trace",
           "description": "The TRACE method performs a message loop-back test along the path to the target resource."
+        },
+        "PATCH": {
+          "caption": "Patch",
+          "description": "The PATCH method applies partial modifications to a resource."
         }
       },
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: Slack thread [here](https://opencybersecu-lz97379.slack.com/archives/C03C2QPSBPB/p1747330481106649)

#### Description of changes:
This change adds PATCH as an allowed Http method in the Http Activity [4002] class and the http_request object. Screenshots of a local run can be seen below:
<img width="1725" alt="image" src="https://github.com/user-attachments/assets/3a327a88-7967-4143-ac59-3da5f2621705" />
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/cb195681-7573-4020-8508-d79ba6daec5a" />
