### PR TITLE
Add bcc and bcc_mailboxes attributes to the email object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,8 +82,8 @@ Thankyou! -->
   1. Added `uid` attribute to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Relaxed `name` attribute constraint to `recommended` in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `at_least_one` constraint for `name` and `type_id` attributes in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
-  1. Added `bcc` attribute to the `email` object
-  1. Added `bcc_mailboxes` attribute to the `email` object
+  1. Added `bcc` attribute to the `email` object. [1632](https://github.com/ocsf/ocsf-schema/pull/1632)
+  1. Added `bcc_mailboxes` attribute to the `email` object. [1632](https://github.com/ocsf/ocsf-schema/pull/1632)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ Thankyou! -->
   1. Added `uid` attribute to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Relaxed `name` attribute constraint to `recommended` in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `at_least_one` constraint for `name` and `type_id` attributes in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
+  1. Added `bcc` attribute to the `email` object
+  1. Added `bcc_mailboxes` attribute to the `email` object
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/dictionary.json
+++ b/dictionary.json
@@ -1079,6 +1079,30 @@
       "sibling": "category_name",
       "type": "integer_t"
     },
+    "bcc": {
+      "caption": "Bcc",
+      "description": "The machine-readable email header Bcc values, as defined by RFC 5322. For example <code>example.user@usersdomain.com</code>.",
+      "type": "email_t",
+      "references": [
+        {
+          "description": "RFC 5322",
+          "url": "https://www.rfc-editor.org/rfc/rfc5322"
+        }
+      ],
+      "is_array": true
+    },
+    "bcc_mailboxes": {
+      "caption": "Bcc Mailboxes",
+      "description": "The human-readable email header Bcc Mailbox values. For example <code>'Example User &lt;example.user@usersdomain.com&gt;'</code>.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "RFC 5322",
+          "url": "https://www.rfc-editor.org/rfc/rfc5322#section-3.4"
+        }
+      ],
+      "is_array": true
+    },
     "cc": {
       "caption": "Cc",
       "description": "The machine-readable email header Cc values, as defined by RFC 5322. For example <code>example.user@usersdomain.com</code>.",

--- a/objects/email.json
+++ b/objects/email.json
@@ -8,6 +8,12 @@
     "$include": [
       "profiles/data_classification.json"
     ],
+    "bcc": {
+      "requirement": "optional"
+    },
+    "bcc_mailboxes": {
+      "requirement": "optional"
+    },
     "cc": {
       "requirement": "optional"
     },


### PR DESCRIPTION
This change adds the bcc and bcc_mailboxes to the email object, supplementing the existing cc, cc_mailboxed, to and to_mailboxes fields.
