### PR TITLE
Added `peripheral_devices` to the `device` object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Thankyou! -->
 * #### Dictionary Attributes
   1. Added `iam_role`, `iam_roles`, `updated_role`, `updated_group`, `updated_user` attributes. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Added `initiator` and `initiator_id` attributes for identifying which endpoint initiated a network communication, with generic `Unknown (0)` and `Other (99)` enums. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
+  1. Added `peripheral_devices` for a set of peripherals. [#1645](https://github.com/ocsf/ocsf-schema/pull/1645)
 ### Improved
 * #### Categories
 * #### Event Classes
@@ -60,6 +61,7 @@ Thankyou! -->
 * #### Profiles
 * #### Objects
   1. Added `iam_role` to `actor`. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
+  1. Added `peripheral_devices` to `device`. [#1645](https://github.com/ocsf/ocsf-schema/pull/1645)
 ### Deprecated
   1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)

--- a/dictionary.json
+++ b/dictionary.json
@@ -4709,6 +4709,12 @@
       "description": "The peripheral device that triggered the event.",
       "type": "peripheral_device"
     },
+    "peripheral_devices": {
+      "caption": "Peripheral Device",
+      "description": "A set of peripheral devices. See specific usage.",
+      "type": "peripheral_device",
+      "is_array": true
+    },
     "permission": {
       "caption": "Permission",
       "description": "The IAM permission related to an event",

--- a/objects/device.json
+++ b/objects/device.json
@@ -119,6 +119,10 @@
     "os_machine_uuid": {
       "requirement": "optional"
     },
+    "peripheral_devices": {
+      "description": "The peripheral devices that are attached or connected to the device.",
+      "requirement": "optional"
+    },
     "region": {
       "description": "The region where the virtual machine is located. For example, an AWS Region.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: 1636

#### Description of changes:

We have `peripheral_device_activity` as a System Activity class, but we have no notion of peripherals that are attached to a device or connected to a device, as is usually how they are found. One shortcoming of the current disconnect is for DLP events where an external storage device is prevented from a copy of some data being written. There may be other use cases where a device is connecting to a printer and the like that today cannot be expressed well.

This PR simply adds an array attribute for `peripheral_devices` to the dictionary and adds the attribute to the `device` object.