### PR TITLE
Fix caption for raw_data_hash attribute

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -4632,7 +4632,7 @@
       "type": "string_t"
     },
     "raw_data_hash": {
-      "caption": "Raw Hash",
+      "caption": "Raw Data Hash",
       "description": "The hash, which describes the content of the raw_data field.",
       "type": "fingerprint"
     },


### PR DESCRIPTION
#### Related PR: https://github.com/ocsf/ocsf-schema/pull/1420

Some low hanging fruit, PR #1420 has a suggestion for updating the caption for `raw_data_hash`. This PR addresses it.
