### PR TITLE
Handle Executable and Read-Only files in the File object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3140,6 +3140,11 @@
       "description": "The indication of whether the email has been read.",
       "type": "boolean_t"
     },
+    "is_read-only": {
+      "caption": "Read-Only",
+      "description": "Indicates that an object cannot be modified. See specific usage",
+      "type": "boolean_t"
+    },
     "is_remote": {
       "caption": "Remote",
       "description": "The indication of whether the session is remote.",

--- a/objects/file.json
+++ b/objects/file.json
@@ -73,6 +73,10 @@
       "profile": "cloud",
       "requirement": "optional"
     },
+    "is_read-only": {
+      "description": "Indicates that the file cannot be modified.",
+      "requirement": "optional"
+    },
     "is_system": {
       "requirement": "optional"
     },
@@ -130,7 +134,7 @@
       "requirement": "optional"
     },
     "type_id": {
-      "description": "The file type ID.",
+      "description": "The file type ID. Note the distinction between a <code>Regular File</code> and an <code>Executable File</code>. If the distinction is not known, or not indicated by the log, use <code>Regular File</code>.",
       "enum": {
         "0": {
           "caption": "Unknown"
@@ -155,6 +159,9 @@
         },
         "7": {
           "caption": "Symbolic Link"
+        },
+        "8": {
+          "caption": "Executable File"
         },
         "99": {
           "caption": "Other"


### PR DESCRIPTION
#### Related Issue: #1418

#### Description of changes:
Added an `Executable File` enum value to the File object type_id enums.
Added an `is_read-only` attribute to the dictionary and redefined it specifically in the `File` object.

After discussion, we felt that treating executable files as distinct from regular files was warranted, vs. relying on the attributes of a file by the file system. The rationale I used was that the actual construction of the executable file is special, similar to a Symbolic Link being special, or a Folder being special - as they are distinguished currently in the enum list.