### PR TITLE
add uid to observable

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3814,6 +3814,11 @@
       "description": "URL where metadata about a configuration or resource is available (e.g., for SAML configurations). See specific usage.",
       "type": "url_t"
     },
+    "metadata_uid": {
+      "caption": "Metadata UID",
+      "description": "The unique identifier (<code>metadata.uid</code>) of the source event that this observable was extracted from. This field enables linking observables back to their originating event data when observables are stored in a separate location or system.",
+      "type": "string_t"
+    },
     "metrics": {
       "caption": "Metrics",
       "description": "The general purpose metrics associated with the event. See specific usage.",

--- a/objects/observable.json
+++ b/objects/observable.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "observable",
   "attributes": {
+    "metadata_uid": {
+      "description": "The unique identifier (<code>metadata.uid</code>) of the source event that this observable was extracted from. This field enables linking observables back to their originating event data when observables are stored in a separate location or system.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The full name of the observable attribute. The <code>name</code> is a pointer/reference to an attribute within the OCSF event data. For example: <code>file.name</code>. Array attributes may be represented in one of three ways. For example: <code>resources.uid</code>, <code>resources[].uid</code>, <code>resources[0].uid</code>.",
       "requirement": "recommended"


### PR DESCRIPTION

<img width="1763" height="228" alt="image" src="https://github.com/user-attachments/assets/db6b8284-9352-48ee-91dc-960aaeda97bc" />
This PR adds a new optional metadata_uid field to the observable object, enabling observables to maintain a reference back to their source event.

Changes:
Added metadata_uid attribute to observable object (objects/observable.json)
Type: string_t
Requirement: optional
Contains the unique identifier (metadata.uid) of the source event
Added metadata_uid dictionary entry (dictionary.json)
Provides schema definition and documentation for the new attribute

Motivation:
When observables are extracted from OCSF events and stored in separate locations or systems (e.g., threat intelligence platforms, observable databases, or SIEM systems), there is currently no standard way to trace them back to their originating event. This makes it difficult to:
Correlate observables with their source context
Perform root cause analysis
Maintain data lineage and audit trails

Impact:
This change enhances the observable object by:
Enabling bidirectional linking between observables and their source events
Supporting use cases where observables are stored separately from event data
Maintaining backward compatibility (field is optional)
Improving data lineage and traceability in security operations
{
  "name": "src_endpoint.ip",
  "type_id": 2,
  "value": "192.168.1.100",
  "metadata_uid": "550e8400-e29b-41d4-a716-446655440000"
}
