### PR TITLE
Updated the MITRE ATT&CK Matrix URL as it has changed.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -3895,7 +3895,7 @@
       "references": [
         {
           "description": "ATT&CK® Matrix",
-          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+          "url": "https://attack.mitre.org"
         },
         {
           "description": "ATLAS™ Matrix",
@@ -6014,7 +6014,7 @@
       "references": [
         {
           "description": "ATT&CK® Matrix",
-          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+          "url": "https://attack.mitre.org"
         },
         {
           "description": "ATLAS™ Matrix",
@@ -6090,7 +6090,7 @@
       "references": [
         {
           "description": "ATT&CK® Matrix",
-          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+          "url": "https://attack.mitre.org"
         },
         {
           "description": "ATLAS™ Matrix",
@@ -6201,7 +6201,7 @@
       "references": [
         {
           "description": "ATT&CK® Matrix",
-          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+          "url": "https://attack.mitre.org"
         },
         {
           "description": "ATLAS™ Matrix",

--- a/objects/attack.json
+++ b/objects/attack.json
@@ -34,7 +34,7 @@
   "references": [
     {
       "description": "ATT&CK® Matrix",
-      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+      "url": "https://attack.mitre.org"
     },
     {
       "description": "ATLAS™ Matrix",

--- a/objects/mitigation.json
+++ b/objects/mitigation.json
@@ -22,7 +22,7 @@
   "references": [
     {
       "description": "ATT&CK® Matrix",
-      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+      "url": "https://attack.mitre.org"
     },
     {
       "description": "ATLAS™ Matrix",

--- a/objects/sub_technique.json
+++ b/objects/sub_technique.json
@@ -18,7 +18,7 @@
   "references": [
     {
       "description": "ATT&CK® Matrix",
-      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+      "url": "https://attack.mitre.org"
     },
     {
       "description": "ATLAS™ Matrix",

--- a/objects/tactic.json
+++ b/objects/tactic.json
@@ -18,7 +18,7 @@
   "references": [
     {
       "description": "ATT&CK® Matrix",
-      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+      "url": "https://attack.mitre.org"
     },
     {
       "description": "ATLAS™ Matrix",

--- a/objects/technique.json
+++ b/objects/technique.json
@@ -18,7 +18,7 @@
   "references": [
     {
       "description": "ATT&CK® Matrix",
-      "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+      "url": "https://attack.mitre.org"
     },
     {
       "description": "ATLAS™ Matrix",


### PR DESCRIPTION
#### Related Issue: N/A

#### Description of changes:
The original URL we were using for the MITRE ATT&CK Matrix had changed so our `References` links needed to be updated.
This PR updates the URLs.