### PR TITLE
feat: add `subgroup` management to Group Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
   1. Added `Disconnect` and `Reconnect` activities in the `RDP Activity` class. [#1415](https://github.com/ocsf/ocsf-schema/pull/1415)
   1. Added `user` as an attribute to the `RDP Activity` class. [#1419](https://github.com/ocsf/ocsf-schema/pull/1419)
   1. Added `raw_data_hash` as an attribute to `base_event`. [#1420](https://github.com/ocsf/ocsf-schema/pull/1420)
+  1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)
   1. Added xxHash H3's 64-bit and 128-bit variants to `algorithm_id` on the `fingerprint` object. [#1420](https://github.com/ocsf/ocsf-schema/pull/1412)
@@ -134,8 +135,8 @@ Thankyou! -->
   1. Added `extensions/windows/reg_key_path_t` as an Observable type - `type_id: 46` and marked fields as this type [#1381](https://github.com/ocsf/ocsf-schema/pull/1381)
      - `reg_key.path` object attribute
      - `reg_value.path` object attribute
-  
-     
+
+
 ### Improved
 * #### Event Classes
   1. Added `assessments` to `config_state`. [#1343](https://github.com/ocsf/ocsf-schema/pull/1343)
@@ -143,7 +144,7 @@ Thankyou! -->
   1. Added `anomaly_analyses` to `detection_finding`. [#1358](https://github.com/ocsf/ocsf-schema/pull/1358)
   1. Added `Detect` value for `activity_id` in Remediation events. [#1362](https://github.com/ocsf/ocsf-schema/pull/1362)
   1. Added `resources` to `user_access`. [#1374](https://github.com/ocsf/ocsf-schema/pull/1374)
-  1. Added `malware_scan_info`, `malware` to `detection_finding`. [#1373](https://github.com/ocsf/ocsf-schema/pull/1373) 
+  1. Added `malware_scan_info`, `malware` to `detection_finding`. [#1373](https://github.com/ocsf/ocsf-schema/pull/1373)
   1. Added `authentication_token` to `authentication`. [#1391](https://github.com/ocsf/ocsf-schema/pull/1391)
 
 * #### Objects
@@ -183,7 +184,7 @@ Thankyou! -->
   1. Added `cis_controls` to `remediation` object [#1369](https://github.com/ocsf/ocsf-schema/pull/1369)
   1. Added `check` object to `compliance` object [#1369](https://github.com/ocsf/ocsf-schema/pull/1369)
   1. Added `Patch` as a value of `http_method` in the `http_request` object. [#1427](https://github.com/ocsf/ocsf-schema/pull/1427)
-     
+
 * #### Profiles
   1. Added `malware_scan_info` to `security_control` profile. [#1373](https://github.com/ocsf/ocsf-schema/pull/1373)
   1. Added `campaign`, `category`, `created_time`, `creator`, `desc`, `expiration_time`, `external_id`, `labels`, `malware`, `modified_time`, `name`, `detection_pattern`, `detection_pattern_type`, `detection_pattern_type_id`, `intrusion_sets`, `risk_score`, `references`, `uploaded_time`, `severity`, `uid` and `threat_actor` to `osint` object. [#1310](https://github.com/ocsf/ocsf-schema/pull/1310)
@@ -236,7 +237,7 @@ Thankyou! -->
     1. Added `location` to the `managed_entity` object. [#1169](https://github.com/ocsf/ocsf-schema/pull/1169)
     1. Added `unmanned_system_operator` to the dictionary, extends `user`. [#1169](https://github.com/ocsf/ocsf-schema/pull/1169)
     1. Added `locations` to the dictionary, an array type of the `location` object, used within the new `operating_area` object. [#1169](https://github.com/ocsf/ocsf-schema/pull/1169)
-    1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. [#1169](https://github.com/ocsf/ocsf-schema/pull/1169) 
+    1. Added `altitude_ceiling`, `altitude_floor`, `geodetic_altitude`, `aerial_height`, `horizontal_accuracy`, `pressure_altitude`, `radius`, `speed`, `track_direction`, and `vertical_speed` all to support `operating_area` and `unmanned_aerial_system` objects. [#1169](https://github.com/ocsf/ocsf-schema/pull/1169)
     1. Added `imei_list` as an array `string_t`. [#1225](https://github.com/ocsf/ocsf-schema/pull/1225)
     1. Added `is_encrypted` as `boolean_t`; `column_name`, `cell_name`, `storage_class`, `key_uid`, `json_path` as `string_t` & `column_number`, `row_number`, `page_number`, `record_index_in_array` as `integer_t`. [#1245](https://github.com/ocsf/ocsf-schema/pull/1245)
     1. Added `group_provisioning_enabled`, `scim_group_schema`, `user_provisioning_enabled`, `scim_user_schema`, `scopes`, `idle_timeout`, `login_endpoint`, `logout_endpoint`, and `metadata_url` entries to the dictionary to support the new `scim` and `sso` objects. [#1239](https://github.com/ocsf/ocsf-schema/pull/1239)

--- a/dictionary.json
+++ b/dictionary.json
@@ -5656,6 +5656,11 @@
       "type": "string_t",
       "is_array": true
     },
+    "subgroup": {
+      "caption": "Subgroup",
+      "description": "A subgroup that was added to or removed from the group.",
+      "type": "group"
+    },
     "subject": {
       "caption": "Subject Details",
       "description": "The identifier of the subject. See specific usage.",

--- a/events/iam/group_management.json
+++ b/events/iam/group_management.json
@@ -30,6 +30,14 @@
         "6": {
           "caption": "Create",
           "description": "A group was created."
+        },
+        "7": {
+          "caption": "Add Subgroup",
+          "description": "Add subgroup to a group."
+        },
+        "8": {
+          "caption": "Remove Subgroup",
+          "description": "Remove subgroup from a group."
         }
       }
     },
@@ -50,6 +58,11 @@
     },
     "user": {
       "description": "A user that was added to or removed from the group.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "subgroup": {
+      "description": "A subgroup that was added to or removed from the group.",
       "group": "primary",
       "requirement": "recommended"
     }


### PR DESCRIPTION
#### Related Issue

[Slack thread](https://opencybersecu-lz97379.slack.com/archives/C03C2QPSBPB/p1750087016794759), seems like it affects more than just me.

#### Description of changes

Many systems have nested groups within groups. The current `Group Management` class isn't able to model those, this adds the activities, and a sub-group property so the additions and removals can be tracked.