### PR TITLE
Rename `event_log_actvity` to `event_log_activity` in the Event Log Activity class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Thankyou! -->
 
 
 ### Bugfixes
+ 1. Renamed `event_log_actvity` to `event_log_activity` in the Event Log Activity class.
 
 ### Deprecated
 

--- a/events/system/event_log_activity.json
+++ b/events/system/event_log_activity.json
@@ -3,7 +3,7 @@
   "caption": "Event Log Activity",
   "description": "Event Log Activity events report actions pertaining to the system's event logging service(s), such as disabling logging or clearing the log data.",
   "extends": "system",
-  "name": "event_log_actvity",
+  "name": "event_log_activity",
   "attributes": {
     "activity_id": {
       "enum": {


### PR DESCRIPTION
#### Description of changes:
The PR corrects the name of the Event Log Activity from `event_log_actvity` to `event_log_activity`.