### PR TITLE
Add Account Switch activity id to Authentication Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Thankyou! -->
   1. Added `Add Subgroup`, and `Remove Subgroup` activities in the `Group Management` class. [#1447](https://github.com/ocsf/ocsf-schema/pull/1447)
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `http_request` and `http_response` objects to the `File Hosting Activity` Class [#1458](https://github.com/ocsf/ocsf-schema/pull/1458)
+  1. Added `Account Switch` activity_id to the `Authentication` class. Added `account_switch_type` and `account_switch_type_id` attributes to the `Authentication` class. [#1460](https://github.com/ocsf/ocsf-schema/pull/1460)
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)

--- a/dictionary.json
+++ b/dictionary.json
@@ -99,6 +99,35 @@
       "description": "The account object describes details about the account that was the source or target of the activity.",
       "type": "account"
     },
+    "account_switch_type": {
+      "caption": "Account Switch Type",
+      "description": "The account switch method, normalized to the caption of the account_switch_type_id value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "account_switch_type_id": {
+      "caption": "Account Switch Type ID",
+      "description": "The normalized identifier of the account switch method.",
+      "sibling": "account_switch_type",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The account switch type is unknown."
+        },
+        "1": {
+          "caption": "Substitute User",
+          "description": "A utility like <code>sudo</code>, <code>su</code>, or equivalent was used to perform actions in the context of another user."
+        },
+        "2": {
+          "caption": "Impersonate",
+          "description": "An API like <code>ImpersonateLoggedOnUser()</code> or equivalent was used to perform actions in the context of another user."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The account switch type is not mapped. See the <code>account_switch_type</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "ack_reason": {
       "caption": "Acknowledgement Reason",
       "description": "An integer that provides a reason code or additional information about the acknowledgment result.",

--- a/events/iam/authentication.json
+++ b/events/iam/authentication.json
@@ -19,6 +19,14 @@
     ]
   },
   "attributes": {
+    "account_switch_type": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "account_switch_type_id": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
     "activity_id": {
       "enum": {
         "1": {
@@ -44,6 +52,10 @@
         "6": {
           "caption": "Preauth",
           "description": "A preauthentication stage was engaged."
+        },
+        "7": {
+          "caption": "Account Switch",
+          "description": "A utility or service switched the user account. See the <code>account_switch_type_id</code> attribute for more details."
         }
       }
     },


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:

Added a new `Account Switch` activity_id to the `Authentication` class to handle the events that switch the user account. 
Added account_switch_type and account_switch_type_id to the `Authentication` class with the following types:
- Substitute User: caused by `sudo` and `su` commands on Unix systems. `sudo` and `su` both use authentication to allow the user to effectively act as another user either in a single command or in a specific session.
- Impersonate: caused by the `ImpersonateLoggedOnUser()` command on Windows systems, or similar. 

<img width="3144" height="1670" alt="image" src="https://github.com/user-attachments/assets/b90eaee8-bc97-4d21-b08b-c242288f3a7c" />
