### PR TITLE
Add `http_request` and `http_response` to `File Hosting Activity` Class

### DIFF
--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -119,6 +119,16 @@
       "group": "context",
       "requirement": "optional"
     },
+    "http_request": {
+      "description": "Details about the underlying HTTP request.",
+      "group": "context",
+      "requirement": "recommended"
+    },
+    "http_response": {
+      "description": "Details about the HTTP response, if available.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "share": {
       "description": "The share name.",
       "group": "context",


### PR DESCRIPTION
#### Related Issue: 

#### Description of changes:

https://opencybersecu-lz97379.slack.com/archives/C05HLGHMKU2/p1751919356748859

<img width="1587" height="305" alt="image" src="https://github.com/user-attachments/assets/9b8c8aeb-a81f-4b7d-8269-c17aa05f2d44" />

Add `http_request` and `http_response` to `File Hosting Activity` Class. This will be especially useful in allowing `User Agent` string to be captured
