### PR TITLE
Set parent `endpoint.uid` as observable instead of child `device.uid`

### DIFF
--- a/objects/device.json
+++ b/objects/device.json
@@ -147,7 +147,6 @@
       "requirement": "optional"
     },
     "uid": {
-      "observable": 47,
       "description": "The unique identifier of the device. For example the Windows TargetSID or AWS EC2 ARN.",
       "requirement": "recommended"
     },

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -130,6 +130,7 @@
       }
     },
     "uid": {
+      "observable": 47,
       "description": "The unique identifier of the endpoint."
     },
     "vlan_uid": {


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
We would like to set endpoint UID as an as an observables to help with UID based correlations. Instead of setting device.uid as the observable, setting it at the parent endpoint object allows the property to be inherited in other endpoint oriented obejcts like src & dst endpoint, etc. in addition device.

Changes: Update `endpoint.uid` as an Observable type - `type_id: 47`

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?