### PR TITLE
Minor refactoring of databucket object 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,9 @@ Thankyou! -->
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)
   1. Improved description of the `Application Error` class. [#1424](https://github.com/ocsf/ocsf-schema/pull/1424)
 
+### Deprecated
+  1. Deprecated usage of `group` attribute in favor of `groups` in the `databucket` object. [#1344]
+
 ## [v1.5.0] - April 28th, 2025
 
 ### Added

--- a/objects/databucket.json
+++ b/objects/databucket.json
@@ -19,7 +19,7 @@
       "requirement": "optional"
     },
     "criticality": {
-      "description": "The criticality of the resource as defined by the event source.",
+      "description": "The criticality of the databucket as defined by the event source.",
       "requirement": "optional"
     },
     "desc": {
@@ -37,14 +37,18 @@
     },
     "group": {
       "description": "The name of the related resource group.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>groups</code> attribute instead.",
+        "since": "1.6.0"
+      }
     },
     "groups": {
       "description": "The group names to which the databucket belongs.",
       "requirement": "optional"
     },
     "hostname": {
-      "description": "The fully qualified name of the resource.",
+      "description": "The fully qualified hostname of the databucket.",
       "requirement": "recommended"
     },
     "ip": {
@@ -74,16 +78,16 @@
       "requirement": "optional"
     },
     "owner": {
-      "description": "The identity of the service or user account that owns the resource.",
+      "description": "The identity of the service or user account that owns the databucket.",
       "requirement": "recommended"
     },
     "region": {
-      "description": "The cloud region of the resource.",
+      "description": "The cloud region of the databucket.",
       "profile": "cloud",
       "requirement": "optional"
     },
     "resource_relationship": {
-      "description": "A graph representation showing how this resource relates to and interacts with other entities in the environment. This can include parent/child relationships, dependencies, or other connections.",
+      "description": "A graph representation showing how this databucket relates to and interacts with other entities in the environment. This can include parent/child relationships, dependencies, or other connections.",
       "requirement": "optional"
     },
     "size": {
@@ -124,7 +128,7 @@
     },
     "zone": {
       "caption": "Cloud Availability Zone",
-      "description": "The specific availability zone within a cloud region where the resource is located.",
+      "description": "The specific availability zone within a cloud region where the databucket is located.",
       "profile": "cloud",
       "requirement": "optional"
     }

--- a/objects/databucket.json
+++ b/objects/databucket.json
@@ -1,7 +1,7 @@
 {
   "caption": "Databucket",
   "description": "The databucket object is a basic container that holds data, typically organized through the use of data partitions.",
-  "extends": "_entity",
+  "extends": "_resource",
   "name": "databucket",
   "attributes": {
     "$include": [

--- a/objects/databucket.json
+++ b/objects/databucket.json
@@ -1,14 +1,25 @@
 {
   "caption": "Databucket",
   "description": "The databucket object is a basic container that holds data, typically organized through the use of data partitions.",
-  "extends": "resource_details",
+  "extends": "_entity",
   "name": "databucket",
   "attributes": {
     "$include": [
       "profiles/data_classification.json"
     ],
+    "agent_list": {
+      "requirement": "optional"
+    },
+    "cloud_partition": {
+      "profile": "cloud",
+      "requirement": "optional"
+    },
     "created_time": {
       "description": "The time when the databucket was known to have been created.",
+      "requirement": "optional"
+    },
+    "criticality": {
+      "description": "The criticality of the resource as defined by the event source.",
       "requirement": "optional"
     },
     "desc": {
@@ -24,8 +35,23 @@
       "description": "Details about the file/object within a databucket.",
       "requirement": "optional"
     },
+    "group": {
+      "description": "The name of the related resource group.",
+      "requirement": "optional"
+    },
     "groups": {
       "description": "The group names to which the databucket belongs.",
+      "requirement": "optional"
+    },
+    "hostname": {
+      "description": "The fully qualified name of the resource.",
+      "requirement": "recommended"
+    },
+    "ip": {
+      "description": "The IP address of the resource, in either IPv4 or IPv6 format.",
+      "requirement": "recommended"
+    },
+    "is_backed_up": {
       "requirement": "optional"
     },
     "is_encrypted": {
@@ -42,6 +68,23 @@
     },
     "name": {
       "description": "The databucket name."
+    },
+    "namespace": {
+      "description": "The namespace is useful when similar entities exist that you need to keep separate.",
+      "requirement": "optional"
+    },
+    "owner": {
+      "description": "The identity of the service or user account that owns the resource.",
+      "requirement": "recommended"
+    },
+    "region": {
+      "description": "The cloud region of the resource.",
+      "profile": "cloud",
+      "requirement": "optional"
+    },
+    "resource_relationship": {
+      "description": "A graph representation showing how this resource relates to and interacts with other entities in the environment. This can include parent/child relationships, dependencies, or other connections.",
+      "requirement": "optional"
     },
     "size": {
       "description": "The size of the databucket in bytes.",
@@ -74,9 +117,20 @@
     },
     "uid": {
       "description": "The unique identifier of the databucket."
+    },
+    "version": {
+      "description": "The version of the resource. For example <code>1.2.3</code>.",
+      "requirement": "optional"
+    },
+    "zone": {
+      "caption": "Cloud Availability Zone",
+      "description": "The specific availability zone within a cloud region where the resource is located.",
+      "profile": "cloud",
+      "requirement": "optional"
     }
   },
   "profiles": [
-    "data_classification"
+    "data_classification",
+    "cloud"
   ]
 }


### PR DESCRIPTION
#### Related Issue: n/a

NOTE: This PR doesn't add any new attribute to the object. It only refactors the current definition of `databucket` to extend `_resource` instead of `resource_details`.  Any previously inherited attributes are now added explicitly to maintain backwards compatibility. Also deprecating a redundant attribute.

This is being done to avoid further pollution of the databucket object with attributes from the resource_details object, which was a result of unnecessary inheritance.

---

1. Deprecating `group` in favor of `groups`
2. Changing descriptions to explicitly call out databucket instead of resources wherever applicable
