### PR TITLE
fix Anti-Patternf script

### DIFF
--- a/.github/scripts/check_antipatterns.py
+++ b/.github/scripts/check_antipatterns.py
@@ -780,7 +780,7 @@ def cmd_prepare() -> None:
         if not attr_def:
             continue
         for detector in attr_detectors:
-            for f in detector(attr_name, attr_def, "dictionary", {}):
+            for f in detector(attr_name, attr_def, "dictionary", compiled_dict):
                 findings.append(f.to_dict())
         # Dictionary-level cross-checks
         for f in check_duplicate_attribute(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Bugfixes
+1. Fixed the static anti-pattern checker so dictionary attributes are analyzed with the full compiled dictionary; the `missing-sibling` rule no longer false-positives when the sibling exists in `dictionary.json`. [#1613](https://github.com/ocsf/ocsf-schema/pull/1613)
+
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)
 


### PR DESCRIPTION
Summary

For dictionary attributes, that check runs in a loop that passed {} as all_attrs, so the sibling was never visible—even when tunnel_type exists in dictionary.json. That produced a false warning on [PR #1602](https://github.com/ocsf/ocsf-schema/pull/1602) after tunnel_type_id got dictionary-level enum values (the rule only runs when an enum is present).

What was fixed
That loop now passes compiled_dict (the compiled dictionary’s attributes map) instead of {}, matching how object/class checks pass their container attributes and how other dictionary checks (duplicate_*, learned patterns) already used compiled_dict.

Result
Dictionary-level missing-sibling is evaluated against the real dictionary definitions, so a defined sibling like tunnel_type is recognized and the spurious warning goes away after this change is merged and CI re-runs.