### PR TITLE
Correct the peripheral_device.type_id enum values

### DIFF
--- a/objects/peripheral_device.json
+++ b/objects/peripheral_device.json
@@ -50,15 +50,15 @@
           "caption": "Printer",
           "description": "The peripheral device is a printer."
         },
-        "7": {
+        "5": {
           "caption": "Monitor",
           "description": "The peripheral device is a monitor."
         },
-        "9": {
+        "6": {
           "caption": "Microphone",
           "description": "The peripheral device is a microphone."
         },
-        "10": {
+        "7": {
           "caption": "Webcam",
           "description": "The peripheral device is a webcam."
         },


### PR DESCRIPTION
#### Related Issue: 
#1471 

#### Description of changes: 
This PR corrects the order of the enum values for the `peripheral_device.type_id` which was introduced in an earlier 1.7.0-dev PR (#1471). Without this update, the enums would be introduced to OCSF with numerical gaps.

NOTE: No update to changelog is needed since the enum was both introduced in and fixed in `1.7.0-dev`

## Before:

```json
        "7": {
          "caption": "Monitor",
          "description": "The peripheral device is a monitor."
        },
        "9": {
          "caption": "Microphone",
          "description": "The peripheral device is a microphone."
        },
        "10": {
          "caption": "Webcam",
          "description": "The peripheral device is a webcam."
```

## After:

```json
        "5": {
          "caption": "Monitor",
          "description": "The peripheral device is a monitor."
        },
        "6": {
          "caption": "Microphone",
          "description": "The peripheral device is a microphone."
        },
        "7": {
          "caption": "Webcam",
          "description": "The peripheral device is a webcam."
```


