### PR TITLE
Add Imphash finger print. Add imported_symbols to file object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,8 @@ Thankyou! -->
   1. Added `ai_role_id`, `ai_role` attributes for AI communication context with proper sibling relationship. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
   1. Added `prompt_tokens`, `completion_tokens`, `total_tokens` attributes for AI token usage metrics. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
   1. Added `embedding_model` attribute for AI retrieval systems. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
-  1. Added `imported_symbols` attribute for reporting an executable file's imports.
-  1. Added `Imphash (18)` enum to the `fingerprint` attribute.
+  1. Added `imported_symbols` attribute for reporting an executable file's imports.  [#1553](https://github.com/ocsf/ocsf-schema/pull/1553)
+  1. Added `Imphash (18)` enum to the `algorithm_id` attribute of the `fingerprint` object. [#1553](https://github.com/ocsf/ocsf-schema/pull/1553)
 
 ### Improved
 * #### Categories
@@ -67,7 +67,7 @@ Thankyou! -->
 * #### Profiles
 * #### Objects
   1. Extended `database` object with AI-specific database types (`Vector (7)`, `Knowledge Graph (8)`) and `embedding_model` field for AI retrieval systems. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
-  1. Added `imported_symbols` attribute to the `file` object.
+  1. Added `imported_symbols` attribute to the `file` object.  [#1553](https://github.com/ocsf/ocsf-schema/pull/1553)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ Thankyou! -->
   1. Added `ai_role_id`, `ai_role` attributes for AI communication context with proper sibling relationship. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
   1. Added `prompt_tokens`, `completion_tokens`, `total_tokens` attributes for AI token usage metrics. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
   1. Added `embedding_model` attribute for AI retrieval systems. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
+  1. Added `imported_symbols` attribute for reporting an executable file's imports.
+  1. Added `Imphash (18)` enum to the `fingerprint` attribute.
 
 ### Improved
 * #### Categories
@@ -65,6 +67,7 @@ Thankyou! -->
 * #### Profiles
 * #### Objects
   1. Extended `database` object with AI-specific database types (`Vector (7)`, `Knowledge Graph (8)`) and `embedding_model` field for AI retrieval systems. [#1488](https://github.com/ocsf/ocsf-schema/pull/1488)
+  1. Added `imported_symbols` attribute to the `file` object.
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/dictionary.json
+++ b/dictionary.json
@@ -2997,6 +2997,12 @@
       "description": "The impact as an integer value of the finding, valid range 0-100.",
       "type": "integer_t"
     },
+    "imported_symbols": {
+      "caption": "Imported Symbols",
+      "description": "A list of symbols imported by the executable file.",
+      "type": "string_t",
+      "is_array": true
+    },
     "injection_type": {
       "caption": "Injection Type",
       "description": "The process injection method, normalized to the caption of the injection_type_id value. In the case of 'Other', it is defined by the event source.",

--- a/objects/file.json
+++ b/objects/file.json
@@ -56,6 +56,9 @@
     "hashes": {
       "requirement": "recommended"
     },
+    "imported_symbols": {
+      "requirement": "optional"
+    },
     "internal_name": {
       "description": "The name of the file as identified within the file itself. This contrasts with the name by which the file is known on disk. Where available, the internal name is widely used by security practitioners and detection content because the on-disk file name is not reliable. On the Windows OS, most PE files contain a <a href=\"https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource\">VERSIONINFO</a> resource from which the internal name can be obtained. On macOS, binaries can optionally embed a copy of the application's Info.plist file which in turn contains the name of the executable.",
       "requirement": "optional"

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -170,7 +170,7 @@
         },
         "18": {
           "caption": "Imphash",
-          "description": "Mandiant's 128-bit hash of a PE file's imports.",
+          "description": "Import hash (imphash) based on the import table of a Portable Executable (PE) file producing a 128-bit (16-byte) hash value.",
           "references": [
             {
               "description": "Tracking Malware with Import Hashing",

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -168,6 +168,16 @@
             }
           ]
         },
+        "18": {
+          "caption": "Imphash",
+          "description": "Mandiant's 128-bit hash of a PE file's imports.",
+          "references": [
+            {
+              "description": "Tracking Malware with Import Hashing",
+              "url": "https://cloud.google.com/blog/topics/threat-intelligence/tracking-malware-import-hashing/"
+            }
+          ]
+        },
         "99": {
           "caption": "Other"
         }


### PR DESCRIPTION
#### Related Issue:  

[1551 : Add information about a file's imports to the file object](https://github.com/ocsf/ocsf-schema/issues/1551)

#### Description of changes:

Added an entry for the ImpHash algorithm to the fingerprint algorithm ID enumeration

Added an optional array of strings to a file object for reporting an executable file's imports.
