### PR TITLE
Add Subtitute User activity id to Authentication Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Thankyou! -->
   1. Added `raw_data_hash` as an attribute to `base_event`. [#1420](https://github.com/ocsf/ocsf-schema/pull/1420)
   1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
+  1. Added `Substitute User` activity_id to the `Authentication` class. [#1456](https://github.com/ocsf/ocsf-schema/pull/1456)
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -44,6 +44,10 @@
         "6": {
           "caption": "Preauth",
           "description": "A preauthentication stage was engaged."
+        },
+        "7": {
+          "caption": "Substitute User",
+          "description": "A user attempted to authenticate as another user"
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:

Added a new `Subtitute User` activity_id to the `Authentication` class to handle the events caused by `sudo` and `su` commands on Unix systems. `sudo` and `su` both use authentication to allow the user to effectively act as another user either in a single command or in a specific session.

<img width="2998" height="1500" alt="image" src="https://github.com/user-attachments/assets/3fac6fdc-5d1a-437d-8f29-b57114d6d837" />