### PR TITLE
[chore] Update README to fix version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="ocsf.png" alt="OCSF Logo" width="32"/> Open Cybersecurity Schema Framework
 
-[![Version](https://img.shields.io/badge/version-1.9.0-dev-blue.svg)](version.json)
+[![Version](https://img.shields.io/badge/version-1.9.0--dev-blue.svg)](version.json)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 [![Schema Browser](https://img.shields.io/badge/schema-browser-orange.svg)](https://schema.ocsf.io)
 


### PR DESCRIPTION
#### Related Issue: 
N/A

#### Description of changes:
The current `Version` badge is only displaying `404 | badge not found`. This is because the formatting of badges considers `-` as a [special character separator](https://shields.io/badges). The version `1.9.0-dev` breaks this format ([source commit](https://github.com/ocsf/ocsf-schema/commit/b575b9ec8598cf7dd21330375c5d403a850c2a48)). Documentation states it must be a double dash `--` in the URL input to be displayed as a single dash `-`.