### PR TITLE
Adding provider to resource_details object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Thankyou! -->
   1. Added `fingerprints` attribute to the `network_endpoint` object. [#1560](https://github.com/ocsf/ocsf-schema/pull/1560)
   1. Added `token` as an attribute to the `api` object. [#1429](https://github.com/ocsf/ocsf-schema/pull/1429)
   1. Added `created_time` attribute back to the `authentication_token` object with improved description. [#1429](https://github.com/ocsf/ocsf-schema/pull/1429)
+  1. Added `provider` to the `resource_details` object via `cloud` profile. [#1566](https://github.com/ocsf/ocsf-schema/pull/1566)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/objects/cloud.json
+++ b/objects/cloud.json
@@ -20,7 +20,8 @@
       "requirement": "optional"
     },
     "provider": {
-      "description": "The unique name of the Cloud services provider where the event or finding was created, such as AWS, MS Azure, GCP, etc.",
+      "caption": "Cloud Provider",
+      "description": "The unique name of the Cloud services provider where the event or finding was created. Examples include AWS, Azure, GCP (Google Cloud Platform), Oracle Cloud, IBM Cloud, Alibaba Cloud, or other public, private, or hybrid cloud providers.",
       "requirement": "required"
     },
     "region": {

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -45,7 +45,7 @@
     },
     "provider": {
       "caption": "Cloud Provider",
-      "description": "The cloud service provider that hosts or manages the resource. Examples include AWS, Azure, GCP (Google Cloud Platform), Oracle Cloud, IBM Cloud, Alibaba Cloud, or other public, private, or hybrid cloud providers.",
+      "description": "The cloud service provider that hosts or manages the resource. This field is typically used when the resource is managed by a different provider than the one generating the event or finding. Examples include AWS, Azure, GCP (Google Cloud Platform), Oracle Cloud, IBM Cloud, Alibaba Cloud, or other public, private, or hybrid cloud providers.",
       "profile": "cloud",
       "requirement": "optional"
     },

--- a/objects/resource_details.json
+++ b/objects/resource_details.json
@@ -43,6 +43,12 @@
       "description": "The details of the entity that owns the resource. This object includes properties such as the owner's name, unique identifier, type, domain, and other relevant attributes that help identify the resource owner within the environment.",
       "requirement": "recommended"
     },
+    "provider": {
+      "caption": "Cloud Provider",
+      "description": "The cloud service provider that hosts or manages the resource. Examples include AWS, Azure, GCP (Google Cloud Platform), Oracle Cloud, IBM Cloud, Alibaba Cloud, or other public, private, or hybrid cloud providers.",
+      "profile": "cloud",
+      "requirement": "optional"
+    },
     "region": {
       "description": "The cloud region where the resource is hosted, as defined by the cloud provider. This represents the physical or logical geographic area containing the infrastructure supporting the resource. Examples include AWS regions (us-east-1, eu-west-1), Azure regions (East US, West Europe), GCP regions (us-central1, europe-west1), or Oracle Cloud regions (us-ashburn-1, uk-london-1).",
       "profile": "cloud",


### PR DESCRIPTION
#### Related Issue: n/a. Minor addition to the resource_details object cloud profile, to help identify the cloud service provider, of the resource in question.

#### Description of changes:
1. Adding `provider` to `resource_details` object
2. Updating description of `provider` in `cloud` object
3. Adding captions to `provider` in both `cloud` & `resource_details` object
