### PR TITLE
Add `Code Signing` to `digital_signature` object enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
-  1. Added `Code Signing` to `digital_signature` object enumerations. [#xxxx](https://github.com/ocsf/ocsf-schema/pull/xxxx)
+  1. Added `Code Signing` to `digital_signature` object enumerations. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
 ### Deprecated
   1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
-  1. Added `Code Signing` to `digital_signature` object enumerations. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
+  1. Added `Apple Code Signing (5)` enum value to `algorithm_id` and `Apple Code Signing (6)` enum value to `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
 ### Deprecated
   1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,8 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
-  1. Added `Apple Code Signing (5)` enum value to `algorithm_id` and `Apple Code Signing (6)` enum value to `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
+  1. Added `Code Signing (5)` enum value to `algorithm_id` and `Code Signing (6)` enum value to `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
+  1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
 ### Deprecated
   1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
+  1. Added `Code Signing` to `digital_signature` object enumerations. [#xxxx](https://github.com/ocsf/ocsf-schema/pull/xxxx)
 ### Deprecated
   1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -31,6 +31,10 @@
           "caption": "Authenticode",
           "description": "Microsoft Authenticode Digital Signature Algorithm."
         },
+        "5": {
+          "caption": "Code Signing",
+          "description": "Apple Code Signing Algorithm."
+        },
         "99": {
           "caption": "Other"
         }
@@ -107,6 +111,16 @@
             {
               "description": "Windows Authenticode Portable Executable Signature Format (Microsoft, 2008)",
               "url": "https://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/Authenticode_PE.docx"
+            }
+          ]
+        },
+        "6": {
+          "caption": "Code Signing",
+          "description": "Apple Code Signing - the procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
+          "references": [
+            {
+              "description": "TN3126: Inside Code Signing: Hashes",
+              "url": "https://developer.apple.com/documentation/technotes/tn3126-inside-code-signing-hashes"
             }
           ]
         },

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -118,7 +118,7 @@
         },
         "5": {
           "caption": "Authenticode",
-          "description": "Authenticode - the Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order. Authenticode bundles canonicalization and signing format: when used, <code>algorithm_id</code> is also set to the <code>Authenticode</code> enum value.",
+          "description": "The Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order. Authenticode bundles canonicalization and signing format: when used, <code>algorithm_id</code> is also set to the <code>Authenticode</code> enum value.",
           "references": [
             {
               "description": "Windows Authenticode Portable Executable Signature Format (Microsoft, 2008)",
@@ -128,7 +128,7 @@
         },
         "6": {
           "caption": "Code Signing",
-          "description": "Code Signing - the procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
+          "description": "The procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
           "references": [
             {
               "description": "TN3126: Inside Code Signing: Hashes",

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -32,7 +32,7 @@
           "description": "Microsoft Authenticode Digital Signature Algorithm."
         },
         "5": {
-          "caption": "Code Signing",
+          "caption": "Apple Code Signing",
           "description": "Apple Code Signing Algorithm."
         },
         "99": {
@@ -115,7 +115,7 @@
           ]
         },
         "6": {
-          "caption": "Code Signing",
+          "caption": "Apple Code Signing",
           "description": "Apple Code Signing - the procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
           "references": [
             {

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -29,11 +29,23 @@
         },
         "4": {
           "caption": "Authenticode",
-          "description": "Authenticode Digital Signature Algorithm."
+          "description": "Authenticode Digital Signature Algorithm.",
+          "references": [
+            {
+              "description": "Windows Authenticode Portable Executable Signature Format (Microsoft, 2008)",
+              "url": "https://download.microsoft.com/download/9/c/5/9c5b2167-8017-4bae-9fde-d599bac8184a/Authenticode_PE.docx"
+            }
+          ]
         },
         "5": {
           "caption": "Code Signing",
-          "description": "Code Signing Algorithm."
+          "description": "Code Signing Algorithm.",
+          "references": [
+            {
+              "description": "TN3126: Inside Code Signing: Hashes",
+              "url": "https://developer.apple.com/documentation/technotes/tn3126-inside-code-signing-hashes"
+            }
+          ]
         },
         "99": {
           "caption": "Other"

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -29,11 +29,11 @@
         },
         "4": {
           "caption": "Authenticode",
-          "description": "Microsoft Authenticode Digital Signature Algorithm."
+          "description": "Authenticode Digital Signature Algorithm."
         },
         "5": {
-          "caption": "Apple Code Signing",
-          "description": "Apple Code Signing Algorithm."
+          "caption": "Code Signing",
+          "description": "Code Signing Algorithm."
         },
         "99": {
           "caption": "Other"
@@ -106,7 +106,7 @@
         },
         "5": {
           "caption": "Authenticode",
-          "description": "Microsoft Authenticode - the Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order. Authenticode bundles canonicalization and signing format: when used, <code>algorithm_id</code> is also set to the <code>Authenticode</code> enum value.",
+          "description": "Authenticode - the Portable Executable (PE) Image Hash procedure that canonicalizes the PE structure into the byte sequence fed to the digest, excluding specified header fields and digesting sections in a defined order. Authenticode bundles canonicalization and signing format: when used, <code>algorithm_id</code> is also set to the <code>Authenticode</code> enum value.",
           "references": [
             {
               "description": "Windows Authenticode Portable Executable Signature Format (Microsoft, 2008)",
@@ -115,8 +115,8 @@
           ]
         },
         "6": {
-          "caption": "Apple Code Signing",
-          "description": "Apple Code Signing - the procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
+          "caption": "Code Signing",
+          "description": "Code Signing - the procedure that describes how hashes of code and other structures form the Code Directory message that is signed. When used, <code>algorithm_id</code> is also set to the <code>Code Signing</code> enum value.",
           "references": [
             {
               "description": "TN3126: Inside Code Signing: Hashes",


### PR DESCRIPTION
#### Related Issue: 

[Apple Code Signing identification is needed in digital_signature object
 #1667](https://github.com/ocsf/ocsf-schema/issues/1667)

#### Description of changes:

Added `Code Signing` to `digital_signature` object enumerations.


<img width="2501" height="783" alt="algorith" src="https://github.com/user-attachments/assets/e6628165-3985-480f-8378-13b240ddb96a" />
<img width="2730" height="282" alt="serialisation" src="https://github.com/user-attachments/assets/99a7caf3-8e00-47a6-bf5e-c394b3e9a07b" />
