### PR TITLE
Added `Service` to `user` `type_id` enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
   1. Added `user` as an attribute to the `RDP Activity` class. [#1419](https://github.com/ocsf/ocsf-schema/pull/1419)
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)
+  1. Added `Service` to `user` `type_id` enum. [#1428](https://github.com/ocsf/ocsf-schema/pull/1428)
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)

--- a/objects/user.json
+++ b/objects/user.json
@@ -86,6 +86,10 @@
           "caption": "System",
           "description": "System account. For example, Windows computer accounts with a trailing dollar sign ($)."
         },
+        "4": {
+          "caption": "Service",
+          "description": "Service account. For example, Windows service account."
+        },
         "99": {
           "caption": "Other"
         }


### PR DESCRIPTION
#### Description of changes:
We need to convey the information that a [Service Account](https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-service-accounts) was used. As there already is a `System` account type in the `user`, it seems fitting to add the Service account to the same enum. 
