### PR TITLE
Add DNS Zone Transfer Activity class (AXFR / IXFR / NOTIFY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Thankyou! -->
   1. Added user_management and role_management. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Added clipboard_activity. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added device_power_state_activity (`Device Power State Activity`) class to capture power state changes of a device. [#1624](https://github.com/ocsf/ocsf-schema/pull/1624)
-  1. Added `dns_zone_transfer_activity` (`DNS Zone Transfer Activity`) class to capture DNS zone transfers (AXFR/IXFR) and NOTIFY. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
+  1. Added `dns_zone_transfer_activity` (`DNS Zone Transfer Activity`) class to capture DNS zone transfers (AXFR/IXFR) and NOTIFY. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
 * #### Profiles
 * #### Objects
   1. Added `job_action` object to describe an action that job can perform. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -60,7 +60,7 @@ Thankyou! -->
   1. Added `dns_section` object to represent a DNS message section containing supplementary resource records and an optional TSIG record. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `tsig` object to represent a TSIG (Transaction Signature) record with structured fields for security analytics: `algorithm`, `key_name`, `error_id`, and `error`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `download_info` object with information pertaining to a downloaded file. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
-  1. Added `dns_soa` object to represent the RFC 1035 SOA (Start of Authority) record RDATA, used to carry zone serials and timers in DNS zone transfers. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
+  1. Added `dns_soa` object to represent the RFC 1035 SOA (Start of Authority) record RDATA, used to carry zone serials and timers in DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
@@ -80,7 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
-  1. Added `dns_zone`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
+  1. Added `dns_zone`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
 
 ### Improved
 * #### Categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
-  1. Added `dns_zone`, `additional`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
+  1. Added `dns_zone`, `additional`, `soa`, `updated_soa`, `num_records`, `transfer_type`, `transfer_type_id`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
 
 ### Improved
 * #### Categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Thankyou! -->
   1. Added user_management and role_management. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
   1. Added clipboard_activity. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added device_power_state_activity (`Device Power State Activity`) class to capture power state changes of a device. [#1624](https://github.com/ocsf/ocsf-schema/pull/1624)
+  1. Added `dns_zone_transfer_activity` (`DNS Zone Transfer Activity`) class to capture DNS zone transfers (AXFR/IXFR) and NOTIFY. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
 * #### Profiles
 * #### Objects
   1. Added `job_action` object to describe an action that job can perform. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -59,6 +60,7 @@ Thankyou! -->
   1. Added `dns_section` object to represent a DNS message section containing supplementary resource records and an optional TSIG record. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `tsig` object to represent a TSIG (Transaction Signature) record with structured fields for security analytics: `algorithm`, `key_name`, `error_id`, and `error`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `download_info` object with information pertaining to a downloaded file. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `dns_soa` object to represent the RFC 1035 SOA (Start of Authority) record RDATA, used to carry zone serials and timers in DNS zone transfers. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
@@ -78,6 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `dns_zone`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#PRNUM](https://github.com/ocsf/ocsf-schema/pull/PRNUM)
 
 ### Improved
 * #### Categories

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
-  1. Added `dns_zone`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
+  1. Added `dns_zone`, `additional`, `soa`, `updated_soa`, `num_records`, and the SOA sub-fields `primary_server`, `responsible_party`, `serial`, `refresh_interval`, `retry_interval`, `expire_interval`, and `minimum_ttl` for DNS zone transfers. [#1675](https://github.com/ocsf/ocsf-schema/pull/1675)
 
 ### Improved
 * #### Categories

--- a/dictionary.json
+++ b/dictionary.json
@@ -6936,6 +6936,17 @@
       "description": "The unique identifier of the transaction.",
       "type": "string_t"
     },
+    "transfer_type": {
+      "caption": "Transfer Type",
+      "description": "The type of transfer, normalized to the caption of the <code>transfer_type_id</code> value. In the case of 'Other', it is defined by the event source. See specific usage.",
+      "type": "string_t"
+    },
+    "transfer_type_id": {
+      "caption": "Transfer Type ID",
+      "description": "The normalized identifier of the transfer type. See specific usage.",
+      "sibling": "transfer_type",
+      "type": "integer_t"
+    },
     "transformation_info_list": {
       "caption": "Transformation Info",
       "description": "An array of transformation info that describes the mappings or transforms applied to the data.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -182,6 +182,11 @@
       "description": "The Additional section of the DNS response message sent by the server, containing supplementary resource records and an optional TSIG record. A DNS message has at most one TSIG record; for a transaction with both query and response, the query TSIG is in <code>query_additional.tsig</code> and the response TSIG is in <code>response_additional.tsig</code>.",
       "type": "dns_section"
     },
+    "additional": {
+      "caption": "DNS Additional Section",
+      "description": "The Additional section of a DNS message, containing supplementary resource records and an optional TSIG record. Per RFC 2845, a DNS message has at most one TSIG record, available via <code>additional.tsig</code>.",
+      "type": "dns_section"
+    },
     "additional_restrictions": {
       "caption": "Additional Restrictions",
       "description": "The supplementary restrictions that may apply to an entity, by the virtue of a policy. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -2302,6 +2302,11 @@
       "description": "The Domain-based Message Authentication, Reporting and Conformance (DMARC) policy status.",
       "type": "string_t"
     },
+    "dns_zone": {
+      "caption": "DNS Zone",
+      "description": "The fully qualified name of the DNS zone, i.e., the zone apex. For example: <code>example.com</code>. See specific usage.",
+      "type": "string_t"
+    },
     "dnssec_status": {
       "caption": "DNSSEC Status",
       "description": "The normalized value of dnssec_status_id.",
@@ -2663,6 +2668,11 @@
       "caption": "Expiration Time",
       "description": "The expiration time. See specific usage.",
       "type": "timestamp_t"
+    },
+    "expire_interval": {
+      "caption": "Expire Interval",
+      "description": "The DNS SOA EXPIRE field: the time interval, in seconds, after which a secondary name server that has been unable to refresh the zone stops answering authoritatively for it. See RFC 1035 §3.3.13.",
+      "type": "integer_t"
     },
     "exploit_last_seen_time": {
       "caption": "Exploit Last Seen Time",
@@ -4261,6 +4271,11 @@
       "description": "The Multipurpose Internet Mail Extensions (MIME) type of the data, if applicable.  See specific usage.",
       "type": "string_t"
     },
+    "minimum_ttl": {
+      "caption": "Minimum TTL",
+      "description": "The DNS SOA MINIMUM field: the time interval, in seconds, that defines the TTL for negative caching of records from this zone. See RFC 1035 §3.3.13 and RFC 2308.",
+      "type": "integer_t"
+    },
     "mitigation": {
       "caption": "MITRE Mitigation",
       "description": "The Mitigation object describes the MITRE ATT&CK® or ATLAS™ Mitigation ID and/or name that is associated to an attack.",
@@ -4397,6 +4412,11 @@
     "num_folders": {
       "caption": "Scanned Folders",
       "description": "The number of folders scanned.",
+      "type": "integer_t"
+    },
+    "num_records": {
+      "caption": "Number of Records",
+      "description": "The number of records. See specific usage.",
       "type": "integer_t"
     },
     "num_infected": {
@@ -4949,6 +4969,11 @@
       "type": "security_state",
       "is_array": true
     },
+    "primary_server": {
+      "caption": "Primary Server",
+      "description": "The DNS SOA MNAME field: the fully qualified domain name of the primary (master) name server that is the original source of data for the zone. For example: <code>ns1.example.com</code>. See RFC 1035 §3.3.13.",
+      "type": "string_t"
+    },
     "priority": {
       "caption": "Priority",
       "description": "The priority, normalized to the caption of the priority_id value. In the case of 'Other', it is defined by the event source.",
@@ -5434,6 +5459,11 @@
       "description": "The request header that identifies the address of the previous web page, which is linked to the current web page or resource being requested.",
       "type": "string_t"
     },
+    "refresh_interval": {
+      "caption": "Refresh Interval",
+      "description": "The DNS SOA REFRESH field: the time interval, in seconds, before a secondary name server should query the primary to check for zone updates. See RFC 1035 §3.3.13.",
+      "type": "integer_t"
+    },
     "region": {
       "caption": "Region",
       "description": "The name or the code of a region. See specific usage.",
@@ -5639,6 +5669,16 @@
       "caption": "Response Time",
       "description": "The Domain Name System (DNS) response time.",
       "type": "timestamp_t"
+    },
+    "responsible_party": {
+      "caption": "Responsible Party",
+      "description": "The DNS SOA RNAME field: the email address of the party responsible for the zone, encoded as a domain name (the first label is the local part of the address). For example: <code>hostmaster.example.com</code> represents <code>hostmaster@example.com</code>. See RFC 1035 §3.3.13.",
+      "type": "string_t"
+    },
+    "retry_interval": {
+      "caption": "Retry Interval",
+      "description": "The DNS SOA RETRY field: the time interval, in seconds, before a secondary name server should retry a failed zone refresh. See RFC 1035 §3.3.13.",
+      "type": "integer_t"
     },
     "return_path": {
       "caption": "Return Path",
@@ -6059,6 +6099,11 @@
       "description": "The sequence number. See specific usage.",
       "type": "long_t"
     },
+    "serial": {
+      "caption": "Serial",
+      "description": "The DNS SOA SERIAL field: the unsigned 32-bit version number of the zone, incremented when the zone contents change. Secondary name servers compare this value to decide whether a zone transfer is needed. See RFC 1035 §3.3.13.",
+      "type": "long_t"
+    },
     "serial_number": {
       "observable": 37,
       "caption": "Serial Number",
@@ -6241,6 +6286,11 @@
       "caption": "Server Name Indication",
       "description": " The Server Name Indication (SNI) extension sent by the client.",
       "type": "string_t"
+    },
+    "soa": {
+      "caption": "SOA Record",
+      "description": "The DNS SOA (Start of Authority) record. See specific usage.",
+      "type": "dns_soa"
     },
     "software_components": {
       "caption": "Software Components",
@@ -7080,6 +7130,11 @@
       "caption": "Updated Role",
       "description": "The updated role. See specific usage.",
       "type": "iam_role"
+    },
+    "updated_soa": {
+      "caption": "Updated SOA Record",
+      "description": "The DNS SOA (Start of Authority) record after the change. See specific usage.",
+      "type": "dns_soa"
     },
     "updated_user": {
       "caption": "Updated User",

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -9,11 +9,11 @@
       "enum": {
         "1": {
           "caption": "Transfer Request",
-          "description": "A request from a secondary name server to transfer a zone. Whether a full (AXFR) or incremental (IXFR) transfer was requested is conveyed by <code>type_id</code>. See RFC 5936 and RFC 1995."
+          "description": "A request from a secondary name server to transfer a zone. Whether a full (AXFR) or incremental (IXFR) transfer was requested is conveyed by <code>transfer_type_id</code>. See RFC 5936 and RFC 1995."
         },
         "2": {
           "caption": "Transfer Response",
-          "description": "A zone transfer response message from the primary name server. A single transfer may be delivered as a stream of multiple response messages. Whether the delivered data is a full (AXFR) or incremental (IXFR) transfer is conveyed by <code>type_id</code>; note that a server may answer an IXFR request with a full transfer when it cannot produce a delta. See RFC 5936 and RFC 1995."
+          "description": "A zone transfer response message from the primary name server. A single transfer may be delivered as a stream of multiple response messages. Whether the delivered data is a full (AXFR) or incremental (IXFR) transfer is conveyed by <code>transfer_type_id</code>; note that a server may answer an IXFR request with a full transfer when it cannot produce a delta. See RFC 5936 and RFC 1995."
         },
         "3": {
           "caption": "Notify",
@@ -21,12 +21,11 @@
         },
         "4": {
           "caption": "Completed Transfer",
-          "description": "A completed zone transfer reported as a single summary record rather than as separate request and response messages. Used by sources, such as name server logs, that emit one event per transfer with the zone, record count, byte count, duration, and peer. Whether the transfer was full (AXFR) or incremental (IXFR) is conveyed by <code>type_id</code>."
+          "description": "A completed zone transfer reported as a single summary record rather than as separate request and response messages. Used by sources, such as name server logs, that emit one event per transfer with the zone, record count, byte count, duration, and peer. Whether the transfer was full (AXFR) or incremental (IXFR) is conveyed by <code>transfer_type_id</code>."
         }
       }
     },
-    "type_id": {
-      "caption": "Transfer Type ID",
+    "transfer_type_id": {
       "description": "The normalized identifier of the zone transfer type. On a <code>Transfer Request</code> this is the type requested; on a <code>Transfer Response</code> or <code>Completed Transfer</code> this is the type actually delivered.",
       "requirement": "recommended",
       "enum": {
@@ -40,13 +39,12 @@
         }
       }
     },
-    "type": {
-      "caption": "Transfer Type",
-      "description": "The zone transfer type, normalized to the caption of the <code>type_id</code> value. In the case of 'Other', it is defined by the event source.",
+    "transfer_type": {
+      "description": "The zone transfer type, normalized to the caption of the <code>transfer_type_id</code> value. In the case of 'Other', it is defined by the event source.",
       "requirement": "optional"
     },
     "dns_zone": {
-      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY. The message role is conveyed by <code>activity_id</code> and the transfer type (AXFR or IXFR) by <code>type_id</code>. For example: <code>example.com</code>.",
+      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY. The message role is conveyed by <code>activity_id</code> and the transfer type (AXFR or IXFR) by <code>transfer_type_id</code>. For example: <code>example.com</code>.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -1,7 +1,7 @@
 {
   "uid": 15,
   "caption": "DNS Zone Transfer Activity",
-  "description": "DNS Zone Transfer Activity events report the bulk replication of a DNS zone between name servers, as seen on the network. This includes full transfers (AXFR, RFC 5936), incremental transfers (IXFR, RFC 1995), and change notifications (NOTIFY, RFC 1996). Unlike <code>DNS Activity</code>, which reports per-name queries and answers, this class captures whole-zone semantics: SOA serials, the records that make up the zone, and the multi-message streams that carry them. An unauthorized or unexpected zone transfer is a classic reconnaissance and information-disclosure signal.",
+  "description": "DNS Zone Transfer Activity events report the bulk replication of a DNS zone between name servers, as seen on the network. This includes full transfers (AXFR, RFC 5936), incremental transfers (IXFR, RFC 1995), and change notifications (NOTIFY, RFC 1996). Unlike <code>DNS Activity</code>, which reports per-name queries and answers, this class captures whole-zone semantics: SOA serials, the records that make up the zone, and the multi-message streams that carry them.",
   "extends": "network",
   "name": "dns_zone_transfer_activity",
   "attributes": {

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -22,6 +22,10 @@
         "4": {
           "caption": "Notify",
           "description": "A NOTIFY message sent by the primary name server to inform a secondary that the zone has changed and a transfer may be needed. See RFC 1996."
+        },
+        "5": {
+          "caption": "Transfer",
+          "description": "A completed zone transfer reported as a single summary record rather than as separate request and response messages. Used by sources, such as name server logs, that emit one event per transfer with the zone, record count, byte count, duration, and peer. Whether the transfer was full (AXFR) or incremental (IXFR) is reflected by the records present and, for IXFR, by the <code>soa</code> and <code>updated_soa</code> serials."
         }
       }
     },
@@ -192,6 +196,18 @@
     {
       "description": "RFC 1996 — A Mechanism for Prompt Notification of Zone Changes (NOTIFY).",
       "url": "https://www.rfc-editor.org/rfc/rfc1996"
+    },
+    {
+      "description": "RFC 1035 — Domain Names, Implementation and Specification.",
+      "url": "https://www.rfc-editor.org/rfc/rfc1035"
+    },
+    {
+      "description": "RFC 2845 — Secret Key Transaction Authentication for DNS (TSIG).",
+      "url": "https://www.rfc-editor.org/rfc/rfc2845"
+    },
+    {
+      "description": "RFC 6895 — Domain Name System (DNS) IANA Considerations (response codes).",
+      "url": "https://www.rfc-editor.org/rfc/rfc6895"
     }
   ]
 }

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -49,8 +49,8 @@
       "group": "context",
       "requirement": "optional"
     },
-    "tsig": {
-      "description": "The TSIG (Transaction Signature) record authenticating this message. Per RFC 2845, at most one TSIG record is permitted per DNS message; for zone transfers it authenticates the requesting secondary or the primary's signed response, as indicated by <code>activity_id</code>. A <code>BADKEY</code> or <code>BADSIG</code> error commonly indicates an unauthorized transfer attempt.",
+    "additional": {
+      "description": "The Additional section of this DNS message, carrying any supplementary resource records (such as an EDNS OPT pseudo-record) and an optional TSIG record. Because <code>activity_id</code> distinguishes the request from the response, each event represents a single DNS message with a single Additional section. The TSIG record authenticating the message is available via <code>additional.tsig</code>; a <code>BADKEY</code> or <code>BADSIG</code> error commonly indicates an unauthorized transfer attempt.",
       "group": "context",
       "requirement": "optional"
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -29,6 +29,10 @@
       "description": "The normalized identifier of the zone transfer type. On a <code>Transfer Request</code> this is the type requested; on a <code>Transfer Response</code> or <code>Completed Transfer</code> this is the type actually delivered.",
       "requirement": "recommended",
       "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The transfer type is unknown. For example, the event source reports a transfer without indicating whether it was full or incremental, or the message has no transfer type (such as a NOTIFY)."
+        },
         "1": {
           "caption": "Full Transfer (AXFR)",
           "description": "A full zone transfer, in which the primary name server sends the complete contents of the zone. See RFC 5936."
@@ -36,6 +40,10 @@
         "2": {
           "caption": "Incremental Transfer (IXFR)",
           "description": "An incremental zone transfer, in which the primary name server sends only the changes since the secondary's known SOA serial. See RFC 1995."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The transfer type is not mapped. See the <code>transfer_type</code> attribute, which contains a data source specific value."
         }
       }
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -26,12 +26,7 @@
       }
     },
     "dns_zone": {
-      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY, and is the canonical field for the zone name. For example: <code>example.com</code>.",
-      "group": "primary",
-      "requirement": "recommended"
-    },
-    "query": {
-      "description": "The DNS query that requests the transfer, carrying the request type in <code>query.type</code>, e.g., <code>AXFR</code>, <code>IXFR</code>, or <code>SOA</code> (for NOTIFY), and the class in <code>query.class</code>. The zone name is reported in <code>dns_zone</code>; <code>query.hostname</code>, if populated, mirrors it.",
+      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY. The transfer type (AXFR, IXFR, NOTIFY) is conveyed by <code>activity_id</code>. For example: <code>example.com</code>.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -8,29 +8,45 @@
     "activity_id": {
       "enum": {
         "1": {
-          "caption": "Full Transfer Request (AXFR)",
-          "description": "A request for a full zone transfer, in which the primary name server sends the complete contents of the zone. See RFC 5936."
+          "caption": "Transfer Request",
+          "description": "A request from a secondary name server to transfer a zone. Whether a full (AXFR) or incremental (IXFR) transfer was requested is conveyed by <code>type_id</code>. See RFC 5936 and RFC 1995."
         },
         "2": {
-          "caption": "Incremental Transfer Request (IXFR)",
-          "description": "A request for an incremental zone transfer, in which the primary name server sends only the changes since the secondary's known SOA serial. See RFC 1995."
+          "caption": "Transfer Response",
+          "description": "A zone transfer response message from the primary name server. A single transfer may be delivered as a stream of multiple response messages. Whether the delivered data is a full (AXFR) or incremental (IXFR) transfer is conveyed by <code>type_id</code>; note that a server may answer an IXFR request with a full transfer when it cannot produce a delta. See RFC 5936 and RFC 1995."
         },
         "3": {
-          "caption": "Transfer Response",
-          "description": "A zone transfer response message from the primary name server. A single AXFR or IXFR transfer may be delivered as a stream of multiple response messages."
+          "caption": "Notify",
+          "description": "A NOTIFY message sent by the primary name server to inform a secondary that the zone has changed and a transfer may be needed. NOTIFY has no transfer type. See RFC 1996."
         },
         "4": {
-          "caption": "Notify",
-          "description": "A NOTIFY message sent by the primary name server to inform a secondary that the zone has changed and a transfer may be needed. See RFC 1996."
-        },
-        "5": {
-          "caption": "Transfer",
-          "description": "A completed zone transfer reported as a single summary record rather than as separate request and response messages. Used by sources, such as name server logs, that emit one event per transfer with the zone, record count, byte count, duration, and peer. Whether the transfer was full (AXFR) or incremental (IXFR) is reflected by the records present and, for IXFR, by the <code>soa</code> and <code>updated_soa</code> serials."
+          "caption": "Completed Transfer",
+          "description": "A completed zone transfer reported as a single summary record rather than as separate request and response messages. Used by sources, such as name server logs, that emit one event per transfer with the zone, record count, byte count, duration, and peer. Whether the transfer was full (AXFR) or incremental (IXFR) is conveyed by <code>type_id</code>."
         }
       }
     },
+    "type_id": {
+      "caption": "Transfer Type ID",
+      "description": "The normalized identifier of the zone transfer type. On a <code>Transfer Request</code> this is the type requested; on a <code>Transfer Response</code> or <code>Completed Transfer</code> this is the type actually delivered.",
+      "requirement": "recommended",
+      "enum": {
+        "1": {
+          "caption": "Full Transfer (AXFR)",
+          "description": "A full zone transfer, in which the primary name server sends the complete contents of the zone. See RFC 5936."
+        },
+        "2": {
+          "caption": "Incremental Transfer (IXFR)",
+          "description": "An incremental zone transfer, in which the primary name server sends only the changes since the secondary's known SOA serial. See RFC 1995."
+        }
+      }
+    },
+    "type": {
+      "caption": "Transfer Type",
+      "description": "The zone transfer type, normalized to the caption of the <code>type_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional"
+    },
     "dns_zone": {
-      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY. The transfer type (AXFR, IXFR, NOTIFY) is conveyed by <code>activity_id</code>. For example: <code>example.com</code>.",
+      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY. The message role is conveyed by <code>activity_id</code> and the transfer type (AXFR or IXFR) by <code>type_id</code>. For example: <code>example.com</code>.",
       "group": "primary",
       "requirement": "recommended"
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -49,11 +49,8 @@
       "group": "context",
       "requirement": "optional"
     },
-    "query_additional": {
-      "group": "context",
-      "requirement": "optional"
-    },
-    "response_additional": {
+    "tsig": {
+      "description": "The TSIG (Transaction Signature) record authenticating this message. Per RFC 2845, at most one TSIG record is permitted per DNS message; for zone transfers it authenticates the requesting secondary or the primary's signed response, as indicated by <code>activity_id</code>. A <code>BADKEY</code> or <code>BADSIG</code> error commonly indicates an unauthorized transfer attempt.",
       "group": "context",
       "requirement": "optional"
     },

--- a/events/network/dns_zone_transfer_activity.json
+++ b/events/network/dns_zone_transfer_activity.json
@@ -1,0 +1,205 @@
+{
+  "uid": 15,
+  "caption": "DNS Zone Transfer Activity",
+  "description": "DNS Zone Transfer Activity events report the bulk replication of a DNS zone between name servers, as seen on the network. This includes full transfers (AXFR, RFC 5936), incremental transfers (IXFR, RFC 1995), and change notifications (NOTIFY, RFC 1996). Unlike <code>DNS Activity</code>, which reports per-name queries and answers, this class captures whole-zone semantics: SOA serials, the records that make up the zone, and the multi-message streams that carry them. An unauthorized or unexpected zone transfer is a classic reconnaissance and information-disclosure signal.",
+  "extends": "network",
+  "name": "dns_zone_transfer_activity",
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Full Transfer Request (AXFR)",
+          "description": "A request for a full zone transfer, in which the primary name server sends the complete contents of the zone. See RFC 5936."
+        },
+        "2": {
+          "caption": "Incremental Transfer Request (IXFR)",
+          "description": "A request for an incremental zone transfer, in which the primary name server sends only the changes since the secondary's known SOA serial. See RFC 1995."
+        },
+        "3": {
+          "caption": "Transfer Response",
+          "description": "A zone transfer response message from the primary name server. A single AXFR or IXFR transfer may be delivered as a stream of multiple response messages."
+        },
+        "4": {
+          "caption": "Notify",
+          "description": "A NOTIFY message sent by the primary name server to inform a secondary that the zone has changed and a transfer may be needed. See RFC 1996."
+        }
+      }
+    },
+    "dns_zone": {
+      "description": "The DNS zone being transferred, i.e., the zone apex. This is the QNAME present in every message of the transfer or NOTIFY, and is the canonical field for the zone name. For example: <code>example.com</code>.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "query": {
+      "description": "The DNS query that requests the transfer, carrying the request type in <code>query.type</code>, e.g., <code>AXFR</code>, <code>IXFR</code>, or <code>SOA</code> (for NOTIFY), and the class in <code>query.class</code>. The zone name is reported in <code>dns_zone</code>; <code>query.hostname</code>, if populated, mirrors it.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "soa": {
+      "description": "The current Start of Authority (SOA) record for the zone. For an IXFR request, this is the SOA the secondary already holds, i.e., the \"from\" serial that bounds the requested delta.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "updated_soa": {
+      "description": "The new Start of Authority (SOA) record for the zone after the transfer, i.e., the \"to\" serial. Present when the transfer advances the zone to a newer serial.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "records": {
+      "description": "The resource records transferred for the zone. For an AXFR this is the complete set of zone records; for an IXFR this is the changed records that make up the delta.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "authority": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "query_additional": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "response_additional": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "num_records": {
+      "caption": "Number of Records",
+      "description": "The number of resource records transferred. Useful when the event source reports a count without shipping every record.",
+      "group": "context",
+      "requirement": "optional"
+    },
+    "rcode": {
+      "description": "The DNS server response code, normalized to the caption of the <code>rcode_id</code> value. In the case of 'Other', it is defined by the event source. A <code>Refused</code> code typically indicates a blocked or unauthorized transfer.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "rcode_id": {
+      "caption": "Response Code ID",
+      "description": "The normalized identifier of the DNS server response code. See RFC 6895.",
+      "group": "primary",
+      "requirement": "recommended",
+      "enum": {
+        "0": {
+          "caption": "NoError",
+          "description": "No Error."
+        },
+        "1": {
+          "caption": "FormError",
+          "description": "Format Error."
+        },
+        "2": {
+          "caption": "ServError",
+          "description": "Server Failure."
+        },
+        "3": {
+          "caption": "NXDomain",
+          "description": "Non-Existent Domain."
+        },
+        "4": {
+          "caption": "NotImp",
+          "description": "Not Implemented."
+        },
+        "5": {
+          "caption": "Refused",
+          "description": "Query Refused. For a zone transfer, this typically indicates the transfer was blocked because the requesting client is not authorized."
+        },
+        "6": {
+          "caption": "YXDomain",
+          "description": "Name Exists when it should not."
+        },
+        "7": {
+          "caption": "YXRRSet",
+          "description": "RR Set Exists when it should not."
+        },
+        "8": {
+          "caption": "NXRRSet",
+          "description": "RR Set that should exist does not."
+        },
+        "9": {
+          "caption": "NotAuth",
+          "description": "Not Authorized or Server Not Authoritative for zone."
+        },
+        "10": {
+          "caption": "NotZone",
+          "description": "Name not contained in zone."
+        },
+        "11": {
+          "caption": "DSOTYPENI",
+          "description": "DSO-TYPE Not Implemented."
+        },
+        "16": {
+          "caption": "BADVERS",
+          "description": "Bad EDNS OPT Version. Indicates that the client requested an EDNS version that the server does not support."
+        },
+        "17": {
+          "caption": "BADKEY",
+          "description": "Key not recognized."
+        },
+        "18": {
+          "caption": "BADTIME",
+          "description": "Signature out of time window."
+        },
+        "19": {
+          "caption": "BADMODE",
+          "description": "Bad TKEY Mode."
+        },
+        "20": {
+          "caption": "BADNAME",
+          "description": "Duplicate key name."
+        },
+        "21": {
+          "caption": "BADALG",
+          "description": "Algorithm not supported."
+        },
+        "22": {
+          "caption": "BADTRUNC",
+          "description": "Bad Truncation."
+        },
+        "23": {
+          "caption": "BADCOOKIE",
+          "description": "Bad/missing Server Cookie."
+        },
+        "24": {
+          "caption": "Unassigned",
+          "description": "The codes deemed to be unassigned by the RFC (unassigned codes: 12-15, 24-3840, 4096-65534)."
+        },
+        "25": {
+          "caption": "Reserved",
+          "description": "The codes deemed to be reserved by the RFC (codes: 3841-4095, 65535)."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The dns response code is not defined by the RFC."
+        }
+      }
+    },
+    "transaction_id": {
+      "caption": "DNS Transaction ID",
+      "description": "The 16-bit DNS transaction identifier assigned by the client and echoed unchanged in the server response. This value is the same for both the request and response messages.",
+      "group": "primary",
+      "requirement": "recommended"
+    },
+    "src_endpoint": {
+      "description": "The initiator of the zone transfer, typically the secondary (slave) name server requesting the zone or the recipient of a NOTIFY.",
+      "requirement": "recommended"
+    },
+    "dst_endpoint": {
+      "description": "The responder of the zone transfer, typically the primary (master) name server serving the zone or the sender of a NOTIFY.",
+      "requirement": "recommended"
+    }
+  },
+  "references": [
+    {
+      "description": "RFC 5936 — DNS Zone Transfer Protocol (AXFR).",
+      "url": "https://www.rfc-editor.org/rfc/rfc5936"
+    },
+    {
+      "description": "RFC 1995 — Incremental Zone Transfer in DNS (IXFR).",
+      "url": "https://www.rfc-editor.org/rfc/rfc1995"
+    },
+    {
+      "description": "RFC 1996 — A Mechanism for Prompt Notification of Zone Changes (NOTIFY).",
+      "url": "https://www.rfc-editor.org/rfc/rfc1996"
+    }
+  ]
+}

--- a/objects/dns_soa.json
+++ b/objects/dns_soa.json
@@ -1,0 +1,35 @@
+{
+  "caption": "DNS SOA Record",
+  "description": "The DNS SOA (Start of Authority) object represents the RDATA of a Start of Authority resource record, as defined in RFC 1035 §3.3.13. It carries the authoritative parameters of a DNS zone, including the serial number used to coordinate zone transfers between primary and secondary name servers.",
+  "extends": "object",
+  "name": "dns_soa",
+  "attributes": {
+    "primary_server": {
+      "requirement": "recommended"
+    },
+    "responsible_party": {
+      "requirement": "recommended"
+    },
+    "serial": {
+      "requirement": "recommended"
+    },
+    "refresh_interval": {
+      "requirement": "optional"
+    },
+    "retry_interval": {
+      "requirement": "optional"
+    },
+    "expire_interval": {
+      "requirement": "optional"
+    },
+    "minimum_ttl": {
+      "requirement": "optional"
+    }
+  },
+  "references": [
+    {
+      "description": "RFC 1035 — Domain Names, Implementation and Specification (SOA RDATA §3.3.13).",
+      "url": "https://www.rfc-editor.org/rfc/rfc1035#section-3.3.13"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds first-class support for **DNS zone transfers** (AXFR / IXFR) and **NOTIFY**, resolving #1669. Today these can only be captured by `DNS Activity` as ordinary queries/answers, so transfer-specific semantics — SOA serials, full-vs-incremental, multi-message streams — are lost or land in `unmapped`. An unauthorized or unexpected zone transfer is a classic recon / info-disclosure signal.

## What's added

- **New class** `DNS Zone Transfer Activity` (`events/network/dns_zone_transfer_activity.json`, network uid 15).
- **New object** `dns_soa` (`objects/dns_soa.json`) — the 7 RFC 1035 SOA RDATA fields, referenced via `soa` / `updated_soa` (the before/after convention). `serial` is a `long_t` (SOA serial is unsigned 32-bit).
- **Dictionary attributes** — `dns_zone`, `additional`, `soa`, `updated_soa`, `num_records`, `transfer_type` / `transfer_type_id`, and the SOA sub-fields.
- **CHANGELOG.md** updated under `[Unreleased]`.

## Design notes

- **Two orthogonal enums.** `activity_id` is the message role (Transfer Request / Transfer Response / Notify / Completed Transfer); `transfer_type_id` is the kind (Full AXFR / Incremental IXFR). This avoids encoding the type twice and disambiguates an IXFR request answered with a full transfer.
- **`dns_zone`** carries the zone apex directly, rather than overloading `query`.
- **`additional`** (a single `dns_section`) carries the message's Additional section, with TSIG via `additional.tsig`. One section, not two — each event is a single DNS message.
- **`Completed Transfer`** activity covers sources (e.g. BIND) that log a whole transfer as one summary record; record count is `num_records`, bytes/time/peers reuse the `network` base.

Everything else (`traffic`, `start_time`/`end_time`, `transaction_id`, endpoints, `rcode`) reuses the `network` base and existing DNS objects.

<img width="471" height="660" alt="image" src="https://github.com/user-attachments/assets/85a53223-41af-4c46-8524-0cc2cc35c7f6" />

<img width="2815" height="1108" alt="image" src="https://github.com/user-attachments/assets/7def7963-6af8-4a27-9a23-843fbb7a5dd0" />