### PR TITLE
issue-1457: Improve clarity on which network endpoint initiated flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Thankyou! -->
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `http_request` and `http_response` objects to the `File Hosting Activity` Class [#1458](https://github.com/ocsf/ocsf-schema/pull/1458)
   1. Added `Account Switch` activity_id to the `Authentication` class. Added `account_switch_type` and `account_switch_type_id` attributes to the `Authentication` class. [#1460](https://github.com/ocsf/ocsf-schema/pull/1460)
-  1. Added `connection_initiator` and `connection_initiator_id` sibling attributes to `Network Activity` class. [#1464](https://github.com/ocsf/ocsf-schema/pull/1464)
+  1. Added `is_src_dst_assignment_known` attribute to `Network Activity` class. [#1464](https://github.com/ocsf/ocsf-schema/pull/1464)
 
 
 * #### Objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Thankyou! -->
   1. Added `MTA Relay` activity and `to`/`from` attributes to the `Email Activity` class. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `http_request` and `http_response` objects to the `File Hosting Activity` Class [#1458](https://github.com/ocsf/ocsf-schema/pull/1458)
   1. Added `Account Switch` activity_id to the `Authentication` class. Added `account_switch_type` and `account_switch_type_id` attributes to the `Authentication` class. [#1460](https://github.com/ocsf/ocsf-schema/pull/1460)
+  1. Added `connection_initiator` and `connection_initiator_id` sibling attributes to `Network Activity` class. [#1464](https://github.com/ocsf/ocsf-schema/pull/1464)
+
 
 * #### Objects
   1. Added more `algorithm_id` values and references to the `fingerprint` object. [#1412](https://github.com/ocsf/ocsf-schema/pull/1412)
@@ -79,6 +81,7 @@ Thankyou! -->
   1. Improved description of the `Application Error` class. [#1424](https://github.com/ocsf/ocsf-schema/pull/1424)
   1. Fixed links to ocsf-docs repo [#1453](https://github.com/ocsf/ocsf-schema/pull/1453)
   1. Set `device.uid` as an Observable type - type_id: 47 [#1446](https://github.com/ocsf/ocsf-schema/pull/1446)
+  1. Improved descriptions of `src_endpoint` and `dst_endpoint` attributes in `Network Activity` class. [#1464](https://github.com/ocsf/ocsf-schema/pull/1464)
 
 ### Deprecated
   1. Deprecated usage of `group` attribute in favor of `groups` in the `databucket` object. #1344

--- a/dictionary.json
+++ b/dictionary.json
@@ -1349,7 +1349,7 @@
     },
     "connection_initiator": {
       "caption": "Connection Initiator",
-      "description": "Identifies which endpoint actively established the network connection, independent of observed traffic direction.",
+      "description": "Identifies which endpoint initiated the network connection, independent of observed traffic direction.",
       "type": "string_t"
     },
     "connection_initiator_id": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1349,7 +1349,7 @@
     },
     "connection_initiator": {
       "caption": "Connection Initiator",
-      "description": "Indicates which endpoint initiated the connection (i.e. the network flow).",
+      "description": "Identifies which endpoint actively established the network connection, independent of observed traffic direction.",
       "type": "string_t"
     },
     "connection_initiator_id": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -1347,31 +1347,6 @@
         }
       }
     },
-    "connection_initiator": {
-      "caption": "Connection Initiator",
-      "description": "Identifies which endpoint initiated the network connection, independent of observed traffic direction.",
-      "type": "string_t"
-    },
-    "connection_initiator_id": {
-      "caption": "Connection Initiator ID",
-      "description": "The normalized identifier of the <code>connection_initiator</code>.",
-      "sibling": "connection_initiator",
-      "type": "integer_t",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "Endpoint role cannot be determined."
-        },
-        "1": {
-          "caption": "Source Endpoint",
-          "description": "The <code>src_endpoint</code> initiated the connection."
-        },
-        "2": {
-          "caption": "Destination Endpoint",
-          "description": "The <code>dst_endpoint</code> initiated the connection."
-        }
-      }
-    },
     "connection_info": {
       "caption": "Connection Info",
       "description": "The network connection information.",
@@ -3286,6 +3261,11 @@
     "is_shared": {
       "caption": "Shared Device",
       "description": "The event occurred on a shared device.",
+      "type": "boolean_t"
+    },
+    "is_src_dst_assignment_known": {
+      "caption": "Source/Destination Assignment Known",
+      "description": "<code>true</code> denotes that <code>src_endpoint</code> and <code>dst_endpoint</code> correctly identify the initiator and responder respectively. <code>false</code> denotes that the event source has arbitrarily assigned one peer to <code>src_endpoint</code> and the other to <code>dst_endpoint</code>, in other words that initiator and responder are not being asserted. This can occur, for example, when the event source is a network appliance that has not observed the initiation of a given connection. In the absence of this attribute, interpretation of the initiator and responder is implementation-specific.",
       "type": "boolean_t"
     },
     "is_superseded": {
@@ -6484,7 +6464,7 @@
       "description": "The timestamp when this identity last successfully authenticated to any system or service. See specific usage.",
       "type": "timestamp_t"
     },
-    "access_analysis_result":{
+    "access_analysis_result": {
       "caption": "Access Analysis Result",
       "description": "Describes access relationships and pathways between identities, resources, focusing on who can access what and through which mechanisms. This evaluates access levels (read/write/admin), access types (direct, cross-account, public, federated), and the conditions under which access is granted. Use this for resource-centric security assessments such as external access discovery, public exposure analysis, etc.",
       "type": "access_analysis_result"
@@ -6506,7 +6486,7 @@
       "type": "string_t",
       "is_array": true
     },
-    "identity_activity_metrics":{
+    "identity_activity_metrics": {
       "caption": "Identity Activity Metrics",
       "description": "Describes usage activity and other metrics of an Identity i.e. AWS IAM User, GCP IAM Principal, etc.",
       "type": "identity_activity_metrics"

--- a/dictionary.json
+++ b/dictionary.json
@@ -1347,6 +1347,31 @@
         }
       }
     },
+    "connection_initiator": {
+      "caption": "Connection Initiator",
+      "description": "Indicates which endpoint initiated the connection (i.e. the network flow).",
+      "type": "string_t"
+    },
+    "connection_initiator_id": {
+      "caption": "Connection Initiator ID",
+      "description": "The normalized identifier of the <code>connection_initiator</code>.",
+      "sibling": "connection_initiator",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "Endpoint role cannot be determined."
+        },
+        "1": {
+          "caption": "Source Endpoint",
+          "description": "The <code>src_endpoint</code> initiated the connection."
+        },
+        "2": {
+          "caption": "Destination Endpoint",
+          "description": "The <code>dst_endpoint</code> initiated the connection."
+        }
+      }
+    },
     "connection_info": {
       "caption": "Connection Info",
       "description": "The network connection information.",

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -13,20 +13,12 @@
       "group": "context",
       "requirement": "optional"
     },
-    "connection_initiator": {
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "connection_initiator_id": {
-        "group": "primary",
-        "requirement": "recommended"
-    },
     "connection_info": {
       "group": "primary",
       "requirement": "recommended"
     },
     "dst_endpoint": {
-      "description": "The destination endpoint of network traffic. Whether the destination endpoint initiated the flow is specified in the <code>connection_initiator</code> field.",
+      "description": "The responder (server) in a network connection.",
       "group": "primary",
       "requirement": "recommended"
     },
@@ -39,7 +31,7 @@
       "requirement": "recommended"
     },
     "src_endpoint": {
-      "description": "The source endpoint of network traffic.  Whether the source endpoint initiated the flow is specified in the <code>connection_initiator</code> field.",
+      "description": "The initiator (client) of the network connection.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/network.json
+++ b/events/network/network.json
@@ -13,12 +13,20 @@
       "group": "context",
       "requirement": "optional"
     },
+    "connection_initiator": {
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "connection_initiator_id": {
+        "group": "primary",
+        "requirement": "recommended"
+    },
     "connection_info": {
       "group": "primary",
       "requirement": "recommended"
     },
     "dst_endpoint": {
-      "description": "The responder (server) in a network connection.",
+      "description": "The destination endpoint of network traffic. Whether the destination endpoint initiated the flow is specified in the <code>connection_initiator</code> field.",
       "group": "primary",
       "requirement": "recommended"
     },
@@ -31,7 +39,7 @@
       "requirement": "recommended"
     },
     "src_endpoint": {
-      "description": "The initiator (client) of the network connection.",
+      "description": "The source endpoint of network traffic.  Whether the source endpoint initiated the flow is specified in the <code>connection_initiator</code> field.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -42,7 +42,7 @@
     },
     "is_src_dst_assignment_known": {
       "group": "primary",
-      "requirement": "optional"
+      "requirement": "recommended"
     },
     "src_endpoint": {
       "description": " The initiator of the network connection. In some contexts an event source cannot correctly identify the initiator. Refer to <code>is_src_dst_assignment_known</code> for certainty."

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -37,6 +37,16 @@
         }
       }
     },
+    "dst_endpoint": {
+      "description": "The responder of the network connection. In some contexts an event source cannot correctly identify the responder. Refer to <code>is_src_dst_assignment_known</code> for certainty."
+    },
+    "is_src_dst_assignment_known": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "src_endpoint": {
+      "description": " The initiator of the network connection. In some contexts an event source cannot correctly identify the initiator. Refer to <code>is_src_dst_assignment_known</code> for certainty."
+    },
     "url": {
       "description": "The URL details relevant to the network traffic.",
       "group": "primary",


### PR DESCRIPTION
#### Related Issue: 
#1457 
#### Description of changes:

- Update src/dst endpoint descriptions in the network activity class to make it clear that they might not be the initiator/receiver of the communications
- Add `is_src_dst_assignment_known` boolean attribute to convey which endpoint initiated the flow.


<img width="2971" height="677" alt="image" src="https://github.com/user-attachments/assets/b16a23ea-5b0a-4bd0-a882-5c9a18e60fa3" />



