### PR TITLE
Add `prompt_text` and `response_text` to `message_context` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
-  1. Added `prompt_text` and `response_text` attributes for capturing the input prompt text and model response text of an AI message. [#1640](https://github.com/ocsf/ocsf-schema/issues/1640)
+  1. Added `prompt_text` and `response_text` attributes for capturing the input prompt text and model response text of an AI message. [#1674](https://github.com/ocsf/ocsf-schema/pull/1674)
 
 ### Improved
 * #### Categories
@@ -108,7 +108,7 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
-  1. Added `prompt_text` and `response_text` attributes to the `message_context` object, complementing the existing `prompt_tokens` and `completion_tokens` metrics with the verbatim prompt and response text. [#1640](https://github.com/ocsf/ocsf-schema/issues/1640)
+  1. Added `prompt_text` and `response_text` attributes to the `message_context` object, complementing the existing `prompt_tokens` and `completion_tokens` metrics with the verbatim prompt and response text. [#1674](https://github.com/ocsf/ocsf-schema/pull/1674)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `prompt_text` and `response_text` attributes for capturing the input prompt text and model response text of an AI message. [#1640](https://github.com/ocsf/ocsf-schema/issues/1640)
 
 ### Improved
 * #### Categories
@@ -107,6 +108,7 @@ Thankyou! -->
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
+  1. Added `prompt_text` and `response_text` attributes to the `message_context` object, complementing the existing `prompt_tokens` and `completion_tokens` metrics with the verbatim prompt and response text. [#1640](https://github.com/ocsf/ocsf-schema/issues/1640)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes

--- a/dictionary.json
+++ b/dictionary.json
@@ -5059,6 +5059,11 @@
         "since": "1.4.0"
       }
     },
+    "prompt_text": {
+      "caption": "Prompt Text",
+      "description": "The text of the input prompt provided to the model for this message. This is the verbatim instruction, query, or context supplied to the AI system that drove the operation.",
+      "type": "string_t"
+    },
     "prompt_tokens": {
       "caption": "Prompt Tokens",
       "description": "Number of tokens in the input prompt for this message.",
@@ -5634,6 +5639,11 @@
       "caption": "API Response Details",
       "description": "General Purpose API Response Object. See specific usage.",
       "type": "response"
+    },
+    "response_text": {
+      "caption": "Response Text",
+      "description": "The text of the model's response generated for this message. For agent-mediated operations, this is the content returned by the assistant, tool, or agent.",
+      "type": "string_t"
     },
     "response_time": {
       "caption": "Response Time",

--- a/objects/message_context.json
+++ b/objects/message_context.json
@@ -50,14 +50,18 @@
       "requirement": "recommended"
     },
     "completion_tokens": {
-      "description": "Number of tokens in the model's response/completion for this message.",
       "requirement": "optional"
     },
     "name": {
       "description": "The name or identifier of the message context. In AI systems, this could be the conversation ID, session name, thread identifier, or interaction name (e.g., 'user-session-123', 'conversation-abc', 'chat-thread-456')."
     },
+    "prompt_text": {
+      "requirement": "optional"
+    },
     "prompt_tokens": {
-      "description": "Number of tokens in the input prompt for this message.",
+      "requirement": "optional"
+    },
+    "response_text": {
       "requirement": "optional"
     },
     "service": {
@@ -65,7 +69,6 @@
       "requirement": "recommended"
     },
     "total_tokens": {
-      "description": "Total number of tokens used for this message (prompt + completion).",
       "requirement": "optional"
     },
     "uid": {


### PR DESCRIPTION
Capture the verbatim input prompt and model response text of an AI message, complementing the existing `prompt_tokens` and `completion_tokens` metrics on the `message_context` object.

<img width="2746" height="665" alt="image" src="https://github.com/user-attachments/assets/f3fe82f0-35cc-424f-a93c-bf1a259ae18f" />


#### Related Issue: 
#1640 
