### PR TITLE
Added type-specific attributes to represent Windows registry value data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Thankyou! -->
 * #### Dictionary Attributes
   1. Added `from_list`, `from_mailboxes`,`reply_to_list`, `return_path`, `sender` and `sender_mailbox`. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `access_level`, `programmatic_credentials`, `last_authentication_time`, `access_analysis_result`, `last_used_time`, `accessors`, `granted_privileges`, `identity_activity_metrics`, `password_last_used_time`, `access_type`, `permission_analysis_results`, `additional_restrictions`, `unused_privileges_count`, `condition_keys`, `applications`, `role`, `role_id`. #1389
+  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to Windows extension. [#1468]
+
 * #### Objects
   1. Added  `access_analysis_result`, `additional_restriction`, `identity_activity_metrics`, `permission_analysis_result`, `programmatic_credential`. #1389
 
@@ -73,17 +75,21 @@ Thankyou! -->
   1. Added `from_list`, `from_mailboxes`,`reply_to_list`, `return_path`, `sender` and `sender_mailbox` attributes to `email` object. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `role`, `role_id` to `resource_details` object, `type` to `policy` object,  #1389
   1. Added `is_truncated` and `untruncated_size` to `metadata`, `logger` objects. #1461
+  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to `reg_value` object in Windows extension. [#1468]
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)
   1. Improved description of the `Application Error` class. [#1424](https://github.com/ocsf/ocsf-schema/pull/1424)
   1. Fixed links to ocsf-docs repo [#1453](https://github.com/ocsf/ocsf-schema/pull/1453)
   1. Set `device.uid` as an Observable type - type_id: 47 [#1446](https://github.com/ocsf/ocsf-schema/pull/1446)
+  1. Improved the description of the `bytestring_t` data type. [#1468]
 
 ### Deprecated
   1. Deprecated usage of `group` attribute in favor of `groups` in the `databucket` object. #1344
-  2. Deprecated usage of `credential_uid` attribute in favor of `programmatic_credentials` in the `user` object. #1389
-  3. Deprecated usage of items `3` and `4` in the `type_id` enum in `account` object, in favor of the `type_id` enum in the `user` object. #1389
+  1. Deprecated usage of `credential_uid` attribute in favor of `programmatic_credentials` in the `user` object. #1389
+  1. Deprecated usage of items `3` and `4` in the `type_id` enum in `account` object, in favor of the `type_id` enum in the `user` object. #1389
+  1. Deprecated `data` attribute in favor of `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` in `reg_value` object of Windows extension. [#1468]
+  1. Deprecated item `9` (`REG_QWORD_LITTLE_ENDIAN`) in the `type_id` enum in the `reg_value` object. Its presence was an error. [#1468]
 
 ## [v1.5.0] - April 28th, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ Thankyou! -->
 * #### Dictionary Attributes
   1. Added `from_list`, `from_mailboxes`,`reply_to_list`, `return_path`, `sender` and `sender_mailbox`. [#1454](https://github.com/ocsf/ocsf-schema/pull/1454)
   1. Added `access_level`, `programmatic_credentials`, `last_authentication_time`, `access_analysis_result`, `last_used_time`, `accessors`, `granted_privileges`, `identity_activity_metrics`, `password_last_used_time`, `access_type`, `permission_analysis_results`, `additional_restrictions`, `unused_privileges_count`, `condition_keys`, `applications`, `role`, `role_id`. #1389
-  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to Windows extension. [#1468]
+  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to Windows extension. [#1468](https://github.com/ocsf/ocsf-schema/pull/1468)
 
 * #### Objects
   1. Added  `access_analysis_result`, `additional_restriction`, `identity_activity_metrics`, `permission_analysis_result`, `programmatic_credential`. #1389
@@ -79,7 +79,7 @@ Thankyou! -->
   1. Added `role`, `role_id` to `resource_details` object, `type` to `policy` object,  #1389
   1. Added `is_truncated` and `untruncated_size` to `metadata`, `logger` objects. #1461
   1. Added `open_ports` to the `network_interface` object. #1466
-  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to `reg_value` object in Windows extension. [#1468]
+  1. Added `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` to `reg_value` object in Windows extension. [#1468](https://github.com/ocsf/ocsf-schema/pull/1468)
 
 ### Misc
   1. Fixed spelling errors throughout the project and added spell checking to the CI linter workflow. [#1411](https://github.com/ocsf/ocsf-schema/pull/1411)
@@ -87,14 +87,13 @@ Thankyou! -->
   1. Fixed links to ocsf-docs repo [#1453](https://github.com/ocsf/ocsf-schema/pull/1453)
   1. Set `device.uid` as an Observable type - type_id: 47 [#1446](https://github.com/ocsf/ocsf-schema/pull/1446)
   1. Improved descriptions of `src_endpoint` and `dst_endpoint` attributes in `Network Activity` class. [#1464](https://github.com/ocsf/ocsf-schema/pull/1464)
-  1. Improved the description of the `bytestring_t` data type. [#1468]
+  1. Improved the description of the `bytestring_t` data type. [#1468](https://github.com/ocsf/ocsf-schema/pull/1468)
 
 ### Deprecated
   1. Deprecated usage of `group` attribute in favor of `groups` in the `databucket` object. #1344
   1. Deprecated usage of `credential_uid` attribute in favor of `programmatic_credentials` in the `user` object. #1389
   1. Deprecated usage of items `3` and `4` in the `type_id` enum in `account` object, in favor of the `type_id` enum in the `user` object. #1389
-  1. Deprecated `data` attribute in favor of `reg_binary_data`, `reg_integer_data`, `reg_string_data`, `reg_string_list_data` in `reg_value` object of Windows extension. [#1468]
-  1. Deprecated item `9` (`REG_QWORD_LITTLE_ENDIAN`) in the `type_id` enum in the `reg_value` object. Its presence was an error. [#1468]
+  1. Deprecated item `9` (`REG_QWORD_LITTLE_ENDIAN`) in the `type_id` enum in the `reg_value` object. Its presence was an error. [#1468](https://github.com/ocsf/ocsf-schema/pull/1468)
 
 ## [v1.5.0] - April 28th, 2025
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -6566,7 +6566,14 @@
       },
       "bytestring_t": {
         "caption": "Byte String",
-        "description": "Base64 encoded immutable byte sequence.",
+        "description": "Base 64 encoded immutable byte sequence. Traditional Base 64 is preferred but publishers may use URL-safe Base 64 when known to be acceptable to consumers. These encodings are described in RFC 4648.",
+        "references": [
+          {
+            "description": "RFC 4648",
+            "url": "https://www.rfc-editor.org/rfc/rfc4648.html"
+          }
+        ],
+        "regex": "^(?:(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)|(?:[A-Za-z0-9_-]{4})*(?:[A-Za-z0-9_-]{2}==|[A-Za-z0-9_-]{3}=))?$",
         "type": "string_t",
         "type_name": "String"
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -6565,7 +6565,7 @@
   },
   "types": {
     "caption": "Data Types",
-    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
+    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementers of OCSF should ensure they abide to these constraints.",
     "attributes": {
       "boolean_t": {
         "caption": "Boolean",

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -18,10 +18,31 @@
       "description": "The registry value before the mutation",
       "type": "reg_value"
     },
+    "reg_binary_data": {
+      "caption": "Registry Binary Data",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_BINARY</code>.",
+      "type": "bytestring_t"
+    },
+    "reg_integer_data": {
+      "caption": "Registry Integer Data",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_DWORD</code>, <code>REG_DWORD_BIG_ENDIAN</code>, or <code>REG_QWORD</code>.",
+      "type": "long_t"
+    },
     "reg_key": {
       "caption": "Registry Key",
       "description": "The registry key.",
       "type": "reg_key"
+    },
+    "reg_string_data": {
+      "caption": "Registry String Data",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_SZ</code> or <code>REG_EXPAND_SZ</code>.",
+      "type": "string_t"
+    },
+    "reg_string_list_data": {
+      "caption": "Registry String List Data",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_MULTI_SZ</code>.",
+      "type": "string_t",
+      "is_array": true
     },
     "reg_value": {
       "caption": "Registry Value",

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -20,7 +20,7 @@
     },
     "reg_binary_data": {
       "caption": "Registry Binary Data",
-      "description": "The data of the registry value when <code>type_id</code> is <code>REG_BINARY</code>.",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_BINARY</code> or <code>REG_NONE</code>.",
       "type": "bytestring_t"
     },
     "reg_integer_data": {
@@ -35,7 +35,7 @@
     },
     "reg_string_data": {
       "caption": "Registry String Data",
-      "description": "The data of the registry value when <code>type_id</code> is <code>REG_SZ</code> or <code>REG_EXPAND_SZ</code>.",
+      "description": "The data of the registry value when <code>type_id</code> is <code>REG_SZ</code>, <code>REG_EXPAND_SZ</code>, or <code>REG_LINK</code>.",
       "type": "string_t"
     },
     "reg_string_list_data": {
@@ -222,7 +222,7 @@
   },
   "types": {
     "caption": "Data Types",
-    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementors of OCSF should ensure they abide to these constraints.",
+    "description": "The data types available in OCSF. Each data type specifies constraints in the form regular expressions, max lengths or value limits. Implementers of OCSF should ensure they abide to these constraints.",
     "attributes": {
       "reg_key_path_t": {
         "observable": 46,

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -7,7 +7,11 @@
   "attributes": {
     "data": {
       "description": "The data of the registry value.",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the appropriate type-specific attribute from <code>reg_binary_data</code>, <code>reg_integer_data</code>, <code>reg_string_data</code>, or <code>reg_string_list_data</code>.",
+        "since": "1.6.0"
+      }
     },
     "is_default": {
       "requirement": "optional"
@@ -28,6 +32,18 @@
       "description": "The full path to the registry key, where the value is located.",
       "requirement": "required",
       "type": "reg_key_path_t"
+    },
+    "reg_binary_data": {
+      "requirement": "optional"
+    },
+    "reg_integer_data": {
+      "requirement": "optional"
+    },
+    "reg_string_data": {
+      "requirement": "optional"
+    },
+    "reg_string_list_data": {
+      "requirement": "optional"
     },
     "type": {
       "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a>.",
@@ -62,7 +78,11 @@
           "caption": "REG_QWORD"
         },
         "9": {
-          "caption": "REG_QWORD_LITTLE_ENDIAN"
+          "caption": "REG_QWORD_LITTLE_ENDIAN",
+          "@deprecated": {
+            "message": "Use <code>REG_QWORD</code> instead.",
+            "since": "1.6.0"
+          }
         },
         "10": {
           "caption": "REG_SZ"

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -6,12 +6,8 @@
   "name": "reg_value",
   "attributes": {
     "data": {
-      "description": "The data of the registry value.",
-      "requirement": "optional",
-      "@deprecated": {
-        "message": "Use the appropriate type-specific attribute from <code>reg_binary_data</code>, <code>reg_integer_data</code>, <code>reg_string_data</code>, or <code>reg_string_list_data</code>.",
-        "since": "1.6.0"
-      }
+      "description": "The data of the registry value. Where the value type is known, implementers should instead use a type-specific attribute, i.e. <code>reg_binary_data</code>, <code>reg_integer_data</code>, <code>reg_string_data</code>, or <code>reg_string_list_data</code>.",
+      "requirement": "optional"
     },
     "is_default": {
       "requirement": "optional"
@@ -54,38 +50,48 @@
       "requirement": "recommended",
       "enum": {
         "1": {
-          "caption": "REG_BINARY"
+          "caption": "REG_BINARY",
+          "description": "Arbitrary binary data."
         },
         "2": {
-          "caption": "REG_DWORD"
+          "caption": "REG_DWORD",
+          "description": "A 32-bit integer."
         },
         "3": {
-          "caption": "REG_DWORD_BIG_ENDIAN"
+          "caption": "REG_DWORD_BIG_ENDIAN",
+          "description": "A 32-bit integer in big-endian byte order."
         },
         "4": {
-          "caption": "REG_EXPAND_SZ"
+          "caption": "REG_EXPAND_SZ",
+          "description": "A string containing unexpanded environment variables, e.g. <code>%USERPROFILE%\\Downloads</code>."
         },
         "5": {
-          "caption": "REG_LINK"
+          "caption": "REG_LINK",
+          "description": "A string containing the target path of a symbolic link created by calling <code>RegCreateKeyEx</code> with <code>REG_OPTION_CREATE_LINK</code>."
         },
         "6": {
-          "caption": "REG_MULTI_SZ"
+          "caption": "REG_MULTI_SZ",
+          "description": "A sequence of zero or more strings."
         },
         "7": {
-          "caption": "REG_NONE"
+          "caption": "REG_NONE",
+          "description": "A value with no declared type."
         },
         "8": {
-          "caption": "REG_QWORD"
+          "caption": "REG_QWORD",
+          "description": "A 64-bit integer."
         },
         "9": {
           "caption": "REG_QWORD_LITTLE_ENDIAN",
+          "description": "Not defined in Windows documentation and previously added to OCSF in error.",
           "@deprecated": {
             "message": "Use <code>REG_QWORD</code> instead.",
             "since": "1.6.0"
           }
         },
         "10": {
-          "caption": "REG_SZ"
+          "caption": "REG_SZ",
+          "description": "A string."
         }
       }
     }

--- a/metaschema/deprecated.schema.json
+++ b/metaschema/deprecated.schema.json
@@ -7,7 +7,7 @@
   "type": "object",
   "properties": {
     "message": {
-      "description": "A message that explains the deprecation to implementors.",
+      "description": "A message that explains the deprecation to implementers.",
       "type": "string"
     },
     "since": {


### PR DESCRIPTION
#### Related Issue: 

[Window registry value data should be representable using type-specific attributes](https://github.com/ocsf/ocsf-schema/issues/1467)

#### Description of changes:

Added four attributes in Windows extension, enabling the data of an individual Windows registry value to be correctly typed.