### PR TITLE
Adding is_truncated and untruncated_size to metadata

### DIFF
--- a/objects/logger.json
+++ b/objects/logger.json
@@ -12,6 +12,10 @@
       "description": "The unique identifier of the event assigned by the logger.",
       "requirement": "optional"
     },
+    "is_truncated": {
+      "description": "Indicates whether the event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
+      "requirement": "optional"
+    },
     "log_level": {
       "requirement": "optional"
     },
@@ -42,6 +46,10 @@
     "uid": {
       "description": "The unique identifier of the logging product instance.",
       "requirement": "recommended"
+    },
+    "untruncated_size": {
+      "description": "The original size of the event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
+      "requirement": "optional"
     },
     "version": {
       "description": "The version of the logging product.",

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -13,7 +13,7 @@
       "requirement": "optional"
     },
     "is_truncated": {
-      "description": "Indicates whether the event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
+      "description": "Indicates whether the OCSF event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
       "requirement": "optional"
     },
     "log_level": {

--- a/objects/logger.json
+++ b/objects/logger.json
@@ -48,7 +48,7 @@
       "requirement": "recommended"
     },
     "untruncated_size": {
-      "description": "The original size of the event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
+      "description": "The original size of the OCSF event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
       "requirement": "optional"
     },
     "version": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -83,7 +83,7 @@
       "requirement": "optional"
     },
     "untruncated_size": {
-      "description": "The original size of the event data in bytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
+      "description": "The original size of the event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
       "requirement": "optional"
     },
     "version": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -22,6 +22,10 @@
     "extensions": {
       "requirement": "optional"
     },
+    "is_truncated": {
+      "description": "Indicates whether the event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
+      "requirement": "optional"
+    },
     "labels": {
       "description": "The list of labels attached to the event. For example: <code>[\"sample\", \"dev\"]</code>",
       "requirement": "optional"
@@ -78,8 +82,12 @@
       "description": "The logging system-assigned unique identifier of an event instance.",
       "requirement": "optional"
     },
+    "untruncated_size": {
+      "description": "The original size of the event data in bytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
+      "requirement": "optional"
+    },
     "version": {
-      "description": "The version of the OCSF schema, using Semantic Versioning Specification (<a target='_blank' href='https://semver.org'>SemVer</a>). For example: 1.0.0. Event consumers use the version to determine the available event attributes.",
+      "description": "The version of the OCSF schema, using Semantic Versioning Specification (<a target='_blank' href='https://semver.org'>SemVer</a>). For example: <code>1.0.0.</code> Event consumers use the version to determine the available event attributes.",
       "requirement": "required"
     }
   },

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -23,7 +23,7 @@
       "requirement": "optional"
     },
     "is_truncated": {
-      "description": "Indicates whether the event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
+      "description": "Indicates whether the OCSF event data has been truncated due to size limitations. When <code>true</code>, some event data may have been omitted to fit within system constraints.",
       "requirement": "optional"
     },
     "labels": {

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -83,7 +83,7 @@
       "requirement": "optional"
     },
     "untruncated_size": {
-      "description": "The original size of the event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
+      "description": "The original size of the OCSF event data in kilobytes before any truncation occurred. This field is typically populated when <code>is_truncated</code> is <code>true</code> to indicate the full size of the original event.",
       "requirement": "optional"
     },
     "version": {


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:
1. Added existing attributes -`is_truncated` and `untruncated_size` to the `metadata` and `logger` object. These will be used to represent event/finding truncation, by event producers and/or by subsequent "logging" entities.

<img width="1422" height="703" alt="Screenshot 2025-07-22 at 11 16 31" src="https://github.com/user-attachments/assets/c031b773-295f-46b4-8986-b3f643a2448d" />
