### PR TITLE
Adding open_ports to the network_interface object

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -4021,6 +4021,12 @@
       "description": "The Windows options needed to open a registry key.",
       "type": "integer_t"
     },
+    "open_ports": {
+      "caption": "Open Ports",
+      "description": "The list of open ports on a network interface, including port numbers and associated protocol information.",
+      "type": "port_info",
+      "is_array": true
+    },
     "open_type": {
       "caption": "Open Type",
       "description": "The file open type.",

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -22,6 +22,9 @@
     "namespace": {
       "requirement": "optional"
     },
+    "open_ports": {
+      "requirement": "optional"
+    },
     "subnet_prefix": {
       "requirement": "optional"
     },
@@ -51,7 +54,7 @@
           "caption": "Other"
         }
       },
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "uid": {
       "description": "The unique identifier for the network interface.",
@@ -63,7 +66,8 @@
       "ip",
       "mac",
       "name",
-      "hostname"
+      "hostname",
+      "uid"
     ]
   }
 }

--- a/objects/port_info.json
+++ b/objects/port_info.json
@@ -1,0 +1,25 @@
+{
+  "caption": "Port Information",
+  "description": "The Port Information object describes a port and its associated protocol details.",
+  "extends": "object",
+  "name": "port_info",
+  "attributes": {
+    "port": {
+      "description": "The port number. For example: <code>80</code>, <code>443</code>, <code>22</code>.",
+      "requirement": "required"
+    },
+    "protocol_name": {
+      "description": "The IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). For example: <code>tcp</code> or <code>udp</code>.",
+      "references": [
+        {
+          "description": "IANA Protocol Numbers",
+          "url": "https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml"
+        }
+      ],
+      "requirement": "recommended"
+    },
+    "protocol_num": {
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
#### Related Issue: Currently, there is no good method to represent open ports on a device. This PR adds an object to help represent this information. Down the roads, we can also tie in the services that are listening on those ports, in the same `port_info` object.

#### Description of changes:
1. Adding a new object - `port_info`
2. Adding `open_ports` as an array of `port_info` object to the `network_interface` object.
3. Expanding the constraints in the `network_interface` object to include `uid`.