### PR TITLE
Added Deleted to finding status_id enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Thankyou! -->
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)
   1. Added `Service` to `user` `type_id` enum. [#1428](https://github.com/ocsf/ocsf-schema/pull/1428)
+  1. Added `Deleted` to `finding` `status_id` enum. [#1437](https://github.com/ocsf/ocsf-schema/pull/1437)
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -95,6 +95,10 @@
         "5": {
           "caption": "Archived",
           "description": "The Finding was archived."
+        },
+        "6": {
+          "caption": "Deleted",
+          "description": "The Finding was deleted. For example, it might have been created in error."
         }
       }
     },


### PR DESCRIPTION
#### Description of changes:
We have a few cases when we need to delete findings. For example:

1. The finding was created by misconfigured or buggy producer. When the issues is discovered, the producer needs to inform all services consuming the data that the finding is not valid anymore and should be discarded.
2. A customer was evaluating the product, created some test findings and now wants to start using the product in production. We need to delete the data from POC.