### PR TITLE
fix: Add references and @deprecated to profile metaschema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Thankyou! -->
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)
+1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.
 
 ## [v1.8.0] - Mar 16th, 2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)
-1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.[#1625]((https://github.com/ocsf/ocsf-schema/pull/1625)
+1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.[#1625](https://github.com/ocsf/ocsf-schema/pull/1625)
 
 ## [v1.8.0] - Mar 16th, 2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)
-1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.
+1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.[#1625]((https://github.com/ocsf/ocsf-schema/pull/1625)
 
 ## [v1.8.0] - Mar 16th, 2026
 ### Added

--- a/metaschema/profile.schema.json
+++ b/metaschema/profile.schema.json
@@ -6,6 +6,9 @@
   "title": "Profile",
   "type": "object",
   "properties": {
+    "@deprecated": {
+      "$ref": "deprecated.schema.json"
+    },
     "annotations": {
       "type": "object",
       "description": "Annotations for this profile describing categories it belongs in."
@@ -33,6 +36,9 @@
       "type": "string",
       "description": "A name of the profile. It must be a unique name. The name is all lower case letters, combine words using underscore.",
       "pattern": "^[a-z0-9_]*$"
+    },
+    "references": {
+      "$ref": "references.schema.json"
     },
     "attributes": {
       "type": "object",


### PR DESCRIPTION
related PR - https://github.com/ocsf/ocsf-schema/pull/1616

## Summary

The profile metaschema (`profile.schema.json`) is missing `references` and `@deprecated` properties that are supported by the event class and object metaschemas (via `common-event-object.schema.json`). Since the profile schema sets `additionalProperties: false`, any profile that uses these fields (e.g. `datetime.json` uses `references`) would fail strict metaschema validation.

## Changes

- Added `references` property (`$ref` to `references.schema.json`) to the profile metaschema
- Added `@deprecated` property (`$ref` to `deprecated.schema.json`) to the profile metaschema
- Updated CHANGELOG

## Testing

- Verified `datetime.json` (which uses `references`) passes validation against the updated metaschema
- No existing profiles use `@deprecated` at the profile level yet, but the field is now available for future use