### PR TITLE
Clarify time field convention for aggregate events

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -42,6 +42,11 @@
       "uid": 8,
       "caption": "Unmanned Systems",
       "description": "Unmanned Systems events report the activity, existence, and/or state of unmanned systems for tracking, mission planning, and other related activities."
+    },
+    "ai": {
+      "uid": 9,
+      "caption": "AI Activity",
+      "description": "AI Activity events report the lifecycle and control-plane operations of autonomous AI agents, including delegation issuance, revocation, expiry, and completion."
     }
   }
 }

--- a/dictionary.json
+++ b/dictionary.json
@@ -6624,7 +6624,7 @@
     },
     "time": {
       "caption": "Event Time",
-      "description": "The normalized event occurrence time or the finding creation time.",
+      "description": "The normalized event occurrence time or the finding creation time. See specific usage.",
       "type": "timestamp_t"
     },
     "timespan": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -6624,7 +6624,7 @@
     },
     "time": {
       "caption": "Event Time",
-      "description": "The normalized event occurrence time or the finding creation time. See specific usage.",
+      "description": "The normalized event occurrence time or the finding creation time.",
       "type": "timestamp_t"
     },
     "timespan": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -216,6 +216,11 @@
       "type": "agent",
       "is_array": true
     },
+    "ai_agent": {
+      "caption": "AI Agent",
+      "description": "The AI Agent object describes an autonomous AI agent acting under delegated authority. Distinguished from the agent object (security sensors) and from human principals.",
+      "type": "ai_agent"
+    },
     "ai_model": {
       "caption": "AI Model",
       "description": "The AI Model object describes the characteristics of an AI/ML model. Examples include language models like GPT-4, embedding models like text-embedding-ada-002, and computer vision models like CLIP.",
@@ -1853,6 +1858,27 @@
       "caption": "Dependency Chain",
       "description": "Information about the chain of dependencies related to the issue as reported by an Application Security or Vulnerability Management tool. E.g., <code>serverless-offline -> @serverless/utils -> memoizee -> es5-ext</code>.",
       "type": "string_t"
+    },
+    "delegation": {
+      "caption": "Delegation",
+      "description": "The Delegation object describes a durable authorization context issued by a principal to an autonomous agent, representing delegated authority to act on the principal's behalf.",
+      "type": "delegation"
+    },
+    "delegation_lineage": {
+      "caption": "Delegation Lineage",
+      "description": "A directed graph representing the full delegation ancestry tree rooted at the current delegation. Nodes are delegation_node objects carrying delegation context, agent identity, and model information. Directed edges represent parent-child relationships established via sub-agent spawning or re-delegation. Populated on Delegation Activity lifecycle events (Complete, Revoke, Expire) as a materialized view of the delegation DAG for lineage queries.",
+      "type": "delegation_lineage"
+    },
+    "delegation_node": {
+      "caption": "Delegation Node",
+      "description": "A graph node representing a delegation in a delegation lineage graph, combining node identity with flattened delegation attributes and the agent to which authority was delegated.",
+      "type": "delegation_node"
+    },
+    "delegation_nodes": {
+      "caption": "Delegation Nodes",
+      "description": "The collection of delegation nodes in a delegation lineage graph.",
+      "type": "delegation_node",
+      "is_array": true
     },
     "depth": {
       "caption": "CVSS Depth",
@@ -3565,6 +3591,11 @@
       "description": "The identifier of the issuer. See specific usage.",
       "type": "string_t"
     },
+    "issuer_uid": {
+      "caption": "Issuer ID",
+      "description": "The unique identifier of the trusted boundary that issued a delegation or credential.",
+      "type": "string_t"
+    },
     "ja3_hash": {
       "caption": "JA3 Hash",
       "description": "The MD5 hash of a JA3 string.",
@@ -4067,6 +4098,22 @@
       "caption": "Message",
       "description": "The description of the event/finding, as defined by the source.",
       "type": "string_t"
+    },
+    "manifest_uid": {
+      "caption": "Manifest ID",
+      "description": "The identifier of the capability manifest describing an agent's declared skills, expected sub-agent dependencies, and tool scopes.",
+      "type": "string_t"
+    },
+    "manifest_version": {
+      "caption": "Manifest Version",
+      "description": "The version of the capability manifest active at the time of agent registration or update.",
+      "type": "string_t"
+    },
+    "declared_agents": {
+      "caption": "Declared Agents",
+      "description": "The sub-agents an agent is declared to depend on, snapshotted from its capability manifest at registration time.",
+      "type": "ai_agent",
+      "is_array": true
     },
     "message_context": {
       "caption": "Message Context",

--- a/events/ai/agent_activity.json
+++ b/events/ai/agent_activity.json
@@ -1,0 +1,100 @@
+{
+  "uid": 2,
+  "caption": "Agent Activity",
+  "description": "Agent Activity events report lifecycle transitions of an autonomous AI agent — the actor that performs tasks under delegated authority. These events track the agent's own lifecycle, independent of any particular delegation. An agent may serve multiple delegations across its lifetime; this event class provides the anchor for cross-delegation baselining and agent-level configuration tracking.",
+  "extends": "ai",
+  "name": "agent_activity",
+  "attributes": {
+    "$include": [
+      "profiles/trace.json"
+    ],
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Spawn",
+          "description": "A new agent instance was created. The <code>ai_agent.instance_uid</code> is minted at this point. The agent is now available to accept delegations."
+        },
+        "2": {
+          "caption": "Terminate",
+          "description": "An agent instance shut down. May be normal completion, forced termination, or crash. Use <code>status_id</code> to distinguish success from failure."
+        },
+        "3": {
+          "caption": "Suspend",
+          "description": "An agent was paused at the agent level — waiting for human-in-the-loop approval, rate limited, or yielding in an async workflow. Distinct from a delegation-level suspend."
+        },
+        "4": {
+          "caption": "Resume",
+          "description": "An agent resumed execution from a suspended state."
+        },
+        "5": {
+          "caption": "Update",
+          "description": "An agent's configuration changed at runtime — model upgrade, tool set modification, system prompt update, or capability change."
+        },
+        "6": {
+          "caption": "Register",
+          "description": "An agent registered with a gateway or orchestrator and its design-time declarations were snapshotted. Captures the manifest version, declared sub-agent dependencies, and tool scopes at the moment the agent became known to the runtime. Enables comparison of declared behavior against observed runtime behavior."
+        }
+      }
+    },
+    "ai_agent": {
+      "description": "The autonomous agent that is the subject of this lifecycle event.",
+      "group": "primary",
+      "requirement": "required"
+    },
+    "delegation": {
+      "description": "The delegation the agent is currently serving, if any. An agent may be spawned before receiving a delegation, or may be between delegations at the time of the event.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "duration": {
+      "description": "The total runtime of the agent instance in milliseconds, from spawn to termination. Populated on Terminate events.",
+      "group": "occurrence",
+      "requirement": "recommended"
+    },
+    "start_time": {
+      "description": "The time the agent instance was spawned.",
+      "group": "occurrence",
+      "requirement": "recommended"
+    },
+    "end_time": {
+      "description": "The time the agent instance was terminated, if applicable.",
+      "group": "occurrence",
+      "requirement": "optional"
+    },
+    "prompt_tokens": {
+      "description": "Aggregate number of input prompt tokens consumed across the agent instance's lifetime. Populated on Terminate events.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "completion_tokens": {
+      "description": "Aggregate number of completion/response tokens generated across the agent instance's lifetime. Populated on Terminate events.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "total_tokens": {
+      "description": "Aggregate total tokens (prompt + completion) consumed across the agent instance's lifetime. Populated on Terminate events.",
+      "group": "context",
+      "requirement": "recommended"
+    },
+    "manifest_uid": {
+      "caption": "Manifest ID",
+      "description": "The identifier of the capability manifest (e.g., an OASF record or internal agent registry entry) that describes this agent's declared skills, expected sub-agent dependencies, and tool scopes. Populated on Register and Update events.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "manifest_version": {
+      "caption": "Manifest Version",
+      "description": "The version of the capability manifest active at the time of registration or update. Enables detection of agents running stale or unexpected manifest versions.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "declared_agents": {
+      "description": "The sub-agents this agent is declared to depend on, snapshotted from its capability manifest at registration time. Populated on Register and Update events. Comparing this against runtime delegation lineage reveals undeclared sub-agent spawning.",
+      "group": "context",
+      "requirement": "optional"
+    }
+  },
+  "profiles": [
+    "trace"
+  ]
+}

--- a/events/ai/ai.json
+++ b/events/ai/ai.json
@@ -1,0 +1,15 @@
+{
+  "caption": "AI Activity",
+  "category": "ai",
+  "description": "The AI Activity event is a generic event that defines a set of attributes available in AI activity events. It covers control-plane operations of autonomous AI agents such as delegation lifecycle, agent spawning, and authority management.",
+  "extends": "base_event",
+  "name": "ai",
+  "attributes": {
+    "actor": {
+      "description": "The principal or gateway that initiated the AI activity.",
+      "group": "primary",
+      "requirement": "recommended",
+      "profile": null
+    }
+  }
+}

--- a/events/ai/delegation_activity.json
+++ b/events/ai/delegation_activity.json
@@ -1,0 +1,80 @@
+{
+  "uid": 1,
+  "caption": "Delegation Activity",
+  "description": "Delegation Activity events report lifecycle transitions of an AI delegation — the durable authorization context issued by a principal to an autonomous agent. These are control-plane events distinct from the data-plane tool-call events (e.g. api_activity, process_activity) that carry delegation context. A Create event is emitted when a gateway mints a new delegation. Revoke and Expire events mark premature termination. A Complete event summarizes the delegation's full scope of activity upon closure.",
+  "extends": "ai",
+  "name": "delegation_activity",
+  "attributes": {
+    "$include": [
+      "profiles/trace.json"
+    ],
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Create",
+          "description": "A delegation was issued by a trusted boundary (gateway or orchestrator) to an autonomous agent. The delegation UID is minted at this point and must not be reused."
+        },
+        "2": {
+          "caption": "Revoke",
+          "description": "A delegation was explicitly terminated before completion, typically due to a policy violation, user cancellation, or security enforcement action."
+        },
+        "3": {
+          "caption": "Expire",
+          "description": "A delegation reached its time-to-live limit before the delegated task completed."
+        },
+        "4": {
+          "caption": "Complete",
+          "description": "A delegated task finished and the delegation is closed. This event may carry a summary of the delegation's aggregate activity scope."
+        }
+      }
+    },
+    "delegation": {
+      "description": "The delegation that is the subject of this lifecycle event.",
+      "group": "primary",
+      "requirement": "required"
+    },
+    "ai_agent": {
+      "description": "The autonomous agent to which the delegation was issued. Carries model identity via <code>ai_agent.ai_model</code>.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "duration": {
+      "description": "The total duration of the delegation in milliseconds, from creation to completion, revocation, or expiry.",
+      "group": "occurrence",
+      "requirement": "recommended"
+    },
+    "start_time": {
+      "description": "The time the delegation was created.",
+      "group": "occurrence",
+      "requirement": "recommended"
+    },
+    "end_time": {
+      "description": "The time the delegation was completed, revoked, or expired.",
+      "group": "occurrence",
+      "requirement": "recommended"
+    },
+    "delegation_lineage": {
+      "description": "The full delegation ancestry tree rooted at this delegation, materialized as a directed graph. Nodes are <code>delegation_node</code> objects carrying delegation context, agent identity, and model information; edges represent parent-child relationships from sub-agent spawning or re-delegation. Recommended on Complete, Revoke, and Expire events to enable lineage queries without requiring trace reconstruction.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "prompt_tokens": {
+      "description": "Aggregate number of input prompt tokens consumed across all actions performed under this delegation. Populated on Complete, Revoke, and Expire events.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "completion_tokens": {
+      "description": "Aggregate number of completion/response tokens generated across all actions performed under this delegation. Populated on Complete, Revoke, and Expire events.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "total_tokens": {
+      "description": "Aggregate total tokens (prompt + completion) consumed across all actions performed under this delegation. Populated on Complete, Revoke, and Expire events.",
+      "group": "context",
+      "requirement": "recommended"
+    }
+  },
+  "profiles": [
+    "trace"
+  ]
+}

--- a/events/application/api_activity.json
+++ b/events/application/api_activity.json
@@ -26,6 +26,14 @@
         "4": {
           "caption": "Delete",
           "description": "The API call in the event pertains to a 'delete' activity."
+        },
+        "5": {
+          "caption": "Invoke",
+          "description": "The API call triggers execution of a process, job, tool, or workflow rather than performing a CRUD operation on a resource. Covers agent tool calls, pipeline triggers, and imperative commands."
+        },
+        "6": {
+          "caption": "Share",
+          "description": "The API call expands access or exposure of a resource to another entity — adding members, setting permissions, creating shared links, or sending data to an external recipient. Distinct from Create to preserve the security-relevant signal of access expansion."
         }
       }
     },

--- a/events/application/datastore_activity.json
+++ b/events/application/datastore_activity.json
@@ -6,6 +6,7 @@
   "name": "datastore_activity",
   "attributes": {
     "$include": [
+      "profiles/trace.json",
       "profiles/ai_operation.json"
     ],
     "activity_id": {
@@ -131,6 +132,7 @@
     ]
   },
   "profiles": [
+    "trace",
     "ai_operation"
   ]
 }

--- a/events/application/web_resources_activity.json
+++ b/events/application/web_resources_activity.json
@@ -6,7 +6,9 @@
   "name": "web_resources_activity",
   "attributes": {
     "$include": [
-      "profiles/network_proxy.json"
+      "profiles/network_proxy.json",
+      "profiles/trace.json",
+      "profiles/ai_operation.json"
     ],
     "activity_id": {
       "enum": {
@@ -79,6 +81,8 @@
     }
   },
   "profiles": [
-    "network_proxy"
+    "network_proxy",
+    "trace",
+    "ai_operation"
   ]
 }

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -104,7 +104,7 @@
       "requirement": "required"
     },
     "start_time": {
-      "description": "The start time of a time period, or the time of the least recent event included in the aggregate event.",
+      "description": "The start time of a time period, or the time of the least recent event included in the aggregate event. When <code>start_time</code> is not present on a non-aggregate event, it should be populated from <code>time</code> to support consistent use of <code>start_time</code> for timeline queries.",
       "group": "occurrence",
       "requirement": "optional"
     },
@@ -125,6 +125,7 @@
       "requirement": "recommended"
     },
     "time": {
+      "description": "The normalized event occurrence time. For aggregate events where <code>start_time</code> and <code>end_time</code> are populated, <code>time</code> should be set to <code>start_time</code> — the time of the least recent event in the aggregate. This enables consistent timeline ordering and causal analysis across correlated events. For finding events, <code>time</code> retains its meaning as the finding creation time.",
       "group": "occurrence",
       "requirement": "required"
     },

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -104,7 +104,7 @@
       "requirement": "required"
     },
     "start_time": {
-      "description": "The start time of a time period, or the time of the least recent event included in the aggregate event. When <code>start_time</code> is not present on a non-aggregate event, it should be populated from <code>time</code> to support consistent use of <code>start_time</code> for timeline queries.",
+      "description": "The start time of a time period, or the time of the least recent event included in the aggregate event.",
       "group": "occurrence",
       "requirement": "optional"
     },
@@ -125,7 +125,6 @@
       "requirement": "recommended"
     },
     "time": {
-      "description": "The normalized event occurrence time. For aggregate events where <code>start_time</code> and <code>end_time</code> are populated, <code>time</code> should be set to <code>start_time</code> — the time of the least recent event in the aggregate. This enables consistent timeline ordering and causal analysis across correlated events. For finding events, <code>time</code> retains its meaning as the finding creation time.",
       "group": "occurrence",
       "requirement": "required"
     },

--- a/events/network/email_activity.json
+++ b/events/network/email_activity.json
@@ -5,6 +5,10 @@
   "description": "Email Activity events report SMTP protocol and email activities including those with embedded URLs and files. See the <code>Email</code> object for details.",
   "extends": "base_event",
   "name": "email_activity",
+  "profiles": [
+    "trace",
+    "ai_operation"
+  ],
   "attributes": {
     "activity_id": {
       "requirement": "required",

--- a/events/system/file_activity.json
+++ b/events/system/file_activity.json
@@ -5,6 +5,10 @@
   "extends": "system",
   "name": "file_activity",
   "attributes": {
+    "$include": [
+      "profiles/trace.json",
+      "profiles/ai_operation.json"
+    ],
     "access_mask": {
       "group": "context",
       "requirement": "optional"
@@ -102,6 +106,10 @@
       "requirement": "recommended"
     }
   },
+  "profiles": [
+    "trace",
+    "ai_operation"
+  ],
   "references": [
     {
       "description": "D3FEND™ Ontology d3f:FileEvent",

--- a/events/system/process_activity.json
+++ b/events/system/process_activity.json
@@ -6,6 +6,7 @@
   "name": "process_activity",
   "attributes": {
     "$include": [
+      "profiles/trace.json",
       "profiles/ai_operation.json"
     ],
     "activity_id": {
@@ -90,6 +91,7 @@
     }
   },
   "profiles": [
+      "trace",
       "ai_operation"
   ],
   "references": [

--- a/events/system/scheduled_job_activity.json
+++ b/events/system/scheduled_job_activity.json
@@ -5,6 +5,10 @@
   "extends": "system",
   "name": "scheduled_job_activity",
   "attributes": {
+    "$include": [
+      "profiles/trace.json",
+      "profiles/ai_operation.json"
+    ],
     "activity_id": {
       "enum": {
         "1": {
@@ -38,6 +42,10 @@
       "requirement": "required"
     }
   },
+  "profiles": [
+    "trace",
+    "ai_operation"
+  ],
   "references": [
     {
       "description": "D3FEND™ Ontology d3f:ScheduledJobEvent",

--- a/events/system/script_activity.json
+++ b/events/system/script_activity.json
@@ -5,6 +5,10 @@
   "extends": "system",
   "name": "script_activity",
   "attributes": {
+    "$include": [
+      "profiles/trace.json",
+      "profiles/ai_operation.json"
+    ],
     "activity_id": {
       "enum": {
         "1": {
@@ -17,5 +21,9 @@
       "group": "primary",
       "requirement": "required"
     }
-  }
+  },
+  "profiles": [
+    "trace",
+    "ai_operation"
+  ]
 }

--- a/objects/ai_agent.json
+++ b/objects/ai_agent.json
@@ -1,0 +1,70 @@
+{
+  "caption": "AI Agent",
+  "description": "An autonomous AI agent that performs tasks under delegated authority. Distinguished from the OCSF agent object (which describes security sensors such as EDR and DLP tools) and from human principals. An AI agent has a stable logical identity across runs and a restart-sensitive instance identity. The agent owns its model — the ai_model attribute captures which model was backing the agent at the time of action.",
+  "extends": "object",
+  "name": "ai_agent",
+  "attributes": {
+    "uid": {
+      "caption": "AI Agent ID",
+      "description": "Stable logical identifier for the agent (e.g., <code>research-agent</code>, <code>model-tester</code>). Persists across restarts and instances.",
+      "requirement": "required"
+    },
+    "instance_uid": {
+      "caption": "AI Agent Instance ID",
+      "description": "Identifier for a specific running instance of the agent. Restart-sensitive: a new instance ID is expected after a process restart or re-spawn. Enables attribution of actions to a specific process or session of the agent.",
+      "requirement": "recommended"
+    },
+    "name": {
+      "description": "Human-readable name for the agent. For example: <code>Q4 Analysis Agent</code> or <code>Model Tester Agent</code>.",
+      "requirement": "recommended"
+    },
+    "type": {
+      "caption": "Agent Type",
+      "description": "The agent framework or protocol type, normalized to the caption of the <code>type_id</code> value.",
+      "requirement": "optional"
+    },
+    "type_id": {
+      "caption": "Agent Type ID",
+      "description": "The normalized identifier for the agent framework or protocol. Different agent frameworks have different identity, tool-call, and delegation semantics — recording the type enables cross-framework normalization.",
+      "requirement": "recommended",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The agent framework type is unknown."
+        },
+        "1": {
+          "caption": "Native",
+          "description": "A first-party or proprietary agent without a standardized interoperability protocol. For example, a custom orchestrator or an LLM provider's own agent SDK."
+        },
+        "2": {
+          "caption": "MCP",
+          "description": "An agent that exposes or consumes tools via the Model Context Protocol (MCP), enabling standardized tool discovery and invocation across runtimes."
+        },
+        "3": {
+          "caption": "A2A",
+          "description": "An agent that communicates using the Agent-to-Agent (A2A) protocol, enabling structured inter-agent task delegation and result exchange."
+        },
+        "4": {
+          "caption": "LangChain",
+          "description": "An agent built with the LangChain framework."
+        },
+        "5": {
+          "caption": "AutoGen",
+          "description": "An agent built with the Microsoft AutoGen framework for multi-agent conversation and orchestration."
+        },
+        "6": {
+          "caption": "CrewAI",
+          "description": "An agent built with the CrewAI framework for role-based multi-agent collaboration."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The agent framework type is not listed. Use the <code>type</code> attribute to describe it."
+        }
+      }
+    },
+    "ai_model": {
+      "description": "The AI model backing this agent at the time of action. An agent's model may change across instances or versions; this captures the model in use for the specific event or delegation.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -1,0 +1,27 @@
+{
+  "caption": "Delegation",
+  "description": "A durable authorization context issued by a principal to an autonomous agent, representing delegated authority to act on the principal's behalf. A delegation persists independently of any single trace, session, or workflow instance. Delegations form a directed acyclic graph (DAG) via parent references, enabling lineage queries across multi-agent compositions.",
+  "extends": "object",
+  "name": "delegation",
+  "attributes": {
+    "uid": {
+      "caption": "Delegation ID",
+      "description": "Unique identifier for this delegation context. Must be stable across the lifetime of the delegation and minted by a trusted boundary (gateway, orchestrator) rather than asserted by the agent. All events executed under this delegation share this identifier.",
+      "requirement": "required"
+    },
+    "parent_uid": {
+      "caption": "Parent Delegation ID",
+      "description": "The delegation identifier of the parent delegation, if this delegation was created via re-delegation or sub-agent spawning. Enables lineage closure: the transitive closure of parent references forms a queryable ancestry DAG.",
+      "requirement": "optional"
+    },
+    "created_time": {
+      "description": "The time when the delegation was issued by the gateway or orchestrator.",
+      "requirement": "recommended"
+    },
+    "issuer_uid": {
+      "caption": "Issuer ID",
+      "description": "The unique identifier of the trusted boundary (gateway, orchestrator, or SDK wrapper) that minted this delegation. Supports binding integrity: downstream consumers can verify that delegation IDs were issued by a trusted boundary rather than asserted by the agent. Correlates with <code>metadata.product.uid</code> on the corresponding <code>delegation_activity</code> event for full gateway details.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/delegation_lineage.json
+++ b/objects/delegation_lineage.json
@@ -1,0 +1,16 @@
+{
+  "caption": "Delegation Lineage",
+  "description": "A directed graph representing the delegation ancestry tree. Nodes are delegation_node objects carrying the full context of each delegation point — authorization metadata, agent identity, and backing model. Edges represent parent-child relationships established via sub-agent spawning or re-delegation. The graph is always directed; authority flows from parent to child.",
+  "extends": "object",
+  "name": "delegation_lineage",
+  "attributes": {
+    "delegation_nodes": {
+      "description": "The delegation nodes in the lineage graph. Each node is a <code>delegation_node</code> object carrying delegation context, agent identity, and model information.",
+      "requirement": "required"
+    },
+    "edges": {
+      "description": "The parent-child relationships between delegations. Each edge's source is the parent delegation UID and target is the child delegation UID. The relation is typically <code>spawned</code> or <code>re-delegated</code>.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/delegation_node.json
+++ b/objects/delegation_node.json
@@ -1,0 +1,15 @@
+{
+  "caption": "Delegation Node",
+  "description": "A node in a delegation lineage graph. Flattens in delegation attributes and adds agent identity for a single unified structure. Each node captures the full context of a delegation point: authorization metadata, the agent to which authority was delegated, and the model backing that agent.",
+  "extends": "object",
+  "name": "delegation_node",
+  "attributes": {
+    "$include": [
+      "objects/delegation.json"
+    ],
+    "ai_agent": {
+      "description": "The autonomous agent to which this delegation was issued. Carries model identity via <code>ai_agent.ai_model</code>.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -1,14 +1,26 @@
 {
     "caption": "AI Operation",
-    "description": "AI-specific attributes for model operations, retrieval systems, and agent activities. e.g. model_name, total_token_counts etc.",
+    "description": "Stamps AI context onto data-plane events — tool calls, file operations, process launches, etc. — so that any action can be attributed to a model, an agent, or a delegation. Four independent concerns, each independently optional: populate what applies. For agent-mediated operations, model identity is carried within <code>ai_agent.ai_model</code>; the standalone <code>ai_model</code> attribute covers direct model invocations without an autonomous agent. Control-plane events (delegation_activity, agent_activity) declare their own agent and delegation attributes directly and do not use this profile.",
     "meta": "profile",
     "name": "ai_operation",
     "attributes": {
         "ai_model": {
+            "description": "The AI model involved in this operation. Use for direct model invocations (e.g., a stateless LLM API call) where no autonomous agent is involved. For agent-mediated operations, model identity is carried within <code>ai_agent.ai_model</code> instead.",
             "group": "context",
             "requirement": "recommended"
         },
+        "ai_agent": {
+            "description": "The autonomous AI agent that performed this action. Carries model identity via <code>ai_agent.ai_model</code>. Populate when the action was performed by an agent operating under delegated authority rather than a direct model call.",
+            "group": "context",
+            "requirement": "optional"
+        },
         "message_context": {
+            "description": "Conversation metadata such as token counts and message-level detail.",
+            "group": "context",
+            "requirement": "optional"
+        },
+        "delegation": {
+            "description": "The delegation under whose authority this action was performed. Links the event to a durable authorization context independent of traces and sessions. Enables queries like 'show me everything this delegation did.'",
             "group": "context",
             "requirement": "optional"
         }


### PR DESCRIPTION
## Summary

Closes #1611

Adds explicit documentation to the `time` and `start_time` field descriptions in `base_event.json` establishing the convention for how `time` should be populated on aggregate events — a question that was undocumented and causing implementer confusion.

**Changes:**
- `events/base_event.json` — adds a `description` to `time` (previously had none) clarifying that for aggregate events, `time = start_time`
- `events/base_event.json` — extends the `start_time` description with the reverse convention: when `start_time` is absent on a non-aggregate event, populate it from `time`
- `dictionary.json` — adds "See specific usage." to the `time` description to align with the pattern used by `start_time` and `end_time` in the dictionary, pointing readers to the event-level override

## Convention

**For aggregate events** (where `start_time`, `end_time`, and `count` are populated):
> `time` should be set to `start_time` — the time of the least recent event in the aggregate.

**For non-aggregate events** where `start_time` is absent:
> `start_time` should be populated from `time`.

## Rationale

- Analyst timeline views and incident correlation need a consistent anchor point — the start of observed activity, not the end
- Preserves causal ordering: if `time = end_time`, a later aggregate could appear to precede an earlier one
- Consistent with the existing decision for network activities
- Avoids events landing in unexpected data partitions when partitioned by `time`
- Finding events are explicitly carved out: `time` retains its meaning as finding creation time

## Test plan

- [ ] Review updated descriptions in `events/base_event.json` for `time` and `start_time`
- [ ] Confirm `dictionary.json` `time` description is consistent with the "See specific usage." pattern
- [ ] Verify no other base event fields are affected