### PR TITLE
Add `interface_flags` to `network_interface` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Thankyou! -->
 * #### Dictionary Attributes
   1. Added `iam_role`, `iam_roles`, `updated_role`, `updated_group`, `updated_user` attributes. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Added `initiator` and `initiator_id` attributes for identifying which endpoint initiated a network communication, with generic `Unknown (0)` and `Other (99)` enums. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
+  1. Added `interface_flags` attribute for network interface operational flags. [#1646](https://github.com/ocsf/ocsf-schema/issues/1646)
 ### Improved
 * #### Categories
 * #### Event Classes

--- a/dictionary.json
+++ b/dictionary.json
@@ -3363,6 +3363,12 @@
         }
       }
     },
+    "interface_flags": {
+      "caption": "Network Interface Flags",
+      "description": "The list of operational flags set on the network interface. Values are normalized to lowercase (e.g. <code>up</code>, <code>broadcast</code>, <code>multicast</code>, <code>promisc</code>, <code>noarp</code>, <code>loopback</code>, <code>pointtopoint</code>). The <code>promisc</code> flag indicates promiscuous mode — a potential indicator of unauthorized packet capture.",
+      "type": "string_t",
+      "is_array": true
+    },
     "interface_name": {
       "caption": "Network Interface Name",
       "description": "The name of the network interface (e.g. eth2).",

--- a/objects/network_interface.json
+++ b/objects/network_interface.json
@@ -8,6 +8,10 @@
       "description": "The hostname associated with the network interface.",
       "requirement": "recommended"
     },
+    "interface_flags": {
+      "description": "The operational flags set on the network interface (e.g. <code>up</code>, <code>broadcast</code>, <code>promisc</code>). The <code>promisc</code> flag indicates promiscuous mode.",
+      "requirement": "optional"
+    },
     "ip": {
       "description": "The IP address associated with the network interface.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue: #1646

#### Description of changes:

Add `interface_flags` (`string_t[]`) to the `network_interface` object for representing interface operational flags (e.g. `up`, `broadcast`, `multicast`, `promisc`, `noarp`, `loopback`, `pointtopoint`).

**Security relevance:** The `promisc` flag indicates promiscuous mode is active — a critical indicator of unauthorized packet capture or network sniffing. Interface operational state (`up`/`down`) and multicast/broadcast exposure are fundamental to network security posture assessment and segmentation verification.

**Changes:**
- `dictionary.json` — added `interface_flags` attribute definition
- `objects/network_interface.json` — added `interface_flags` as optional attribute
- `CHANGELOG.md` — added entry to Unreleased section

**Data sources:** Interface flags are universally available — Linux `SIOCGIFFLAGS` ioctl / netlink, macOS `SIOCGIFFLAGS` ioctl, Windows `GetAdaptersAddresses` API. Every host fact collector surfaces them: Chef Ohai (`network.interfaces.*.flags`), osquery (`interface_details.flags`), Puppet Facter, Ansible facts.

**Example:**
```json
{
  "network_interfaces": [
    {
      "name": "eth0",
      "mac": "00:11:22:33:44:55",
      "ip": "10.0.0.5",
      "interface_flags": ["up", "broadcast", "multicast"]
    }
  ]
}
```

**Validation:** OCSF validator passes 12/12 with this change.

### Checklist:
1. [x] Added entry to `Unreleased` section in CHANGELOG.md
2. [x] Followed contribution guidelines
3. [x] Ran ocsf-validator — 12/12 tests passing
4. [x] PR title in sync with description