### PR TITLE
Cross reference between `process` and  `win_service` objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,13 +76,14 @@ Thankyou! -->
  1. Added `function_invocation` to the `module` object. [#1497](https://github.com/ocsf/ocsf-schema/pull/1497)
   1. Relaxed the `file` attribute requirement to `optional` in the `job` object. [#1509](https://github.com/ocsf/ocsf-schema/pull/1509)
   1. Relaxed the `name` and `uid` requirement to `recommended` with `at_least_one` constraint in the `extension` object. [#1511](https://github.com/ocsf/ocsf-schema/pull/1511)
+ 1. 
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
   1. Added `Local (4)` enum to the `direction_id` attribute. [#1475](https://github.com/ocsf/ocsf-schema/pull/1475)
   1. Added `Atom (38)` enum as an available `type_id` for `win_resource` object. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
   1. Updated reference descriptions/urls for win_resource types, including `Directory (1)`, `Event (2)`, `Timer (3)`, `Device (4)`, `Mutant (5)`, `File (7)`, `Token (8)`, `Thread (9)`, `Section (10)`, `WindowStation (11)`, `Driver (15)`, `IoCompletion (16)`, `Controller (17)`, `SymbolicLink (18)`, `WmiGuid (19)`, `Process (20)`, `Profile (21)`, `Desktop (22)`, `KeyedEvent (23)`, `Adapter (24)`, `Callback (27)`, `Semaphore (28)`, `Job (29)`, `ALPC Port (32)`, `SAM_ALIAS (33)`, `SAM_GROUP (34)`, `SAM_USER (35)`, `SAM_DOMAIN (36)`, `SAM_SERVER (37)`, and `Atom (38)`. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
-
+  1. Added `hosting_process` and `service_dll`
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,8 @@ Thankyou! -->
   1. Added `Local (4)` enum to the `direction_id` attribute. [#1475](https://github.com/ocsf/ocsf-schema/pull/1475)
   1. Added `Atom (38)` enum as an available `type_id` for `win_resource` object. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
   1. Updated reference descriptions/urls for win_resource types, including `Directory (1)`, `Event (2)`, `Timer (3)`, `Device (4)`, `Mutant (5)`, `File (7)`, `Token (8)`, `Thread (9)`, `Section (10)`, `WindowStation (11)`, `Driver (15)`, `IoCompletion (16)`, `Controller (17)`, `SymbolicLink (18)`, `WmiGuid (19)`, `Process (20)`, `Profile (21)`, `Desktop (22)`, `KeyedEvent (23)`, `Adapter (24)`, `Callback (27)`, `Semaphore (28)`, `Job (29)`, `ALPC Port (32)`, `SAM_ALIAS (33)`, `SAM_GROUP (34)`, `SAM_USER (35)`, `SAM_DOMAIN (36)`, `SAM_SERVER (37)`, and `Atom (38)`. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
-  1. Added `hosting_process` and `service_dll`
+  1. Added `hosting_process`, `service_file` and `service_dll_file` to the `win_service` object
+  1. Added `hosted_services` to the Windows extension to the `process` object.
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,6 @@ Thankyou! -->
  1. Added `function_invocation` to the `module` object. [#1497](https://github.com/ocsf/ocsf-schema/pull/1497)
   1. Relaxed the `file` attribute requirement to `optional` in the `job` object. [#1509](https://github.com/ocsf/ocsf-schema/pull/1509)
   1. Relaxed the `name` and `uid` requirement to `recommended` with `at_least_one` constraint in the `extension` object. [#1511](https://github.com/ocsf/ocsf-schema/pull/1511)
- 1. 
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Thankyou! -->
 * #### Profiles
 * #### Objects
   1. Added `reporter` object. [#1476](https://github.com/ocsf/ocsf-schema/pull/1476)
+  1. Added Windows extension to the `process` object.
 * #### Observables
   1. Set `network_endpoint.uid` as an Observable type - `type_id: 48`. [#1502](https://github.com/ocsf/ocsf-schema/pull/1502)
  1. Added the `function_invocation` and `parameter` objects. [#1497](https://github.com/ocsf/ocsf-schema/pull/1497)
@@ -76,13 +77,15 @@ Thankyou! -->
  1. Added `function_invocation` to the `module` object. [#1497](https://github.com/ocsf/ocsf-schema/pull/1497)
   1. Relaxed the `file` attribute requirement to `optional` in the `job` object. [#1509](https://github.com/ocsf/ocsf-schema/pull/1509)
   1. Relaxed the `name` and `uid` requirement to `recommended` with `at_least_one` constraint in the `extension` object. [#1511](https://github.com/ocsf/ocsf-schema/pull/1511)
+  1. Added `hosting_process`, `service_file` and `service_dll_file` to the `win_service` object.
+  1. Added `hosted_services`, array to the `process` object.
+
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
   1. Added `Local (4)` enum to the `direction_id` attribute. [#1475](https://github.com/ocsf/ocsf-schema/pull/1475)
   1. Added `Atom (38)` enum as an available `type_id` for `win_resource` object. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
   1. Updated reference descriptions/urls for win_resource types, including `Directory (1)`, `Event (2)`, `Timer (3)`, `Device (4)`, `Mutant (5)`, `File (7)`, `Token (8)`, `Thread (9)`, `Section (10)`, `WindowStation (11)`, `Driver (15)`, `IoCompletion (16)`, `Controller (17)`, `SymbolicLink (18)`, `WmiGuid (19)`, `Process (20)`, `Profile (21)`, `Desktop (22)`, `KeyedEvent (23)`, `Adapter (24)`, `Callback (27)`, `Semaphore (28)`, `Job (29)`, `ALPC Port (32)`, `SAM_ALIAS (33)`, `SAM_GROUP (34)`, `SAM_USER (35)`, `SAM_DOMAIN (36)`, `SAM_SERVER (37)`, and `Atom (38)`. [#1477](https://github.com/ocsf/ocsf-schema/pull/1477)
-  1. Added `hosting_process`, `service_file` and `service_dll_file` to the `win_service` object
   1. Added `hosted_services` to the Windows extension to the `process` object.
 
 ### Bugfixes

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -211,23 +211,23 @@
     },
     "hosting_process": {
       "caption": "Hosting Process",
-      "description": "The process that is hosting this service",
+      "description": "The process that is hosting this service.",
       "type": "process_entity"
     },
     "hosted_services": {
       "caption": "Hosted Services",
-      "description": "The services that this process that is hosting",
-      "type": "win_service"
+      "description": "The services that this process that is hosting.",
+      "type": "win_service",
       "is_array": true
    },
     "service_file": {
       "caption": "Service File",
-      "description": "The executable file which is used to launch the service",
+      "description": "The executable file which is used to launch the service.",
       "type": "file"
     },
     "service_dll_file": {
       "caption": "Service DLL",
-      "description": "The DLL which implements the service",
+      "description": "The DLL which implements the service.",
       "type": "file"
     },
     "win_resource": {

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -209,6 +209,16 @@
         }
       }
     },
+    "hosting_process": {
+      "caption": "Hosting Process",
+      "description": "The process that is hosting this service",
+      "type": "process_entity"
+    },
+    "service_dll": {
+      "caption": "Service DLL",
+      "description": "The DLL which implements this service",
+      "type": "string_t"
+    },
     "win_resource": {
       "caption": "Windows Resource",
       "description": "The Windows resource object that was accessed, such as a mutant or timer.",

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -216,18 +216,18 @@
     },
     "hosted_services": {
       "caption": "Hosted Services",
-      "description": "The services that this process that is hosting.",
+      "description": "The Windows services that this process is hosting.",
       "type": "win_service",
       "is_array": true
    },
     "service_file": {
       "caption": "Service File",
-      "description": "The executable file which is used to launch the service.",
+      "description": "For a user mode service (<code>service_type_id</code> 3 or 4) this is the executable program that the SCM launches as the service process.<br>For a kernel mode driver (<code>service_type_id</code> 1 or 2) this is the driver file loaded into the kernel at the request of the SCM. ",
       "type": "file"
     },
     "service_dll_file": {
       "caption": "Service DLL",
-      "description": "The DLL which implements the service.",
+      "description": "For a shared user mode service (<code>service_type_id</code> is 4) this is the DLL that gets loaded by the generic service host process (e.g. <code>svchost.exe</code>) to implement the service.",
       "type": "file"
     },
     "win_resource": {

--- a/extensions/windows/dictionary.json
+++ b/extensions/windows/dictionary.json
@@ -214,10 +214,21 @@
       "description": "The process that is hosting this service",
       "type": "process_entity"
     },
-    "service_dll": {
+    "hosted_services": {
+      "caption": "Hosted Services",
+      "description": "The services that this process that is hosting",
+      "type": "win_service"
+      "is_array": true
+   },
+    "service_file": {
+      "caption": "Service File",
+      "description": "The executable file which is used to launch the service",
+      "type": "file"
+    },
+    "service_dll_file": {
       "caption": "Service DLL",
-      "description": "The DLL which implements this service",
-      "type": "string_t"
+      "description": "The DLL which implements the service",
+      "type": "file"
     },
     "win_resource": {
       "caption": "Windows Resource",

--- a/extensions/windows/objects/process.json
+++ b/extensions/windows/objects/process.json
@@ -1,11 +1,11 @@
 {
   "caption": "Windows Process",
-  "description": "Extends the process object to add Windows specific fields",
+  "description": "Extends the process object to add Windows specific fields.",
   "extends": "process",
   "attributes": {
     "hosted_services": {
       "requirement": "optional"
-    },
+    }
   },
   "constraints": {
     "at_least_one": [

--- a/extensions/windows/objects/process.json
+++ b/extensions/windows/objects/process.json
@@ -1,0 +1,17 @@
+{
+  "caption": "Windows Process",
+  "description": "Extends the process object to add Windows specific fields",
+  "extends": "process",
+  "attributes": {
+    "hosted_services": {
+      "requirement": "optional"
+    },
+  },
+  "constraints": {
+    "at_least_one": [
+      "pid",
+      "uid",
+      "cpid"
+    ]
+  }
+}

--- a/extensions/windows/objects/process.json
+++ b/extensions/windows/objects/process.json
@@ -1,5 +1,5 @@
 {
-  "caption": "Windows Process",
+  "caption": "Process",
   "description": "Extends the process object to add Windows specific fields.",
   "extends": "process",
   "attributes": {

--- a/extensions/windows/objects/win_service.json
+++ b/extensions/windows/objects/win_service.json
@@ -45,7 +45,10 @@
     "service_type_id": {
       "requirement": "recommended"
     },
-    "service_dll": {
+    "service_file": {
+      "requirement": "recommended"
+    },
+    "service_dll_file": {
       "requirement": "optional"
     },
     "hosting_process": {

--- a/extensions/windows/objects/win_service.json
+++ b/extensions/windows/objects/win_service.json
@@ -44,6 +44,12 @@
     },
     "service_type_id": {
       "requirement": "recommended"
+    },
+    "service_dll": {
+      "requirement": "optional"
+    },
+    "hosting_process": {
+      "requirement": "optional"
     }
   },
   "constraints": {


### PR DESCRIPTION
#### Related Issue: 

https://github.com/ocsf/ocsf-schema/issues/1525

#### Description of changes:

Add field to `win_service` object to refer to the process hosting it.
Add fields to `win_service` object so that the executable file, and the optional dll file,  can be fully described

Add array field to `process` to refer the the service(s) that the process is currently hosting.


