### PR TITLE
Added `state_id` and `state` to `analytic`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Thankyou! -->
   1. Added `status` to `related_event` object. [#1434](https://github.com/ocsf/ocsf-schema/pull/1434)
   1. Added `attack_graph` to `finding_info`. [#1436](https://github.com/ocsf/ocsf-schema/pull/1436)
   1. Added `Executable File` to `file` `type_id` enum. Added `is_readonly` as an optional attribute. [#1438](https://github.com/ocsf/ocsf-schema/pull/1438)
+  1. Added `state_id` and `state` to `analytic`. [#1448](https://github.com/ocsf/ocsf-schema/pull/1448)
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)

--- a/objects/analytic.json
+++ b/objects/analytic.json
@@ -27,6 +27,28 @@
       "description": "Other analytics related to this analytic.",
       "requirement": "optional"
     },
+    "state": {
+      "description": "The Analytic state.",
+      "requirement": "optional"
+    },
+    "state_id": {
+      "description": "The Analytic state identifier.",
+      "requirement": "optional",
+      "enum": {
+        "1": {
+          "caption": "Active",
+          "description": "The Analytic is active."
+        },
+        "2": {
+          "caption": "Suppressed",
+          "description": "The Analytic is suppressed. For example, a user/customer has suppressed a particular detection signature in a security product."
+        },
+        "3": {
+          "caption": "Experimental",
+          "description": "The Analytic is still under development and considered experimental."
+        }
+      }
+    },
     "type": {
       "description": "The analytic type.",
       "requirement": "optional"


### PR DESCRIPTION
This PR addresses the desire to represent the status of an analytic that contributed to a finding in a manner independent from the top-level finding status. 
