### PR TITLE
Added a Notes object and an array of notes to the Findings classes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Thankyou! -->
 1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
 1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
 1. Deprecated the `user` attribute in the `group_management` class in favor of `users`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
+1. Deprecated the `comment` attribute in the `finding` class and its extended classes, and the `incident_finding` class in favor of `notes`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Thankyou! -->
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `users` to `group_management` to replace deprecated `user`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
   1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
-  1. Added `resources` to `finding` for consistency and referencing within the class. Added `devices`, `endpoint_connections`, and `users` to `finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+  1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added the `ai_operation` profile to the `system`, `network`, `application`, and `iam` base event classes so all System Activity, Network Activity, Application Activity, and Identity & Access Management events inherit agent attribution. Also added the profile to `email_activity` (which does not extend a base with the profile). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Thankyou! -->
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `users` to `group_management` to replace deprecated `user`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
   1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
-  1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+  1. Added `resources` to `finding` for consistency and referencing within the class. Added `devices`, `endpoint_connections`, and `users` to `finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added the `ai_operation` profile to the `system`, `network`, `application`, and `iam` base event classes so all System Activity, Network Activity, Application Activity, and Identity & Access Management events inherit agent attribution. Also added the profile to `email_activity` (which does not extend a base with the profile). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Thankyou! -->
   1. Added `dns_section` object to represent a DNS message section containing supplementary resource records and an optional TSIG record. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `tsig` object to represent a TSIG (Transaction Signature) record with structured fields for security analytics: `algorithm`, `key_name`, `error_id`, and `error`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `download_info` object with information pertaining to a downloaded file. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `note` object to capture a comment along with the user who made the comment and when the note was modified. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
@@ -78,6 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `notes` attribute as an array of `Note` objects. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
 ### Improved
 * #### Categories
@@ -89,6 +92,8 @@ Thankyou! -->
   1. Added `transaction_id`, `opcode_id`/`opcode`, `flag_ids`/`flags`, `authority`, `query_additional`, and `response_additional` to `DNS Activity`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `users` to `group_management` to replace deprecated `user`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
+  1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+  1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 * #### Profiles
 * #### Objects
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/dictionary.json
+++ b/dictionary.json
@@ -4378,6 +4378,12 @@
       "type": "string_t",
       "is_array": true
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the event or object. See specific usage.",
+      "type": "note",
+      "is_array": true
+    },
     "nodes": {
       "caption": "Nodes",
       "description": "The list of node objects that are part of the graph.",

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -75,7 +75,7 @@
     "resources": {
       "caption": "Affected Resources",
       "description": "Describes details about resources that were the target of the activity that triggered the finding.",
-      "group": "context",
+      "group": "primary",
       "requirement": "recommended"
     },
     "risk_details": {

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -56,7 +56,16 @@
       "description": "Describes the affected device/host. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",
       "group": "context",
       "requirement": "optional",
-      "profile": null
+      "profile": null,
+      "@deprecated": {
+        "message": "Use the <code>devices</code> attribute instead.",
+        "since": "1.9.0"
+      }
+    },
+    "devices": {
+      "description": "Describes the affected devices/hosts. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about AWS EC2 instances, that are affected by the Finding.</p><p>If a single device is the source of the Finding, use the <code>Host</code> profile.</p>",
+      "group": "context",
+      "requirement": "optional"
     },
     "end_time": {
       "description": "The time of the most recent event or finding that contributed to this finding.",

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -62,6 +62,12 @@
       "group": "primary",
       "requirement": "required"
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time, where an updated comment may not suffice.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "start_time": {
       "description": "The time of the earliest event or finding that contributed to this finding.",
       "requirement": "optional"

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -68,6 +68,12 @@
       "group": "context",
       "requirement": "optional"
     },
+    "resources": {
+      "caption": "Affected Resources",
+      "description": "Describes details about resources that were the target of the activity that triggered the finding.",
+      "group": "context",
+      "requirement": "recommended"
+    },
     "start_time": {
       "description": "The time of the earliest event or finding that contributed to this finding.",
       "requirement": "optional"

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -4,6 +4,9 @@
   "description": "The Finding event is a generic event that defines a set of attributes available in the Findings category.",
   "extends": "base_event",
   "name": "finding",
+  "profiles": [
+    "incident"
+  ],
   "attributes": {
     "$include": [
       "profiles/incident.json"
@@ -53,22 +56,23 @@
       "profile": null
     },
     "device": {
-      "description": "Describes the affected device/host. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",
+      "description": "Describes the device/host relevant to the finding. <p>If applicable, it can be used in conjunction with <code>resources</code>. e.g. The role of the device as the target or the actor, its IP address etc.</p><p>If a single device is the source of the finding, rather than a targeted or affected device, use the <code>Host</code> profile and populate <code>device</code>.</p>",
       "group": "context",
       "requirement": "optional",
-      "profile": null,
-      "@deprecated": {
-        "message": "Use the <code>devices</code> attribute instead.",
-        "since": "1.9.0"
-      }
+      "profile": null
     },
     "devices": {
-      "description": "Describes the affected devices/hosts. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about AWS EC2 instances, that are affected by the Finding.</p><p>If a single device is the source of the Finding, use the <code>Host</code> profile.</p>",
+      "description": "Describes the devices/hosts relevant to the finding. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the devices as targets or actors, their IP addresses etc.</p><p>If a single device is the source of the finding, use the <code>Host</code> profile and populate <code>device</code>.</p>",
       "group": "context",
       "requirement": "optional"
     },
     "end_time": {
       "description": "The time of the most recent event or finding that contributed to this finding.",
+      "requirement": "optional"
+    },
+    "endpoint_connections": {
+      "description": "Describes the affected endpoint network connections, or network connection attempts. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the endpoints as targets or actors, their hostnames etc.</p>",
+      "group": "context",
       "requirement": "optional"
     },
     "finding_info": {
@@ -130,12 +134,14 @@
         }
       }
     },
+    "users": {
+      "description": "Describes the users that are affected by the finding.</p><p>If a single user is the source of the finding or activities behind the finding, use the <code>Host</code> profile and populate <code>actor.user</code>.</p>",
+      "group": "context",
+      "requirement": "optional"
+    },
     "vendor_attributes": {
       "group": "context",
       "requirement": "optional"
     }
-  },
-  "profiles": [
-    "incident"
-  ]
+  }
 }

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -31,7 +31,11 @@
     "comment": {
       "description": "A user provided comment about the finding.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>notes</code> attribute instead.",
+        "since": "1.9.0"
+      }
     },
     "confidence": {
       "group": "context",
@@ -64,7 +68,7 @@
     },
     "notes": {
       "caption": "Notes",
-      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time, where an updated comment may not suffice.",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, the time when the note was created, and the time when the note was last modified (typically by the same user). Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time.",
       "group": "context",
       "requirement": "optional"
     },

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -61,18 +61,8 @@
       "requirement": "optional",
       "profile": null
     },
-    "devices": {
-      "description": "Describes the devices/hosts relevant to the finding. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the devices as targets or actors, their IP addresses etc.</p><p>If a single device is the source of the finding, use the <code>Host</code> profile and populate <code>device</code>.</p>",
-      "group": "context",
-      "requirement": "optional"
-    },
     "end_time": {
       "description": "The time of the most recent event or finding that contributed to this finding.",
-      "requirement": "optional"
-    },
-    "endpoint_connections": {
-      "description": "Describes the affected endpoint network connections, or network connection attempts. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the endpoints as targets or actors, their hostnames etc.</p>",
-      "group": "context",
       "requirement": "optional"
     },
     "finding_info": {
@@ -133,11 +123,6 @@
           "description": "The Finding was deleted. For example, it might have been created in error."
         }
       }
-    },
-    "users": {
-      "description": "Describes the users that are affected by the finding.</p><p>If a single user is the source of the finding or activities behind the finding, use the <code>Host</code> profile and populate <code>actor.user</code>.</p>",
-      "group": "context",
-      "requirement": "optional"
     },
     "vendor_attributes": {
       "group": "context",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -91,6 +91,12 @@
       "group": "context",
       "requirement": "optional"
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the incident. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time, where an updated comment may not suffice.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "priority": {
       "group": "context",
       "requirement": "optional"

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -45,7 +45,11 @@
     "comment": {
       "description": "Additional user supplied details for updating or closing the incident.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>notes</code> attribute instead.",
+        "since": "1.9.0"
+      }
     },
     "confidence": {
       "group": "context",
@@ -93,7 +97,7 @@
     },
     "notes": {
       "caption": "Notes",
-      "description": "Additional notes related to the incident. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time, where an updated comment may not suffice.",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, the time when the note was created, and the time when the note was last modified (typically by the same user). Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time.",
       "group": "context",
       "requirement": "optional"
     },

--- a/objects/note.json
+++ b/objects/note.json
@@ -1,0 +1,20 @@
+{
+  "caption": "Note",
+  "description": "Represents a note or a comment in the system. Notes can be used to provide additional context, explanations, or observations related to an event, object, or any other entity in the system. They can be created and modified by users to capture important information that may not be directly represented in the structured data.",
+  "extends": "object",
+  "name": "note",
+  "attributes": {
+    "comment": {
+      "description": "A user provided comment.",
+      "requirement": "required"
+    },
+    "modified_time": {
+      "description": "The time when the note was last modified.",
+      "requirement": "recommended"
+    },
+    "user": {
+      "description": "The user who created or last modified the note.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/note.json
+++ b/objects/note.json
@@ -8,6 +8,10 @@
       "description": "A user provided comment.",
       "requirement": "required"
     },
+    "created_time": {
+      "description": "The time when the note was created.",
+      "requirement":"recommended"
+    },
     "modified_time": {
       "description": "The time when the note was last modified.",
       "requirement": "recommended"

--- a/objects/note.json
+++ b/objects/note.json
@@ -19,6 +19,14 @@
     "owner": {
       "description": "The user who created or last modified the note. Typically the same user that created the note can modify the note.",
       "requirement": "recommended"
+    },
+    "title": {
+      "description": "A short description of the comment, if applicable.",
+      "requirement": "optional"
+    },
+    "uid": {
+      "description": "The unique identifier of the note, if applicable.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/note.json
+++ b/objects/note.json
@@ -16,8 +16,8 @@
       "description": "The time when the note was last modified.",
       "requirement": "recommended"
     },
-    "user": {
-      "description": "The user who created or last modified the note.",
+    "owner": {
+      "description": "The user who created or last modified the note. Typically the same user that created the note can modify the note.",
       "requirement": "recommended"
     }
   }


### PR DESCRIPTION
#### Related Issue: 1659

#### Description of changes:

As mentioned in the above Issue, a simple `comment` attribute is not sufficient for findings that are modified over time, especially by multiple analysts.

This PR creates a `Note` object that includes a `comment` attribute but also a `owner`, `created_time` and `modified_time` to capture the details of who made the comment and when. The `Finding` classes and the `Incident Finding` class include a `notes` attribute with an array of `Note` objects to track comments over the lifecyle of the finding or incident.

The `comment` attribute is deprecated in favor of `notes`.

`finding` was improved with an array of `devices`, `endpoint_connections`, `users` and more detailed descriptions on when to use `resources` and when to apply the `Host` profile.

One small structural change was made: the `Finding` base class has a `device` attribute whose comment refers to `resources` which only appeared in the extended classes. This PR adds the `resources` attribute to `Finding` but preserves the overriddent descriptions in each of the extended finding classes.