### PR TITLE
set device.uid as an observable

### DIFF
--- a/objects/device.json
+++ b/objects/device.json
@@ -145,7 +145,8 @@
     },
     "uid": {
       "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "observable": 47
     },
     "uid_alt": {
       "description": "An alternate unique identifier of the device if any. For example the ActiveDirectory DN.",


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes: We would like to set `device.uid` as an observables to help with device based correlation.
Changes:

Set `device.uid` as an Observable type - type_id: 47

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
4. Is your PR title in sync with the description?
