### PR TITLE
Relax `file` requirement in `job` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Thankyou! -->
   1. Set the `vendor_name` requirement to `recommended` in the `peripheral_device` object. [#1471](https://github.com/ocsf/ocsf-schema/pull/1471)
   1. Added `reporter` to the `metadata` object. [#1476](https://github.com/ocsf/ocsf-schema/pull/1476)
   1. Added `event_uid` and `type_uid` to the `observable` object. [#1503](https://github.com/ocsf/ocsf-schema/pull/1503)
+  1. Relaxed the `file` attribute requirement to `optional` in the `job` object. [#1509](https://github.com/ocsf/ocsf-schema/pull/1509)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/objects/job.json
+++ b/objects/job.json
@@ -18,7 +18,7 @@
     },
     "file": {
       "description": "The file that pertains to the job.",
-      "requirement": "required"
+      "requirement": "optional"
     },
     "last_run_time": {
       "description": "The time when the job was last run.",


### PR DESCRIPTION
Reason for relaxing requirement in related issue: https://github.com/ocsf/ocsf-schema/issues/1494

