### PR TITLE
Issue 1542.  Add `signatures` array to file object.  Deprecate `signature`.  

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,10 @@ Thankyou! -->
 
 ### Improved
 * #### Objects
-  1. Added `signatures` to the `file` object. [#0](https://github.com/ocsf/ocsf-schema/pull/0)
+  1. Added `signatures` to the `file` object. [#1546](https://github.com/ocsf/ocsf-schema/pull/1546)
 
 ### Deprecated
-1. Deprecated the `signature` attribute of the file object in favour of the `signatures` attribute. [#0](https://github.com/ocsf/ocsf-schema/pull/0)
+1. Deprecated the `signature` attribute of the file object in favour of the `signatures` attribute. [#1546](https://github.com/ocsf/ocsf-schema/pull/1546)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ Thankyou! -->
 * #### Event Classes
   1. Removed erroneous `at_least_one` constraint in `Live Evidence Info` class [#1357](https://github.com/ocsf/ocsf-schema/pull/1537)
 
+### Improved
+* #### Objects
+  1. Added `signatures` to the `file` object. [#0](https://github.com/ocsf/ocsf-schema/pull/0)
+
+### Deprecated
+1. Deprecated the `signature` attribute of the file object in favour of the `signatures` attribute. [#0](https://github.com/ocsf/ocsf-schema/pull/0)
+
+
+
+
 ## [v1.7.0] - Nov 14th, 2025
 
 ### Added

--- a/objects/file.json
+++ b/objects/file.json
@@ -115,6 +115,13 @@
       "requirement": "optional"
     },
     "signature": {
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>signatures</code> attribute.",
+        "since": "1.8.0"
+      }
+    },
+    "signatures": {
       "requirement": "optional"
     },
     "size": {


### PR DESCRIPTION
#### Related Issue: 

[1542](https://github.com/ocsf/ocsf-schema/issues/1542)

#### Description of changes:

 Add `signatures` array to file object.  
Deprecate `signature`.  