### PR TITLE
Added `xattributes` to `_entity`. 

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -7214,7 +7214,7 @@
     },
     "xattributes": {
       "caption": "Extended Attributes",
-      "description": "An unordered collection of zero or more name/value pairs where each pair represents a file or folder extended attribute.</p>For example: Windows alternate data stream attributes (ADS stream name, ADS size, etc.), user-defined or application-defined attributes, ACL, owner, primary group, etc. Examples from DCS: </p><ul><li><strong>ads_name</strong></li><li><strong>ads_size</strong></li><li><strong>dacl</strong></li><li><strong>owner</strong></li><li><strong>primary_group</strong></li><li><strong>link_name</strong> - name of the link associated to the file.</li><li><strong>hard_link_count</strong> - the number of links that are associated to the file.</li></ul>",
+      "description": "Attributes not present in the schema that extend the class or object. See specific usage.",
       "type": "object"
     },
     "zone": {

--- a/objects/_entity.json
+++ b/objects/_entity.json
@@ -11,6 +11,10 @@
     "uid": {
       "description": "The unique identifier of the entity.",
       "requirement": "recommended"
+    },
+    "xattributes": {
+      "description": "Attributes not present in the object that extend the entity.",
+      "requirement": "optional"
     }
   },
   "constraints": {

--- a/objects/file.json
+++ b/objects/file.json
@@ -200,7 +200,8 @@
       "description": "The volume on the storage device where the file is located.",
       "requirement": "optional"
     },
-    "xattributes": {
+     "xattributes": {
+      "description": "An unordered collection of zero or more name/value pairs where each pair represents a file or folder extended attribute.</p>For example: Windows alternate data stream attributes (ADS stream name, ADS size, etc.), user-defined or application-defined attributes, ACL, owner, primary group, etc. Examples from DCS: </p><ul><li><strong>ads_name</strong></li><li><strong>ads_size</strong></li><li><strong>dacl</strong></li><li><strong>owner</strong></li><li><strong>primary_group</strong></li><li><strong>link_name</strong> - name of the link associated to the file.</li><li><strong>hard_link_count</strong> - the number of links that are associated to the file.</li></ul>",
       "requirement": "optional"
     }
   },


### PR DESCRIPTION
#### Related Issue: 1638

#### Description of changes:
Where we have the `unmapped` attribute for attributes that are not mapped to the OCSF class, which effectively extends the class, that data (assumed to be key/value pairs in JSON syntax but not restricted as such) is not scoped to any objects that are included in the event class.

The `file` and `process` objects do include `xattributes` for exactly this purpose. This PR addresses the same augmentation for any `_entity` extended object - not all objects. It is clearly and necessarily an optional attribute, which as with `unmapped` can hold a set of key/value pairs in JSON syntax, or any other structure including arrays or nested objects, although that approach is not recommended from a consumer of the event standpoint.

In so doing, the dictionary description for `xattributes` was specific to the `file` object, and was overridden in the `process` object. This PR generalizes the dictionary description, with a See specific usage convention, and overrides the description directly in the `file` object for compatibility and in the `_entity` object more generally for entities.
