### PR TITLE
Add `Local (4)` enum to `direction_id` Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,32 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Categories
+* #### Event Classes
+* #### Profiles
+* #### Objects
+* #### Platform Extensions
+* #### Dictionary Attributes
+
+### Improved
+* #### Categories
+* #### Event Classes
+* #### Profiles
+* #### Objects
+* #### Platform Extensions
+* #### Dictionary Attributes
+ 1. Added `Local (4)` enum to the `direction_id` attribute.
+
+
+### Bugfixes
+
+### Deprecated
+
+### Breaking changes
+
+### Misc
+
 ## [v1.6.0] - Aug 1st, 2025
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Thankyou! -->
 * #### Objects
 * #### Platform Extensions
 * #### Dictionary Attributes
- 1. Added `Local (4)` enum to the `direction_id` attribute.
+ 1. Added `Local (4)` enum to the `direction_id` attribute. [#1475](https://github.com/ocsf/ocsf-schema/pull/1475)
 
 
 ### Bugfixes

--- a/dictionary.json
+++ b/dictionary.json
@@ -1931,15 +1931,19 @@
         },
         "1": {
           "caption": "Inbound",
-          "description": "Inbound network connection. The connection was originated from the Internet or outside network, destined for services on the inside network."
+          "description": "Inbound network connection. The connection originated from the Internet or outside network, destined for services on the inside network."
         },
         "2": {
           "caption": "Outbound",
-          "description": "Outbound network connection. The connection was originated from inside the network, destined for services on the Internet or outside network."
+          "description": "Outbound network connection. The connection originated from inside the network, destined for services on the Internet or outside network."
         },
         "3": {
           "caption": "Lateral",
-          "description": "Lateral network connection. The connection was originated from inside the network, destined for services on the inside network."
+          "description": "Lateral network connection. The connection originated from inside the network, destined for services on the inside network."
+        },
+        "4": {
+          "caption": "Local",
+          "description": "Local network connection (<code>localhost</code>). The connection is intra-device, originating from and destined for services running on the same device."
         },
         "99": {
           "caption": "Other",


### PR DESCRIPTION
#### Related Issue:
None

#### Description of changes:
This PR adds a `Local (4)` enum for the `direction_id` attribute.
Also corrects a few grammatical errors (incorrect use of 'was')

<img width="1084" height="376" alt="image" src="https://github.com/user-attachments/assets/e5100d2a-aac5-41a4-848c-1f32fe8d4e0c" />

Recognized tangentially during #1470 Review, as we noticed that `direction_id` captures Inbound, Outbound, and Lateral, but not intra-device (local) connections.
