### PR TITLE
Added department to ldap_person and is_on_premises_sync_enabled to account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,14 @@ Thankyou! -->
 * #### Objects
 * #### Platform Extensions
 * #### Dictionary Attributes
+ 1. Added `department` as `string_t` and `is_on_premises_sync_enabled` as `bool_t`. [#1478](https://github.com/ocsf/ocsf-schema/pull/1478)
 
 ### Improved
 * #### Categories
 * #### Event Classes
 * #### Profiles
 * #### Objects
+ 1. Added `department` to `ldap_person` and `is_on_premises_sync_enabled` to `account`. [#1478](https://github.com/ocsf/ocsf-schema/pull/1478)
 * #### Platform Extensions
 * #### Dictionary Attributes
  1. Added `Local (4)` enum to the `direction_id` attribute. [#1475](https://github.com/ocsf/ocsf-schema/pull/1475)

--- a/dictionary.json
+++ b/dictionary.json
@@ -1734,6 +1734,11 @@
       ],
       "is_array": true
     },
+    "department": {
+      "caption": "Department",
+      "description": "The name of the department in which the user works.",
+      "type": "string_t"
+    },
     "dependency_chain": {
       "caption": "Dependency Chain",
       "description": "Information about the chain of dependencies related to the issue as reported by an Application Security or Vulnerability Management tool. E.g., <code>serverless-offline -> @serverless/utils -> memoizee -> es5-ext</code>.",
@@ -3224,6 +3229,11 @@
     "is_on_premises": {
       "caption": "On Premises",
       "description": "The indication of whether the location is on premises.",
+      "type": "boolean_t"
+    },
+    "is_on_premises_sync_enabled": {
+      "caption": "On-Premises Sync Enabled",
+      "description": "Indicates whether synchronization with an on-premises directory service is enabled (e.g., for Azure AD Connect).",
       "type": "boolean_t"
     },
     "is_personal": {

--- a/objects/account.json
+++ b/objects/account.json
@@ -21,6 +21,9 @@
       "description": "The account type, normalized to the caption of 'account_type_id'. In the case of 'Other', it is defined by the event source.",
       "requirement": "optional"
     },
+    "is_on_premises_sync_enabled": {
+      "requirement": "optional"
+    },
     "type_id": {
       "caption": "Type ID",
       "description": "The normalized account type identifier.",

--- a/objects/ldap_person.json
+++ b/objects/ldap_person.json
@@ -14,6 +14,9 @@
     "deleted_time": {
       "requirement": "optional"
     },
+    "department": {
+      "requirement": "optional"
+    },
     "display_name": {
       "description": "The display name of the LDAP person. According to RFC 2798, this is the preferred name of a person to be used when displaying entries.",
       "requirement": "optional",


### PR DESCRIPTION
Added `department` to `ldap_person` and `is_on_premises_sync_enabled` to `account`

**Description**:
Allows mapping of `department` and `onPremisesSyncEnabled` from the [Microsoft Graph API](https://learn.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) to user evidence types.