### PR TITLE
Add `attestation` object and `record_integrity` profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Thankyou! -->
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
-  1. Added `attestation`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `attestation_list`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,11 +64,11 @@ Thankyou! -->
   1. Added `note` object to capture a comment along with the user who made the comment and when the note was modified. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
   1. Added `ai_agent` object representing an autonomous AI agent, distinct from the existing `agent` object (which models security sensors such as EDR, DLP, APM). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `attestation` object carrying digital `signatures` over an event record, with optional tamper-evident chain fields (`entry_hash`, `prev_entry_hash`, `chain_uid`). [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `attestation` object carrying digital `signatures` over an event record, with optional tamper-evident chain fields (`record_hash`, `prev_record_hash`, `chain_uid`). [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
-  1. Added `attestation`, `entry_hash`, `prev_entry_hash`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `attestation`, `record_hash`, `prev_record_hash`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ Thankyou! -->
   1. Added clipboard_activity. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added device_power_state_activity (`Device Power State Activity`) class to capture power state changes of a device. [#1624](https://github.com/ocsf/ocsf-schema/pull/1624)
 * #### Profiles
-  1. Added `record_integrity` profile that adds a cryptographic `attestation` over the event record (integrity, authenticity, and non-repudiation), applied at the base event so any class can carry it. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `record_integrity` profile that adds a cryptographic `attestation` over the event (integrity, authenticity, and non-repudiation), applied at the base event so any class can carry it. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Objects
   1. Added `job_action` object to describe an action that job can perform. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_trigger` object to describe a condition when job performs its action. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -64,11 +64,12 @@ Thankyou! -->
   1. Added `note` object to capture a comment along with the user who made the comment and when the note was modified. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
   1. Added `ai_agent` object representing an autonomous AI agent, distinct from the existing `agent` object (which models security sensors such as EDR, DLP, APM). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `attestation` object carrying digital `signatures` over an event record, with optional tamper-evident chain fields (`record_hash`, `prev_record_hash`, `chain_uid`). [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `attestation` object carrying a `fingerprint` of and digital `signatures` over an event, with optional tamper-evident chain attributes (`prev_event`, `chain_uid`) and an `authority_uid` identifying the attesting party. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `prev_event` object referencing the previous event in a tamper-evident chain by its `fingerprint` (content binding) together with `uid` and `type_uid` (retrieval). [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
-  1. Added `attestation`, `record_hash`, `prev_record_hash`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `attestation`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -106,7 +107,7 @@ Thankyou! -->
   1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added the `ai_operation` profile to the `system`, `network`, `application`, and `iam` base event classes so all System Activity, Network Activity, Application Activity, and Identity & Access Management events inherit agent attribution. Also added the profile to `email_activity` (which does not extend a base with the profile). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added the `record_integrity` profile to the `base_event` class so every event class can optionally carry a cryptographic `attestation` over its record. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added the `record_integrity` profile to the `base_event` class so every event class can optionally carry a cryptographic `attestation` over the event. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Objects
@@ -135,6 +136,7 @@ Thankyou! -->
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (7)` enum value to `serialization_id` in the `digital_signature` object. [#1692](https://github.com/ocsf/ocsf-schema/pull/1692)
+  1. Added `serialization` and `serialization_id` to the `fingerprint` object, mirroring `digital_signature`, so a verifier knows the canonical serialization scheme used to produce the fingerprinted byte sequence. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Thankyou! -->
   1. Added clipboard_activity. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added device_power_state_activity (`Device Power State Activity`) class to capture power state changes of a device. [#1624](https://github.com/ocsf/ocsf-schema/pull/1624)
 * #### Profiles
+  1. Added `record_integrity` profile that adds a cryptographic `attestation` over the event record (integrity, authenticity, and non-repudiation), applied at the base event so any class can carry it. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Objects
   1. Added `job_action` object to describe an action that job can perform. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_trigger` object to describe a condition when job performs its action. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -63,9 +64,11 @@ Thankyou! -->
   1. Added `note` object to capture a comment along with the user who made the comment and when the note was modified. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
   1. Added `ai_agent` object representing an autonomous AI agent, distinct from the existing `agent` object (which models security sensors such as EDR, DLP, APM). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
+  1. Added `attestation` object carrying digital `signatures` over an event record, with optional tamper-evident chain fields (`entry_hash`, `prev_entry_hash`, `chain_uid`). [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
+  1. Added `attestation`, `entry_hash`, `prev_entry_hash`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -103,6 +106,7 @@ Thankyou! -->
   1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added the `ai_operation` profile to the `system`, `network`, `application`, and `iam` base event classes so all System Activity, Network Activity, Application Activity, and Identity & Access Management events inherit agent attribution. Also added the profile to `email_activity` (which does not extend a base with the profile). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
+  1. Added the `record_integrity` profile to the `base_event` class so every event class can optionally carry a cryptographic `attestation` over its record. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Objects

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,12 +131,13 @@ Thankyou! -->
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `prompt_text` and `response_text` attributes to the `message_context` object, complementing the existing `prompt_tokens` and `completion_tokens` metrics with the verbatim prompt and response text. [#1674](https://github.com/ocsf/ocsf-schema/pull/1674)
-  1. Added `Code Signing (5)` enum value to `algorithm_id` and `Code Signing (6)` enum value to `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
+  1. Added `Code Signing (5)` enum value to `algorithm_id` and `Code Signing (7)` enum value to `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (7)` enum value to `serialization_id` in the `digital_signature` object. [#1692](https://github.com/ocsf/ocsf-schema/pull/1692)
+  1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (8)` enum value to `serialization_id` in the `digital_signature` object. [#1692](https://github.com/ocsf/ocsf-schema/pull/1692)
   1. Added `serialization` and `serialization_id` to the `fingerprint` object, mirroring `digital_signature`, so a verifier knows the canonical serialization scheme used to produce the fingerprinted byte sequence. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `Flat (1)` enum value to `serialization_id` in the `digital_signature` and `fingerprint` objects for flat hashes or signatures over a raw byte sequence; the later `serialization_id` values shift up by one (`JCS (2)` through `App Package (8)`), keeping the two enums identical. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/dictionary.json
+++ b/dictionary.json
@@ -192,10 +192,11 @@
       "description": "Identifier of an append-only chain, such as a forensic or audit log, that groups a sequence of attested events for independent verification. Stable for the lifetime of the chain.",
       "type": "string_t"
     },
-    "attestation": {
-      "caption": "Attestation",
-      "description": "A cryptographic attestation over an event, providing integrity, authenticity, and non-repudiation. Carried on the <code>record_integrity</code> profile; the object itself is domain-agnostic.",
-      "type": "attestation"
+    "attestation_list": {
+      "caption": "Attestation List",
+      "description": "One or more cryptographic <code>attestation</code> objects over an event, each providing integrity, authenticity, and non-repudiation. Independent attesters over the same event — for example a producer at write time and a downstream processor at ingest — each contribute a separate attestation, distinct from co-signers on a single attestation, which share its <code>signatures</code> array. Carried on the <code>record_integrity</code> profile; the object itself is domain-agnostic.",
+      "type": "attestation",
+      "is_array": true
     },
     "response_additional": {
       "caption": "DNS Response Additional Section",

--- a/dictionary.json
+++ b/dictionary.json
@@ -177,24 +177,24 @@
       "description": "The permissions that were granted in a platform-native format. See specific usage.",
       "type": "integer_t"
     },
-    "prev_record_hash": {
-      "caption": "Previous Record Hash",
-      "description": "Fingerprint of the prior record in a tamper-evident chain.",
-      "type": "fingerprint"
+    "prev_event": {
+      "caption": "Previous Event",
+      "description": "Reference to the previous event in a tamper-evident chain, binding that event's fingerprint together with locator attributes for retrieval.",
+      "type": "prev_event"
     },
-    "record_hash": {
-      "caption": "Record Hash",
-      "description": "Fingerprint of a record's canonical serialization, used as a link in a tamper-evident chain.",
-      "type": "fingerprint"
+    "authority_uid": {
+      "caption": "Authority ID",
+      "description": "The unique identifier of the authority that produced an attestation. See specific usage.",
+      "type": "string_t"
     },
     "chain_uid": {
       "caption": "Chain ID",
-      "description": "Identifier of an append-only chain, such as a forensic or audit log, that groups a sequence of attested records for independent verification. Stable for the lifetime of the chain.",
+      "description": "Identifier of an append-only chain, such as a forensic or audit log, that groups a sequence of attested events for independent verification. Stable for the lifetime of the chain.",
       "type": "string_t"
     },
     "attestation": {
       "caption": "Attestation",
-      "description": "A cryptographic attestation over an event record, providing integrity, authenticity, and non-repudiation. Carried on the <code>record_integrity</code> profile; the object itself is domain-agnostic.",
+      "description": "A cryptographic attestation over an event, providing integrity, authenticity, and non-repudiation. Carried on the <code>record_integrity</code> profile; the object itself is domain-agnostic.",
       "type": "attestation"
     },
     "response_additional": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -177,13 +177,13 @@
       "description": "The permissions that were granted in a platform-native format. See specific usage.",
       "type": "integer_t"
     },
-    "prev_entry_hash": {
-      "caption": "Previous Entry Hash",
+    "prev_record_hash": {
+      "caption": "Previous Record Hash",
       "description": "Fingerprint of the prior record in a tamper-evident chain.",
       "type": "fingerprint"
     },
-    "entry_hash": {
-      "caption": "Entry Hash",
+    "record_hash": {
+      "caption": "Record Hash",
       "description": "Fingerprint of a record's canonical serialization, used as a link in a tamper-evident chain.",
       "type": "fingerprint"
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -179,7 +179,7 @@
     },
     "prev_event": {
       "caption": "Previous Event",
-      "description": "Reference to the previous event in a tamper-evident chain, binding that event's fingerprint together with locator attributes for retrieval.",
+      "description": "Reference to the previous event in a chain of events. See specific usage.",
       "type": "prev_event"
     },
     "authority_uid": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -177,6 +177,26 @@
       "description": "The permissions that were granted in a platform-native format. See specific usage.",
       "type": "integer_t"
     },
+    "prev_entry_hash": {
+      "caption": "Previous Entry Hash",
+      "description": "Fingerprint of the prior record in a tamper-evident chain.",
+      "type": "fingerprint"
+    },
+    "entry_hash": {
+      "caption": "Entry Hash",
+      "description": "Fingerprint of a record's canonical serialization, used as a link in a tamper-evident chain.",
+      "type": "fingerprint"
+    },
+    "chain_uid": {
+      "caption": "Chain ID",
+      "description": "Identifier of an append-only chain, such as a forensic or audit log, that groups a sequence of attested records for independent verification. Stable for the lifetime of the chain.",
+      "type": "string_t"
+    },
+    "attestation": {
+      "caption": "Attestation",
+      "description": "A cryptographic attestation over an event record, providing integrity, authenticity, and non-repudiation. Carried on the <code>record_integrity</code> profile; the object itself is domain-agnostic.",
+      "type": "attestation"
+    },
     "response_additional": {
       "caption": "DNS Response Additional Section",
       "description": "The Additional section of the DNS response message sent by the server, containing supplementary resource records and an optional TSIG record. A DNS message has at most one TSIG record; for a transaction with both query and response, the query TSIG is in <code>query_additional.tsig</code> and the response TSIG is in <code>response_additional.tsig</code>.",

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -9,6 +9,7 @@
       "profiles/datetime.json",
       "profiles/host.json",
       "profiles/osint.json",
+      "profiles/record_integrity.json",
       "profiles/security_control.json"
     ],
     "activity_id": {
@@ -167,6 +168,7 @@
     "datetime",
     "host",
     "osint",
+    "record_integrity",
     "security_control"
   ]
 }

--- a/objects/ai_agent.json
+++ b/objects/ai_agent.json
@@ -65,7 +65,7 @@
     },
     "charter": {
       "caption": "Agent Charter",
-      "description": "A document that defines an AI agent's durable role, responsibilities, constraints, and operating boundaries. When available, populate <code>hashes</code> on the file for content integrity and <code>signatures</code> for provenance. Integrity of the event record that reports this agent is provided separately by the <code>record_integrity</code> profile.",
+      "description": "A document that defines an AI agent's durable role, responsibilities, constraints, and operating boundaries. When available, populate <code>hashes</code> on the file for content integrity and <code>signatures</code> for provenance. Integrity of the event that reports this agent is provided separately by the <code>record_integrity</code> profile.",
       "requirement": "optional"
     }
   }

--- a/objects/ai_agent.json
+++ b/objects/ai_agent.json
@@ -65,7 +65,7 @@
     },
     "charter": {
       "caption": "Agent Charter",
-      "description": "A document that defines an AI agent's durable role, responsibilities, constraints, and operating boundaries. When available, populate <code>hashes</code> on the file for content integrity and <code>signatures</code> for provenance.",
+      "description": "A document that defines an AI agent's durable role, responsibilities, constraints, and operating boundaries. When available, populate <code>hashes</code> on the file for content integrity and <code>signatures</code> for provenance. Integrity of the event record that reports this agent is provided separately by the <code>record_integrity</code> profile.",
       "requirement": "optional"
     }
   }

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -2,7 +2,7 @@
   "caption": "Attestation",
   "name": "attestation",
   "extends": "object",
-  "description": "A cryptographic attestation that an event record has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. Each signature is computed over a canonical serialization of the record, binding the included fields to that identity. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same record) and may participate in a tamper-evident chain through its entry and previous-entry fingerprints. The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
+  "description": "A cryptographic attestation that an event record has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. Each signature is computed over a canonical serialization of the record, binding the included fields to that identity. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same record) and may participate in a tamper-evident chain through its record and previous-record fingerprints. The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
   "attributes": {
     "uid": {
       "caption": "Attestation ID",
@@ -13,19 +13,19 @@
       "description": "One or more digital signatures over the canonical serialization of the event record, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
       "requirement": "required"
     },
-    "entry_hash": {
-      "caption": "Entry Hash",
-      "description": "Fingerprint of this record's canonical serialization. The next record in the chain references it through that record's <code>prev_entry_hash</code>, so that altering this record breaks every later link.",
+    "record_hash": {
+      "caption": "Record Hash",
+      "description": "Fingerprint of this record's canonical serialization. The next record in the chain references it through that record's <code>prev_record_hash</code>, so that altering this record breaks every later link.",
       "requirement": "required"
     },
-    "prev_entry_hash": {
-      "caption": "Previous Entry Hash",
+    "prev_record_hash": {
+      "caption": "Previous Record Hash",
       "description": "Fingerprint of the prior record in the chain, providing tamper-evident ordering. Absent on the first, or genesis, entry of a chain.",
       "requirement": "recommended"
     },
     "chain_uid": {
       "caption": "Chain ID",
-      "description": "Identifier of the append-only chain, such as a forensic or audit log, that this record belongs to. It groups a sequence of attestations so that an independent verifier can locate and validate them in order; it identifies the chain itself and is not a reference to any record outside of this one. Stable for the lifetime of the chain. For example, every attestation produced during a single agent session shares one <code>chain_uid</code>, while each record carries its own <code>entry_hash</code> and links to its predecessor through <code>prev_entry_hash</code>.",
+      "description": "Identifier of the append-only chain, such as a forensic or audit log, that this record belongs to. It groups a sequence of attestations so that an independent verifier can locate and validate them in order; it identifies the chain itself and is not a reference to any record outside of this one. Stable for the lifetime of the chain. For example, every attestation produced during a single agent session shares one <code>chain_uid</code>, while each record carries its own <code>record_hash</code> and links to its predecessor through <code>prev_record_hash</code>.",
       "requirement": "recommended"
     }
   }

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -1,0 +1,38 @@
+{
+  "caption": "Attestation",
+  "name": "attestation",
+  "extends": "object",
+  "description": "A cryptographic attestation that an event record has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. Each signature is computed over a canonical serialization of the record, binding the included fields to that identity. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same record) and may participate in a tamper-evident chain through its entry and previous-entry fingerprints. The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
+  "constraints": {
+    "at_least_one": [
+      "signatures",
+      "entry_hash"
+    ]
+  },
+  "attributes": {
+    "uid": {
+      "caption": "Attestation ID",
+      "description": "Unique identifier of this attestation. It distinguishes an individual attestation, such as a single link within a tamper-evident chain, from the chain as a whole. See <code>chain_uid</code> for the identifier of the chain itself.",
+      "requirement": "optional"
+    },
+    "signatures": {
+      "description": "One or more digital signatures over the canonical serialization of the event record, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
+      "requirement": "recommended"
+    },
+    "entry_hash": {
+      "caption": "Entry Hash",
+      "description": "Fingerprint of this record's canonical serialization. The next record in the chain references it through that record's <code>prev_entry_hash</code>, so that altering this record breaks every later link.",
+      "requirement": "recommended"
+    },
+    "prev_entry_hash": {
+      "caption": "Previous Entry Hash",
+      "description": "Fingerprint of the prior record in the chain, providing tamper-evident ordering. Absent on the first, or genesis, entry of a chain.",
+      "requirement": "recommended"
+    },
+    "chain_uid": {
+      "caption": "Chain ID",
+      "description": "Identifier of the append-only chain, such as a forensic or audit log, that this record belongs to. It groups a sequence of attestations so that an independent verifier can locate and validate them in order; it identifies the chain itself and is not a reference to any record outside of this one. Stable for the lifetime of the chain. For example, every attestation produced during a single agent session shares one <code>chain_uid</code>, while each record carries its own <code>entry_hash</code> and links to its predecessor through <code>prev_entry_hash</code>.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -3,12 +3,6 @@
   "name": "attestation",
   "extends": "object",
   "description": "A cryptographic attestation that an event record has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. Each signature is computed over a canonical serialization of the record, binding the included fields to that identity. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same record) and may participate in a tamper-evident chain through its entry and previous-entry fingerprints. The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
-  "constraints": {
-    "at_least_one": [
-      "signatures",
-      "entry_hash"
-    ]
-  },
   "attributes": {
     "uid": {
       "caption": "Attestation ID",
@@ -17,12 +11,12 @@
     },
     "signatures": {
       "description": "One or more digital signatures over the canonical serialization of the event record, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
-      "requirement": "recommended"
+      "requirement": "required"
     },
     "entry_hash": {
       "caption": "Entry Hash",
       "description": "Fingerprint of this record's canonical serialization. The next record in the chain references it through that record's <code>prev_entry_hash</code>, so that altering this record breaks every later link.",
-      "requirement": "recommended"
+      "requirement": "required"
     },
     "prev_entry_hash": {
       "caption": "Previous Entry Hash",

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -20,7 +20,7 @@
     },
     "fingerprint": {
       "caption": "Fingerprint",
-      "description": "The fingerprint of this event's canonical serialization. Where <code>signatures</code> are present, each signature is computed over this fingerprint. Without signatures, the fingerprint alone still detects accidental alteration or corruption of the event. The next event in a chain references this value through its own <code>prev_event.fingerprint</code>.",
+      "description": "The fingerprint of this event's canonical serialization. If <code>signatures</code> are present, each signature is computed over this fingerprint. Without signatures, the fingerprint alone still detects accidental alteration or corruption of the event. The next event in a chain references this value through its own <code>prev_event.fingerprint</code>.",
       "requirement": "recommended"
     },
     "prev_event": {

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -2,31 +2,42 @@
   "caption": "Attestation",
   "name": "attestation",
   "extends": "object",
-  "description": "A cryptographic attestation that an event record has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. Each signature is computed over a canonical serialization of the record, binding the included fields to that identity. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same record) and may participate in a tamper-evident chain through its record and previous-record fingerprints. The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
+  "description": "A cryptographic attestation that an event has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. The attestation is computed over a canonical serialization of the event: the entire event, including the attestation's own <code>authority_uid</code>, <code>chain_uid</code>, and <code>prev_event</code> attributes, and excluding only the attestation's <code>fingerprint</code> and <code>signatures</code>. Because <code>prev_event</code> is inside the serialized content, deleting or altering an event in a chain breaks the fingerprint and signatures of the event that references it. An attestation may carry more than one signature (for example, a co-signature, notary, or witness over the same event). The verifiable identity is a technical credential, such as a key or certificate, and is not an attribution of any person, organization, or state.",
   "attributes": {
     "uid": {
       "caption": "Attestation ID",
-      "description": "Unique identifier of this attestation. It distinguishes an individual attestation, such as a single link within a tamper-evident chain, from the chain as a whole. See <code>chain_uid</code> for the identifier of the chain itself.",
+      "description": "Unique identifier of this attestation. It distinguishes an individual attestation, such as a single entry within a tamper-evident chain, from the chain as a whole. See <code>chain_uid</code> for the identifier of the chain itself.",
       "requirement": "optional"
     },
+    "authority_uid": {
+      "caption": "Authority ID",
+      "description": "Unique identifier of the authority that produced this attestation, tying the signing credential to a known party. Because signing credentials rotate and expire, a verifier uses this identifier to confirm that the credential carried in <code>signatures</code> belongs to the expected authority, rather than to a different holder of some otherwise-valid credential. Included in the canonical serialization.",
+      "requirement": "recommended"
+    },
     "signatures": {
-      "description": "One or more digital signatures over the canonical serialization of the event record, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
-      "requirement": "required"
+      "description": "One or more digital signatures, each computed over this event's <code>fingerprint</code> and thereby over the event's canonical serialization, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same event. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
+      "requirement": "recommended"
     },
-    "record_hash": {
-      "caption": "Record Hash",
-      "description": "Fingerprint of this record's canonical serialization. The next record in the chain references it through that record's <code>prev_record_hash</code>, so that altering this record breaks every later link.",
-      "requirement": "required"
+    "fingerprint": {
+      "caption": "Fingerprint",
+      "description": "The fingerprint of this event's canonical serialization. Where <code>signatures</code> are present, each signature is computed over this fingerprint. Without signatures, the fingerprint alone still detects accidental alteration or corruption of the event. The next event in a chain references this value through its own <code>prev_event.fingerprint</code>.",
+      "requirement": "recommended"
     },
-    "prev_record_hash": {
-      "caption": "Previous Record Hash",
-      "description": "Fingerprint of the prior record in the chain, providing tamper-evident ordering. Absent on the first, or genesis, entry of a chain.",
+    "prev_event": {
+      "caption": "Previous Event",
+      "description": "Reference to the previous event in a tamper-evident chain, carrying that event's fingerprint together with locator attributes for retrieval. Absent on the first, or genesis, event of a chain.",
       "requirement": "recommended"
     },
     "chain_uid": {
       "caption": "Chain ID",
-      "description": "Identifier of the append-only chain, such as a forensic or audit log, that this record belongs to. It groups a sequence of attestations so that an independent verifier can locate and validate them in order; it identifies the chain itself and is not a reference to any record outside of this one. Stable for the lifetime of the chain. For example, every attestation produced during a single agent session shares one <code>chain_uid</code>, while each record carries its own <code>record_hash</code> and links to its predecessor through <code>prev_record_hash</code>.",
+      "description": "Identifier of the append-only chain, such as a forensic or audit log, that this event belongs to. It groups a sequence of attestations so that an independent verifier can locate and validate them in order; it identifies the chain itself and is not a reference to any event outside of this one. Stable for the lifetime of the chain. For example, every attestation produced during a single agent session shares one <code>chain_uid</code>, so querying events whose <code>attestation.chain_uid</code> matches retrieves the full chain, including its newest entry, while each event links to its predecessor through <code>prev_event</code>.",
       "requirement": "recommended"
     }
+  },
+  "constraints": {
+    "at_least_one": [
+      "fingerprint",
+      "signatures"
+    ]
   }
 }

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -11,7 +11,7 @@
     },
     "authority_uid": {
       "caption": "Authority ID",
-      "description": "Unique identifier of the authority that produced this attestation, tying the signing credential to a known party. Because signing credentials rotate and expire, a verifier uses this identifier to confirm that the credential carried in <code>signatures</code> belongs to the expected authority, rather than to a different holder of some otherwise-valid credential. Included in the canonical serialization.",
+      "description": "Unique identifier of the authority that produced this attestation. When the attestation has a signature, <code>authority_uid</code> ties the signing credential to a known party: because signing credentials rotate and expire, a verifier uses this identifier to confirm that the credential belongs to the expected authority, rather than to a different holder of some otherwise-valid credential. Where multiple <code>signatures</code> are present, it identifies the authority that produced the attestation; the identity of each co-signer is carried within its own <code>digital_signature</code> object. Included in the canonical serialization.",
       "requirement": "recommended"
     },
     "signatures": {

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -80,13 +80,17 @@
       "requirement": "optional"
     },
     "serialization_id": {
-      "description": "The identifier of the normalized canonical serialization or signing-envelope scheme used to produce the deterministic byte sequence that was signed. A verifier must apply the same scheme to reproduce the signing input. Distinct from <code>algorithm_id</code>, which identifies how the resulting bytes were signed; some signing formats (e.g. <code>Authenticode</code>) define their own canonicalization and populate both fields.",
+      "description": "The identifier of the normalized canonical serialization or signing-envelope scheme used to produce the deterministic byte sequence that was signed. A verifier must apply the same scheme to reproduce the signing input. Use <code>Flat</code> where the signed data is an opaque byte sequence, such as file content, to which no canonical serialization was applied. Distinct from <code>algorithm_id</code>, which identifies how the resulting bytes were signed; some signing formats (e.g. <code>Authenticode</code>) define their own canonicalization and populate both fields.",
       "requirement": "recommended",
       "enum": {
         "0": {
           "caption": "Unknown"
         },
         "1": {
+          "caption": "Flat",
+          "description": "No canonical serialization or signing envelope was applied; the signature is computed over the data's raw byte sequence, such as the content of a disk file or any other opaque byte stream."
+        },
+        "2": {
           "caption": "JCS",
           "description": "JSON Canonicalization Scheme - deterministic JSON serialization of the structured data prior to signing.",
           "references": [
@@ -96,7 +100,7 @@
             }
           ]
         },
-        "2": {
+        "3": {
           "caption": "JWS",
           "description": "JSON Web Signature - the JWS Signing Input, i.e. BASE64URL(protected header) '.' BASE64URL(payload).",
           "references": [
@@ -106,7 +110,7 @@
             }
           ]
         },
-        "3": {
+        "4": {
           "caption": "COSE",
           "description": "CBOR Object Signing and Encryption - the CBOR Sig_structure used as the binary signing input.",
           "references": [
@@ -116,7 +120,7 @@
             }
           ]
         },
-        "4": {
+        "5": {
           "caption": "DSSE",
           "description": "Dead Simple Signing Envelope - the PAE (Pre-Authentication Encoding) canonical signing input. Note: DSSE is a signing-envelope scheme, not a hash algorithm; any payload hash is carried separately in the fingerprint object.",
           "references": [
@@ -126,7 +130,7 @@
             }
           ]
         },
-        "5": {
+        "6": {
           "caption": "Authenticode",
           "description": "The Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order. Authenticode bundles canonicalization and signing format: when used, <code>algorithm_id</code> is also set to the <code>Authenticode</code> enum value.",
           "references": [
@@ -136,7 +140,7 @@
             }
           ]
         },
-        "6": {
+        "7": {
           "caption": "Code Signing",
           "description": "The procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
           "references": [
@@ -146,7 +150,7 @@
             }
           ]
         },
-        "7": {
+        "8": {
           "caption": "App Package",
           "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest, and how that manifest is signed.",
           "references": [

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -239,6 +239,92 @@
         }
       }
     },
+    "serialization": {
+      "description": "The canonical serialization scheme used to produce the deterministic byte sequence that was fingerprinted, normalized to the caption of <code>serialization_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "serialization_id": {
+      "description": "The identifier of the normalized canonical serialization scheme used to produce the deterministic byte sequence that was fingerprinted. A verifier must apply the same scheme to reproduce the fingerprinted input. Only meaningful where the fingerprinted data is structured, such as an event; fingerprints of opaque data, such as file content, do not populate it. Distinct from <code>algorithm_id</code>, which identifies how the resulting bytes were hashed.",
+      "requirement": "optional",
+      "enum": {
+        "0": {
+          "caption": "Unknown"
+        },
+        "1": {
+          "caption": "JCS",
+          "description": "JSON Canonicalization Scheme - deterministic JSON serialization of the structured data prior to hashing.",
+          "references": [
+            {
+              "description": "RFC 8785",
+              "url": "https://www.rfc-editor.org/rfc/rfc8785"
+            }
+          ]
+        },
+        "2": {
+          "caption": "JWS",
+          "description": "JSON Web Signature - the JWS Signing Input, i.e. BASE64URL(protected header) '.' BASE64URL(payload).",
+          "references": [
+            {
+              "description": "RFC 7515",
+              "url": "https://www.rfc-editor.org/rfc/rfc7515"
+            }
+          ]
+        },
+        "3": {
+          "caption": "COSE",
+          "description": "CBOR Object Signing and Encryption - the CBOR Sig_structure used as the binary input.",
+          "references": [
+            {
+              "description": "RFC 9052",
+              "url": "https://www.rfc-editor.org/rfc/rfc9052"
+            }
+          ]
+        },
+        "4": {
+          "caption": "DSSE",
+          "description": "Dead Simple Signing Envelope - the PAE (Pre-Authentication Encoding) canonical input. Note: DSSE is a signing-envelope scheme, not a hash algorithm; the hash algorithm is carried in <code>algorithm_id</code>.",
+          "references": [
+            {
+              "description": "DSSE specification (secure-systems-lab)",
+              "url": "https://github.com/secure-systems-lab/dsse"
+            }
+          ]
+        },
+        "5": {
+          "caption": "Authenticode",
+          "description": "The Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order.",
+          "references": [
+            {
+              "description": "Windows Authenticode Portable Executable Signature Format (Microsoft, 2008)",
+              "url": "https://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/Authenticode_PE.docx"
+            }
+          ]
+        },
+        "6": {
+          "caption": "Code Signing",
+          "description": "The procedure that describes how hashes of code and other structures form the Code Directory message that is digested.",
+          "references": [
+            {
+              "description": "TN3126: Inside Code Signing: Hashes",
+              "url": "https://developer.apple.com/documentation/technotes/tn3126-inside-code-signing-hashes"
+            }
+          ]
+        },
+        "7": {
+          "caption": "App Package",
+          "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest, and how that manifest is signed.",
+          "references": [
+            {
+              "description": "Sign an MSIX package",
+              "url": "https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview"
+            }
+          ]
+        },
+        "99": {
+          "caption": "Other"
+        }
+      }
+    },
     "value": {
       "description": "The fingerprint value.<p><b>Note:</b> This uses type <code>file_hash_t</code> (&quot;Hash&quot;), which has been generalized for all fingerprints but retains the same name and caption for backwards compatibility.</p>",
       "requirement": "required",

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -244,13 +244,17 @@
       "requirement": "optional"
     },
     "serialization_id": {
-      "description": "The identifier of the normalized canonical serialization scheme used to produce the deterministic byte sequence that was fingerprinted. A verifier must apply the same scheme to reproduce the fingerprinted input. Only meaningful where the fingerprinted data is structured, such as an event; fingerprints of opaque data, such as file content, do not populate it. Distinct from <code>algorithm_id</code>, which identifies how the resulting bytes were hashed.",
+      "description": "The identifier of the normalized canonical serialization scheme used to produce the deterministic byte sequence that was fingerprinted. A verifier must apply the same scheme to reproduce the fingerprinted input. Use <code>Flat</code> where the fingerprinted data is an opaque byte sequence, such as file content, to which no canonical serialization was applied. Distinct from <code>algorithm_id</code>, which identifies how the resulting bytes were hashed.",
       "requirement": "optional",
       "enum": {
         "0": {
           "caption": "Unknown"
         },
         "1": {
+          "caption": "Flat",
+          "description": "No canonical serialization was applied; the fingerprint is computed over the data's raw byte sequence, such as the content of a disk file or any other opaque byte stream."
+        },
+        "2": {
           "caption": "JCS",
           "description": "JSON Canonicalization Scheme - deterministic JSON serialization of the structured data prior to hashing.",
           "references": [
@@ -260,7 +264,7 @@
             }
           ]
         },
-        "2": {
+        "3": {
           "caption": "JWS",
           "description": "JSON Web Signature - the JWS Signing Input, i.e. BASE64URL(protected header) '.' BASE64URL(payload).",
           "references": [
@@ -270,7 +274,7 @@
             }
           ]
         },
-        "3": {
+        "4": {
           "caption": "COSE",
           "description": "CBOR Object Signing and Encryption - the CBOR Sig_structure used as the binary input.",
           "references": [
@@ -280,7 +284,7 @@
             }
           ]
         },
-        "4": {
+        "5": {
           "caption": "DSSE",
           "description": "Dead Simple Signing Envelope - the PAE (Pre-Authentication Encoding) canonical input. Note: DSSE is a signing-envelope scheme, not a hash algorithm; the hash algorithm is carried in <code>algorithm_id</code>.",
           "references": [
@@ -290,7 +294,7 @@
             }
           ]
         },
-        "5": {
+        "6": {
           "caption": "Authenticode",
           "description": "The Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order.",
           "references": [
@@ -300,7 +304,7 @@
             }
           ]
         },
-        "6": {
+        "7": {
           "caption": "Code Signing",
           "description": "The procedure that describes how hashes of code and other structures form the Code Directory message that is digested.",
           "references": [
@@ -310,7 +314,7 @@
             }
           ]
         },
-        "7": {
+        "8": {
           "caption": "App Package",
           "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest, and how that manifest is signed.",
           "references": [

--- a/objects/prev_event.json
+++ b/objects/prev_event.json
@@ -2,22 +2,22 @@
   "caption": "Previous Event",
   "name": "prev_event",
   "extends": "object",
-  "description": "The Previous Event object references the prior event in a tamper-evident chain. The <code>fingerprint</code> binds the reference to the previous event's content, so that altering or substituting the previous event breaks the link, while <code>uid</code> and <code>type_uid</code> direct a consumer to where the previous event can be retrieved. A producer can always compute the previous event's fingerprint, but may not reliably know its locator; a missing locator degrades retrieval, never verification.",
+  "description": "The Previous Event object references the previous event in a chain of events. Refer to specific usage.",
   "attributes": {
-    "fingerprint": {
-      "caption": "Fingerprint",
-      "description": "The fingerprint of the previous event's canonical serialization. It matches the previous event's own <code>attestation.fingerprint</code>; a verifier recomputes the previous event's fingerprint and compares it to this value to detect alteration or substitution.",
-      "requirement": "required"
-    },
     "uid": {
       "caption": "Unique ID",
       "description": "The unique identifier of the previous event, as carried in that event's <code>metadata.uid</code>.",
-      "requirement": "recommended"
+      "requirement": "required"
     },
     "type_uid": {
       "caption": "Type ID",
       "description": "The event type identifier of the previous event, as carried in that event's <code>type_uid</code>. It directs a consumer to the event class, and therefore the table or store, where the previous event resides.",
       "requirement": "recommended"
+    },
+    "fingerprint": {
+      "caption": "Fingerprint",
+      "description": "The fingerprint of the previous event, binding this reference to the previous event's content so that altering or substituting the previous event breaks the link. Refer to specific usage.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/prev_event.json
+++ b/objects/prev_event.json
@@ -1,0 +1,23 @@
+{
+  "caption": "Previous Event",
+  "name": "prev_event",
+  "extends": "object",
+  "description": "The Previous Event object references the prior event in a tamper-evident chain. The <code>fingerprint</code> binds the reference to the previous event's content, so that altering or substituting the previous event breaks the link, while <code>uid</code> and <code>type_uid</code> direct a consumer to where the previous event can be retrieved. A producer can always compute the previous event's fingerprint, but may not reliably know its locator; a missing locator degrades retrieval, never verification.",
+  "attributes": {
+    "fingerprint": {
+      "caption": "Fingerprint",
+      "description": "The fingerprint of the previous event's canonical serialization. It matches the previous event's own <code>attestation.fingerprint</code>; a verifier recomputes the previous event's fingerprint and compares it to this value to detect alteration or substitution.",
+      "requirement": "required"
+    },
+    "uid": {
+      "caption": "Unique ID",
+      "description": "The unique identifier of the previous event, as carried in that event's <code>metadata.uid</code>.",
+      "requirement": "recommended"
+    },
+    "type_uid": {
+      "caption": "Type ID",
+      "description": "The event type identifier of the previous event, as carried in that event's <code>type_uid</code>. It directs a consumer to the event class, and therefore the table or store, where the previous event resides.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/profiles/record_integrity.json
+++ b/profiles/record_integrity.json
@@ -1,0 +1,12 @@
+{
+  "caption": "Record Integrity",
+  "description": "The Record Integrity profile adds a cryptographic attestation over the event record itself, providing integrity, authenticity, and non-repudiation independent of any domain-specific content. It is domain-agnostic and may be applied to any event class. The attestation is computed over a canonical serialization of the record; multiple signers, such as a producer plus a co-signature, notary, or witness over the same record, are carried in the attestation's <code>signatures</code> array, and a sequence of records may be linked into a tamper-evident chain.",
+  "meta": "profile",
+  "name": "record_integrity",
+  "attributes": {
+    "attestation": {
+      "group": "context",
+      "requirement": "optional"
+    }
+  }
+}

--- a/profiles/record_integrity.json
+++ b/profiles/record_integrity.json
@@ -1,10 +1,10 @@
 {
   "caption": "Record Integrity",
-  "description": "The Record Integrity profile adds a cryptographic attestation over the event itself, providing integrity, authenticity, and non-repudiation independent of any domain-specific content. It is domain-agnostic and may be applied to any event class. The attestation is computed over a canonical serialization of the event; multiple signers, such as a producer plus a co-signature, notary, or witness over the same event, are carried in the attestation's <code>signatures</code> array, and a sequence of events may form a tamper-evident hash chain.",
+  "description": "The Record Integrity profile adds one or more cryptographic attestations over the event itself, providing integrity, authenticity, and non-repudiation independent of any domain-specific content. It is domain-agnostic and may be applied to any event class. Each attestation is computed over a canonical serialization of the event; independent attesters over the same event each contribute a separate entry in <code>attestation_list</code>, while multiple signers of a single attestation, such as a producer plus a co-signature, notary, or witness, are carried in that attestation's <code>signatures</code> array, and a sequence of events may form a tamper-evident hash chain.",
   "meta": "profile",
   "name": "record_integrity",
   "attributes": {
-    "attestation": {
+    "attestation_list": {
       "group": "context",
       "requirement": "optional"
     }

--- a/profiles/record_integrity.json
+++ b/profiles/record_integrity.json
@@ -1,6 +1,6 @@
 {
   "caption": "Record Integrity",
-  "description": "The Record Integrity profile adds a cryptographic attestation over the event record itself, providing integrity, authenticity, and non-repudiation independent of any domain-specific content. It is domain-agnostic and may be applied to any event class. The attestation is computed over a canonical serialization of the record; multiple signers, such as a producer plus a co-signature, notary, or witness over the same record, are carried in the attestation's <code>signatures</code> array, and a sequence of records may be linked into a tamper-evident chain.",
+  "description": "The Record Integrity profile adds a cryptographic attestation over the event itself, providing integrity, authenticity, and non-repudiation independent of any domain-specific content. It is domain-agnostic and may be applied to any event class. The attestation is computed over a canonical serialization of the event; multiple signers, such as a producer plus a co-signature, notary, or witness over the same event, are carried in the attestation's <code>signatures</code> array, and a sequence of events may form a tamper-evident hash chain.",
   "meta": "profile",
   "name": "record_integrity",
   "attributes": {


### PR DESCRIPTION
> **Revision (2026-06-30 SIG cleanup)** — reworked per the SIG discussion and rebased to a single commit on current `main` (post-#1641). Validates clean (`ocsf-validator`, all checks).
>
> - **`record_integrity` profile applied at `base_event`**, so any event class can carry an attestation (not a hand-picked set). Optional.
> - **`attestation` object**: `signatures` (one or more `digital_signature`s over the canonical record), optional tamper-evident chain (`entry_hash` → next record's `prev_entry_hash`; `chain_uid` identifies the append-only chain), and a `uid` for the individual attestation — distinct from `chain_uid`. Constraint: `at_least_one(signatures, entry_hash)`.
> - **Descriptions clarified**: `chain_uid` now states it identifies the chain itself (not a pointer to an external record), with a worked example; the object description frames the identity as a technical credential — not attribution of any person, organization, or state (ITU).
> - `ai_operation` is no longer modified; the agent charter's own integrity stays on the file object, with a `record_integrity` pointer added to the charter description.

---

## Problem

OCSF events describe what happened — but nothing in the schema lets a consumer prove a stored event **hasn't been altered since it was written**, or that it was **produced by who it claims**. Audit logs are editable by whoever holds the database. That's an accepted risk for human-speed activity; it breaks down when autonomous agents execute thousands of consequential actions (payments, deletions, access grants) and the event log is the *only* evidence of what they did.

Concrete failure: an agent's refund attempt is **denied** by policy. Someone with write access to the log flips that record to "Success" to cover a fraud. Today, no OCSF consumer can detect the edit. (MITRE ATT&CK tracks this as [T1565.001 Stored Data Manipulation](https://attack.mitre.org/techniques/T1565/001/) and [T1070 Indicator Removal](https://attack.mitre.org/techniques/T1070/).)

## What this PR adds

One optional, domain-agnostic object — `attestation` — that makes a stored event **tamper-evident** and optionally **non-repudiable**:

| Field | Type | Plain-English meaning |
|--- |--- |--- |
| `entry_hash` | `fingerprint` | A digest of this event's canonical bytes. If the record changes after writing, recomputing the hash exposes it. |
| `prev_entry_hash` | `fingerprint` | The previous event's `entry_hash`. Links events into a chain: you can't alter or delete one record without breaking the link from the next. Absent on the first entry. |
| `chain_uid` | `string_t` | Which chain this event belongs to, so a verifier can find and walk it. |
| `signature` | `digital_signature` | A cryptographic signature over the same canonical bytes, binding the record to a verifiable producer identity (algorithm, key, and canonicalization scheme are declared inside `digital_signature`, per #1662). |

Carried on the `ai_operation` profile as an optional attribute — zero cost to producers who don't populate it. AI agent activity is the first consumer; nothing in the object is AI-specific.

**Detection, not prevention:** nothing here stops an edit. It makes the edit *provable* by any party holding the exported events — offline, with ~100 lines of stdlib code, no trust in the producer's infrastructure.

## Worked example

The denied-refund event, attested (trimmed; full 3-event chain + standalone verifier attached in the comment thread):

```json
{
  "class_uid": 6003,
  "activity_name": "Create",
  "status": "Failure",
  "status_detail": "denied_by_policy: refunds_require_human_approval",
  "actor": { "app_name": "support-agent-7c2f" },
  "api": { "operation": "POST /agent/tools/issue_refund" },
  "metadata": { "version": "1.9.0-dev", "profiles": ["ai_operation"] },
  "attestation": {
    "chain_uid": "chain-org-acme-demo-2026-06",
    "prev_entry_hash": { "algorithm_id": 3, "value": "46775ce9e42b66b2…" },
    "entry_hash":      { "algorithm_id": 3, "value": "8a1cc9a1149e8896…" },
    "signature": {
      "algorithm_id": 3, "algorithm": "ECDSA P-256 SHA-256",
      "serialization_id": 1, "serialization": "JCS"
    }
  }
}
```

Verification: recompute SHA-256 over the event's canonical bytes (everything except `attestation.entry_hash` and `attestation.signature`) → must equal `entry_hash` → must equal the *next* event's `prev_entry_hash` → signature must verify against the producer's public key. Any edit anywhere breaks the math.

## Glossary (for reviewers new to these concepts)

- **Attestation** — a signed statement vouching for something; here, "this exact record existed in this form, produced under this identity."
- **Hash chain** — each record stores the previous record's digest, so the records form a sequence where altering or removing any one breaks every link after it. Same primitive as git commits.
- **Canonicalization** — a deterministic byte serialization (e.g. JCS, RFC 8785) so producer and verifier hash *identical bytes*. Declared via `digital_signature.serialization_id` (#1662).
- **Non-repudiation** — the producer can't later deny having produced the record, because only their key could have signed it.
- **DSSE** — a standard signing envelope (used by sigstore/in-toto); one of the serialization schemes declarable via #1662. Not required by this PR.

## Files changed

| File | Change |
|--- |--- |
| `objects/attestation.json` | New object (4 attributes, all reusing existing types) |
| `dictionary.json` | `attestation`, `entry_hash`, `prev_entry_hash`, `chain_uid` entries |
| `profiles/ai_operation.json` | Optional `attestation` attribute |
| `CHANGELOG.md` | Two entries |

Additive and non-breaking. No existing class, profile, or object changes shape.

## Open with reviewers (from @mikeradka's questions)

- **Placement:** keep on `ai_operation` (AI as first consumer) vs. rescope into a generic `record_integrity` profile usable by API Activity, IAM, cloud audit, findings. Either works; maintainer steer welcome.
- Pending revisions from the thread: `attestations` array (multi-chain), optional `sequence` (reuses existing dictionary attribute), `signature` relaxed to `recommended` with `at_least_one(signature, entry_hash)`, AI references stripped from the object description.

