### PR TITLE
Issue 1554: Add Network Initiator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,19 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `initiator` and `initiator_id` attributes for identifying which endpoint initiated a network communication, with generic `Unknown (0)` and `Other (99)` enums. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
+
+### Improved
+* #### Event Classes
+  1. Added `initiator_id` and `initiator` to `Network Activity` with network-specific enums `Source Endpoint (1)` and `Destination Endpoint (2)`, and updated `src_endpoint` and `dst_endpoint` descriptions to reflect bi-flow and asymmetric flow scenarios. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
+
 ### Bugfixes
 1. Fixed the static anti-pattern checker so dictionary attributes are analyzed with the full compiled dictionary; the `missing-sibling` rule no longer false-positives when the sibling exists in `dictionary.json`. [#1613](https://github.com/ocsf/ocsf-schema/pull/1613)
+
+### Deprecated
+1. Deprecated `is_src_dst_assignment_known` dictionary attribute and its usage in `Network Activity` in favour of `initiator_id`. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)

--- a/dictionary.json
+++ b/dictionary.json
@@ -3261,7 +3261,7 @@
     },
     "initiator": {
       "caption": "Initiator",
-      "description": "The initiator. See specific usage.",
+      "description": "The initiator of an activity or operation. See specific usage.",
       "type": "string_t"
     },
     "initiator_id": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -3273,12 +3273,6 @@
         "0": {
           "caption": "Unknown"
         },
-        "1": {
-          "caption": "Source Endpoint"
-        },
-        "2": {
-          "caption": "Destination Endpoint"
-        },
         "99": {
           "caption": "Other"
         }

--- a/dictionary.json
+++ b/dictionary.json
@@ -3261,30 +3261,26 @@
     },
     "initiator": {
       "caption": "Initiator",
-      "description": "The human-readable label identifying which endpoint initiated the network communication. See specific usage in the <code>network_activity</code> class.",
+      "description": "The initiator. See specific usage.",
       "type": "string_t"
     },
     "initiator_id": {
       "caption": "Initiator ID",
-      "description": "The normalized identifier indicating which endpoint initiated the network communication. Supersedes <code>is_src_dst_assignment_known</code>. A value of 1 means <code>src_endpoint</code> is the initiator; a value of 2 means <code>dst_endpoint</code> is the initiator. Use this field when bi-flow or asymmetric flow data may cause the source and destination roles to appear reversed relative to the actual connection initiator. See specific usage in the <code>network_activity</code> class.",
+      "description": "The normalized identifier of the <code>initiator</code>. See specific usage.",
       "sibling": "initiator",
       "type": "integer_t",
       "enum": {
         "0": {
-          "caption": "Unknown",
-          "description": "The initiating endpoint cannot be determined from the available flow data."
+          "caption": "Unknown"
         },
         "1": {
-          "caption": "Source Endpoint",
-          "description": "The <code>src_endpoint</code> initiated the communication. The source/destination assignment correctly reflects the direction of initiation."
+          "caption": "Source Endpoint"
         },
         "2": {
-          "caption": "Destination Endpoint",
-          "description": "The <code>dst_endpoint</code> initiated the communication. This occurs in bi-flow or asymmetric flow scenarios where individual directional flows show the response side as the source, making the assignment appear reversed relative to the true initiator."
+          "caption": "Destination Endpoint"
         },
         "99": {
-          "caption": "Other",
-          "description": "The initiating endpoint is known but does not match a defined value. See the <code>initiator</code> attribute for the source-specific value."
+          "caption": "Other"
         }
       }
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -3259,6 +3259,35 @@
       "description": "The unique identifier of a VM instance.",
       "type": "string_t"
     },
+    "initiator": {
+      "caption": "Initiator",
+      "description": "The human-readable label identifying which endpoint initiated the network communication. See specific usage in the <code>network_activity</code> class.",
+      "type": "string_t"
+    },
+    "initiator_id": {
+      "caption": "Initiator ID",
+      "description": "The normalized identifier indicating which endpoint initiated the network communication. Supersedes <code>is_src_dst_assignment_known</code>. A value of 1 means <code>src_endpoint</code> is the initiator; a value of 2 means <code>dst_endpoint</code> is the initiator. Use this field when bi-flow or asymmetric flow data may cause the source and destination roles to appear reversed relative to the actual connection initiator. See specific usage in the <code>network_activity</code> class.",
+      "sibling": "initiator",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The initiating endpoint cannot be determined from the available flow data."
+        },
+        "1": {
+          "caption": "Source Endpoint",
+          "description": "The <code>src_endpoint</code> initiated the communication. The source/destination assignment correctly reflects the direction of initiation."
+        },
+        "2": {
+          "caption": "Destination Endpoint",
+          "description": "The <code>dst_endpoint</code> initiated the communication. This occurs in bi-flow or asymmetric flow scenarios where individual directional flows show the response side as the source, making the assignment appear reversed relative to the true initiator."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The initiating endpoint is known but does not match a defined value. See the <code>initiator</code> attribute for the source-specific value."
+        }
+      }
+    },
     "integrity": {
       "caption": "Integrity",
       "description": "The process integrity level, normalized to the caption of the integrity_id value. In the case of 'Other', it is defined by the event source (Windows only).",
@@ -3498,7 +3527,11 @@
     "is_src_dst_assignment_known": {
       "caption": "Source/Destination Assignment Known",
       "description": "<code>true</code> denotes that <code>src_endpoint</code> and <code>dst_endpoint</code> correctly identify the initiator and responder respectively. <code>false</code> denotes that the event source has arbitrarily assigned one peer to <code>src_endpoint</code> and the other to <code>dst_endpoint</code>, in other words that initiator and responder are not being asserted. This can occur, for example, when the event source is a network appliance that has not observed the initiation of a given connection. In the absence of this attribute, interpretation of the initiator and responder is implementation-specific.",
-      "type": "boolean_t"
+      "type": "boolean_t",
+      "@deprecated": {
+        "message": "Use <code>initiator_id</code> instead, which provides richer semantics for bi-flow and asymmetric flow scenarios.",
+        "since": "1.9.0"
+      }
     },
     "is_superseded": {
       "caption": "The patch is superseded.",

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -38,14 +38,26 @@
       }
     },
     "dst_endpoint": {
-      "description": "The responder of the network connection. In some contexts an event source cannot correctly identify the responder. Refer to <code>is_src_dst_assignment_known</code> for certainty."
+      "description": "The destination endpoint of the network connection — typically the responder. In bi-flow or asymmetric flow scenarios, this endpoint may represent the true initiator of the original connection. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
-    "is_src_dst_assignment_known": {
+    "initiator": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "initiator_id": {
       "group": "primary",
       "requirement": "recommended"
     },
+    "is_src_dst_assignment_known": {
+      "group": "primary",
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use <code>initiator_id</code> instead, which provides richer semantics for bi-flow and asymmetric flow scenarios.",
+        "since": "1.9.0"
+      }
+    },
     "src_endpoint": {
-      "description": " The initiator of the network connection. In some contexts an event source cannot correctly identify the initiator. Refer to <code>is_src_dst_assignment_known</code> for certainty."
+      "description": "The source endpoint of the network connection — typically the initiator. In bi-flow or asymmetric flow scenarios, this endpoint may represent the response side of a connection originally initiated by the destination. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
     "url": {
       "description": "The URL details relevant to the network traffic.",

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -42,7 +42,6 @@
     },
     "initiator": {
       "description": "The normalized caption of <code>initiator_id</code>. One of: <code>Source Endpoint</code>, <code>Destination Endpoint</code>, <code>Unknown</code>, or <code>Other</code>.",
-      "group": "primary",
       "requirement": "optional"
     },
     "initiator_id": {

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -41,11 +41,11 @@
       "description": "The destination endpoint of the network activity — typically the responder. In bi-flow or asymmetric flow scenarios, this endpoint may represent the true initiator of the original communication. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
     "initiator": {
-      "description": "The normalized caption of <code>initiator_id</code>. One of: <code>Source Endpoint</code>, <code>Destination Endpoint</code>, <code>Unknown</code>, or <code>Other</code>.",
+      "description": "The endpoint that initiated the network communication, normalized to the caption of <code>initiator_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
       "requirement": "optional"
     },
     "initiator_id": {
-      "description": "Indicates which endpoint initiated the network communication. Use this field to disambiguate source and destination roles in bi-directional or asymmetric flow scenarios.",
+      "description": "The normalized identifier of the endpoint that initiated the network communication. Use this field to disambiguate source and destination roles in bi-directional or asymmetric flow scenarios.",
       "group": "primary",
       "requirement": "recommended",
       "enum": {

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -41,10 +41,12 @@
       "description": "The destination endpoint of the network connection — typically the responder. In bi-flow or asymmetric flow scenarios, this endpoint may represent the true initiator of the original connection. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
     "initiator": {
+      "description": "The normalized caption of <code>initiator_id</code>. One of: <code>Source Endpoint</code>, <code>Destination Endpoint</code>, <code>Unknown</code>, or <code>Other</code>.",
       "group": "primary",
       "requirement": "optional"
     },
     "initiator_id": {
+      "description": "Indicates which endpoint initiated the network communication. Use this field to disambiguate source and destination roles when the event source represents a bi-directional flow as two separate unidirectional flows, or when a network appliance did not observe the connection handshake and has arbitrarily assigned endpoints. <code>1</code> (Source Endpoint) means <code>src_endpoint</code> is the true initiator and the assignment is correct. <code>2</code> (Destination Endpoint) means <code>dst_endpoint</code> is the true initiator and the assignment is reversed — the response side appears as the source. <code>0</code> (Unknown) means the initiator cannot be determined. Supersedes <code>is_src_dst_assignment_known</code>.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -38,7 +38,7 @@
       }
     },
     "dst_endpoint": {
-      "description": "The destination endpoint of the network connection — typically the responder. In bi-flow or asymmetric flow scenarios, this endpoint may represent the true initiator of the original connection. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
+      "description": "The destination endpoint of the network activity — typically the responder. In bi-flow or asymmetric flow scenarios, this endpoint may represent the true initiator of the original communication. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
     "initiator": {
       "description": "The normalized caption of <code>initiator_id</code>. One of: <code>Source Endpoint</code>, <code>Destination Endpoint</code>, <code>Unknown</code>, or <code>Other</code>.",
@@ -74,7 +74,7 @@
       }
     },
     "src_endpoint": {
-      "description": "The source endpoint of the network connection — typically the initiator. In bi-flow or asymmetric flow scenarios, this endpoint may represent the response side of a connection originally initiated by the destination. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
+      "description": "The source endpoint of the network activity — typically the initiator. In bi-flow or asymmetric flow scenarios, this endpoint may represent the response side of communication originally initiated by the destination. Use <code>initiator_id</code> to determine which endpoint actually initiated the communication."
     },
     "url": {
       "description": "The URL details relevant to the network traffic.",

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -46,9 +46,25 @@
       "requirement": "optional"
     },
     "initiator_id": {
-      "description": "Indicates which endpoint initiated the network communication. Use this field to disambiguate source and destination roles when the event source represents a bi-directional flow as two separate unidirectional flows, or when a network appliance did not observe the connection handshake and has arbitrarily assigned endpoints. <code>1</code> (Source Endpoint) means <code>src_endpoint</code> is the true initiator and the assignment is correct. <code>2</code> (Destination Endpoint) means <code>dst_endpoint</code> is the true initiator and the assignment is reversed — the response side appears as the source. <code>0</code> (Unknown) means the initiator cannot be determined. Supersedes <code>is_src_dst_assignment_known</code>.",
+      "description": "Indicates which endpoint initiated the network communication. Use this field to disambiguate source and destination roles in bi-directional or asymmetric flow scenarios.",
       "group": "primary",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "enum": {
+        "0": {
+          "caption": "Unknown"
+        },
+        "1": {
+          "caption": "Source Endpoint",
+          "description": "The <code>src_endpoint</code> is the true initiator and the source/destination assignment is correct."
+        },
+        "2": {
+          "caption": "Destination Endpoint",
+          "description": "The <code>dst_endpoint</code> is the true initiator and the source/destination assignment is reversed."
+        },
+        "99": {
+          "caption": "Other"
+        }
+      }
     },
     "is_src_dst_assignment_known": {
       "group": "primary",

--- a/events/network/network_activity.json
+++ b/events/network/network_activity.json
@@ -67,7 +67,7 @@
     },
     "is_src_dst_assignment_known": {
       "group": "primary",
-      "requirement": "optional",
+      "requirement": "recommended",
       "@deprecated": {
         "message": "Use <code>initiator_id</code> instead, which provides richer semantics for bi-flow and asymmetric flow scenarios.",
         "since": "1.9.0"


### PR DESCRIPTION
#### Related Issue: 
#1554 

#### Description of changes:
  ---
  dictionary.json

  - Added initiator attribute (string_t, sibling to initiator_id)
  - Added initiator_id attribute (integer_t) with generic enums 0 (Unknown) and 99 (Other)
  - Deprecated `is_src_dst_assignment_known` (since 1.9.0), pointing to initiator_id as the replacement

  ---
  events/network/network_activity.json

  - Added `initiator` — recommended caption sibling for `initiator_id`
  - Added `initiator_id` — marked recommended, with network-specific enum override:
    - 0 Unknown
    - 1 Source Endpoint (`src_endpoint` is the true initiator)
    - 2 Destination Endpoint (`dst_endpoint` is the true initiator, assignment is reversed)
    - 99 Other
  - Deprecated `is_src_dst_assignment_known` — downgraded from recommended to optional, with deprecation annotation
  - Updated `src_endpoint` description — clarifies its role in bi-flow/asymmetric scenarios, directs to `initiator_id`
  - Updated `dst_endpoint` description — same treatment as src_endpoint

<img width="1474" height="828" alt="image" src="https://github.com/user-attachments/assets/0d549f55-feb0-47da-b4bd-6cb260ae3abb" />

<img width="1493" height="686" alt="image" src="https://github.com/user-attachments/assets/aa7afc23-cb65-44c4-ab30-524ee137b91d" />
