### PR TITLE
Add API Token (`token`) Object to API

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -5895,7 +5895,7 @@
     },
     "token": {
       "caption": "Token",
-      "description": "Information about an API (Application Programming Interface) or client token, such as those created or granted by Identity Providers (IdPs) or otherwise.",
+      "description": "The Token object contains the attributes pertaining to an API (Application Programming Interface) or client token (also known as a key). Specific tokens are those created or granted by Identity Providers (IdPs) such as Okta or Microsoft Entra ID Application Registrations. This object can also represent generic API keys created for authentication or authorization in a Software-as-a-Service (SaaS) application.",
       "type": "token"
     },
     "total": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -5893,6 +5893,11 @@
       ],
       "is_array": true
     },
+    "token": {
+      "caption": "Token",
+      "description": "Information about an API (Application Programming Interface) or client token, such as those created or granted by Identity Providers (IdPs) or otherwise.",
+      "type": "token"
+    },
     "total": {
       "caption": "Total",
       "description": "The total number of items. See specific usage.",

--- a/objects/api.json
+++ b/objects/api.json
@@ -23,6 +23,9 @@
       "description": "The information pertaining to the API service.",
       "requirement": "optional"
     },
+    "token": {
+      "requirement": "optional"
+    },
     "version": {
       "description": "The version of the API service.",
       "requirement": "optional"

--- a/objects/authentication_token.json
+++ b/objects/authentication_token.json
@@ -2,7 +2,7 @@
   "caption": "Authentication Token",
   "description": "The Authentication Token object contains the attributes pertaining to an authentication token, ticket, or assertion e.g. Kerberos, OIDC, SAML.",
   "extends": "object",
-  "name": "token",
+  "name": "authentication_token",
   "attributes": {
     "encryption_details": {
       "description": "The encryption details of the authentication token.",

--- a/objects/authentication_token.json
+++ b/objects/authentication_token.json
@@ -2,7 +2,7 @@
   "caption": "Authentication Token",
   "description": "The Authentication Token object contains the attributes pertaining to an authentication token, ticket, or assertion e.g. Kerberos, OIDC, SAML.",
   "extends": "object",
-  "name": "authentication_token",
+  "name": "token",
   "attributes": {
     "created_time": {
       "description": "The time that the authentication token was created.",

--- a/objects/authentication_token.json
+++ b/objects/authentication_token.json
@@ -4,10 +4,6 @@
   "extends": "object",
   "name": "token",
   "attributes": {
-    "created_time": {
-      "description": "The time that the authentication token was created.",
-      "requirement": "recommended"
-    },
     "encryption_details": {
       "description": "The encryption details of the authentication token.",
       "requirement": "recommended"

--- a/objects/token.json
+++ b/objects/token.json
@@ -1,38 +1,31 @@
 {
   "caption": "Token",
-  "description": "The Token object contains the attributes pertaining to an API (Application Programming Interface) or client token, such as those created or granted by Identity Providers (IdPs) such as Okta or Microsoft Entra ID Application Registrations.",
+  "description": "The Token object contains the attributes pertaining to an API (Application Programming Interface) or client token (also known as a key). Specific tokens are those created or granted by Identity Providers (IdPs) such as Okta or Microsoft Entra ID Application Registrations. This object can also represent generic API keys created for authentication or authorization in a Software-as-a-Service (SaaS) application.",
   "extends": "object",
   "name": "token",
   "attributes": {
     "created_time": {
-      "description": "The time that the authentication token was created.",
-      "requirement": "recommended"
-    },
-    "encryption_details": {
-      "description": "The encryption details of the authentication token.",
+      "description": "The time that the token was created.",
       "requirement": "recommended"
     },
     "expiration_time": {
-      "description": "The expiration time of the authentication token.",
+      "description": "The expiration time of the token.",
       "requirement": "optional"
     },
     "is_renewable": {
-      "description": "Indicates whether the authentication token is renewable.",
+      "description": "Indicates whether the token is renewable.",
       "requirement": "optional"
     },
-    "kerberos_flags": {
-      "requirement": "recommended"
-    },
     "type": {
-      "description": "The type of the authentication token.",
+      "description": "The type of the token.",
       "requirement": "recommended"
     },
     "type_id": {
-      "description": "The normalized authentication token type identifier.",
+      "description": "The normalized token type identifier.",
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The Authentication token type is unknown."
+          "description": "The token type is unknown."
         },
         "1": {
           "caption": "Ticket Granting Ticket",

--- a/objects/token.json
+++ b/objects/token.json
@@ -1,0 +1,64 @@
+{
+  "caption": "Token",
+  "description": "The Token object contains the attributes pertaining to an API (Application Programming Interface) or client token, such as those created or granted by Identity Providers (IdPs) such as Okta or Microsoft Entra ID Application Registrations.",
+  "extends": "object",
+  "name": "token",
+  "attributes": {
+    "created_time": {
+      "description": "The time that the authentication token was created.",
+      "requirement": "recommended"
+    },
+    "encryption_details": {
+      "description": "The encryption details of the authentication token.",
+      "requirement": "recommended"
+    },
+    "expiration_time": {
+      "description": "The expiration time of the authentication token.",
+      "requirement": "optional"
+    },
+    "is_renewable": {
+      "description": "Indicates whether the authentication token is renewable.",
+      "requirement": "optional"
+    },
+    "kerberos_flags": {
+      "requirement": "recommended"
+    },
+    "type": {
+      "description": "The type of the authentication token.",
+      "requirement": "recommended"
+    },
+    "type_id": {
+      "description": "The normalized authentication token type identifier.",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The Authentication token type is unknown."
+        },
+        "1": {
+          "caption": "Ticket Granting Ticket",
+          "description": "Ticket Granting Ticket (TGT) for Kerberos."
+        },
+        "2": {
+          "caption": "Service Ticket",
+          "description": "Service Ticket (ST) for Kerberos."
+        },
+        "3": {
+          "caption": "Identity Token",
+          "description": "Identity (ID) Token for OIDC."
+        },
+        "4": {
+          "caption": "Refresh Token",
+          "description": "Refresh Token for OIDC."
+        },
+        "5": {
+          "caption": "SAML Assertion",
+          "description": "Authentication Assertion for SAML."
+        },
+        "99": {
+          "caption": "Other"
+        }
+      },
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/token.json
+++ b/objects/token.json
@@ -16,6 +16,18 @@
       "description": "Indicates whether the token is renewable.",
       "requirement": "optional"
     },
+    "modified_time": {
+      "description": "The last time the token was updated.",
+      "requirement": "optional"
+    },
+    "name": {
+      "description": "The human-friendly name of a token or key, if available, such as the <code>name</code> from the Okta API Token API.",
+      "requirement": "optional"
+    },
+    "tenant_uid": {
+      "description": "The tenant that the token or key belongs to, or the tenant that the token or key is authorized to be used from.",
+      "requirement": "optional"
+    },
     "type": {
       "description": "The type of the token.",
       "requirement": "recommended"
@@ -47,11 +59,27 @@
           "caption": "SAML Assertion",
           "description": "Authentication Assertion for SAML."
         },
+        "6": {
+          "caption": "Client Token",
+          "description": "Client Token for an Entra ID App Registration, or otherwise."
+        },
+        "7": {
+          "caption": "API Token",
+          "description": "A generic API Token or API Key."
+        },
         "99": {
           "caption": "Other"
         }
       },
       "requirement": "recommended"
+    },
+    "uid": {
+      "description": "The unique ID of a token or key, if available, such as the <code>Secret ID</code> of Entra ID Application Registration Client Secrets.",
+      "requirement": "optional"
+    },
+    "zone": {
+      "description": "The network zone that the token or key is authorized to be used from, this corresponds to the <code>network.connection</code> of the Okta API Token API.",
+      "requirement": "optional"
     }
   }
 }


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

Placeholder now until we talk about it on the next meeting.

BLUF: several IDP & IGA tools have the concept of Tokens/Client Tokens/API Tokens/API Keys that can be tracked with an API, not to mention actual API clients made in most SaaS tools for bearer auth/client token authentication. This provides a way to add more details about it to the schema, especially useful for `token` related Okta System Log Events which otherwise would need to use `resource_details.name | uid | type` but still miss out details.

- Creates a new `token` object
- Extends `authentication_token` from `token`
- Adds `token` to `api`
