### PR TITLE
ITU Cleanup: Removed embedded URLs from descriptions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,8 @@ Thankyou! -->
 ### Bugfixes
 1. Fixed the static anti-pattern checker so dictionary attributes are analyzed with the full compiled dictionary; the `missing-sibling` rule no longer false-positives when the sibling exists in `dictionary.json`. [#1613](https://github.com/ocsf/ocsf-schema/pull/1613)
 1. Added `tunnel_type_id` enum values to `dictionary.json` to resolve the anti-pattern of missing enums in the dictionary attribute. [#1602](https://github.com/ocsf/ocsf-schema/pull/1602)
-1. Fixed `rcode_id` enum value 16 caption from `BADSIG_VERS` to `BADVERS` in `DNS Activity`. Code 16 in the DNS header RCODE space is specifically Bad EDNS OPT Version; BADSIG belongs in the TSIG error field. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
+1. Fixed `rcode_id` enum value 16 caption from `BADSIG_VERS` to `BADVERS` in `DNS Activity`. Code 16 in the DNS header RCODE space is specifically Bad EDNS OPT Version; BADSIG belongs in the TSIG error field. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634),
+1. Fixed bad URLs to ASTM F3411-22a in `drone_flights_activity` event class and `unmanned_aerial_system` object. [#1676](https://github.com/ocsf/ocsf-schema/pull/1676)
 
 ### Deprecated
 1. Deprecated `is_src_dst_assignment_known` dictionary attribute and its usage in `Network Activity` in favour of `initiator_id`. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
@@ -137,6 +138,7 @@ Thankyou! -->
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)
 1. Added `references` and `@deprecated` support to the profile metaschema, aligning it with event class and object metaschemas.[#1625](https://github.com/ocsf/ocsf-schema/pull/1625)
+1. Updated all dictionary attributes, event classes, and objects where descriptions contained embedded authoritative URLs, and moved them to `references` sections, keeping the normative schema descriptions free from required URLs. [#1676](https://github.com/ocsf/ocsf-schema/pull/1676)
 
 ## [v1.8.0] - Mar 16th, 2026
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ Thankyou! -->
 ### Bugfixes
 1. Fixed the static anti-pattern checker so dictionary attributes are analyzed with the full compiled dictionary; the `missing-sibling` rule no longer false-positives when the sibling exists in `dictionary.json`. [#1613](https://github.com/ocsf/ocsf-schema/pull/1613)
 1. Added `tunnel_type_id` enum values to `dictionary.json` to resolve the anti-pattern of missing enums in the dictionary attribute. [#1602](https://github.com/ocsf/ocsf-schema/pull/1602)
-1. Fixed `rcode_id` enum value 16 caption from `BADSIG_VERS` to `BADVERS` in `DNS Activity`. Code 16 in the DNS header RCODE space is specifically Bad EDNS OPT Version; BADSIG belongs in the TSIG error field. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634),
+1. Fixed `rcode_id` enum value 16 caption from `BADSIG_VERS` to `BADVERS` in `DNS Activity`. Code 16 in the DNS header RCODE space is specifically Bad EDNS OPT Version; BADSIG belongs in the TSIG error field. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
 1. Fixed bad URLs to ASTM F3411-22a in `drone_flights_activity` event class and `unmanned_aerial_system` object. [#1676](https://github.com/ocsf/ocsf-schema/pull/1676)
 
 ### Deprecated

--- a/dictionary.json
+++ b/dictionary.json
@@ -7686,7 +7686,7 @@
         "references": [
           {
             "description": "JSON",
-            "url": "ttps://www.json.org"
+            "url": "https://www.json.org"
           }
         ]
       },

--- a/dictionary.json
+++ b/dictionary.json
@@ -249,8 +249,14 @@
     },
     "alert": {
       "caption": "Client TLS Alert",
-      "description": "The integer value of TLS alert if present. The alerts are defined in the TLS specification in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc2246'>RFC-2246</a>.",
-      "type": "integer_t"
+      "description": "The integer value of a TLS alert per the TLS specification.",
+      "type": "integer_t",
+      "references": [
+        {
+          "description": "RFC 2246",
+          "url": "https://datatracker.ietf.org/doc/html/rfc2246"
+        }
+      ]
     },
     "algorithm": {
       "caption": "Algorithm",
@@ -1161,8 +1167,14 @@
     },
     "chassis": {
       "caption": "Chassis",
-      "description": "The chassis type describes the system enclosure or physical form factor. Such as the following examples for Windows <a target='_blank' href='https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-systemenclosure'>Windows Chassis Types</a>",
-      "type": "string_t"
+      "description": "The chassis type describes the system enclosure or physical form factor. For example, as described for a Windows chassis type.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Windows Chassis Types",
+          "url": "https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-systemenclosure"
+        }
+      ]
     },
     "checks": {
       "caption": "Compliance Checks",
@@ -1192,8 +1204,14 @@
     },
     "cis_benchmark": {
       "caption": "CIS Benchmark",
-      "description": "The CIS Benchmark describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the Center for Internet Security (<a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>CIS</a>).",
+      "description": "The CIS Benchmark describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the Center for Internet Security.",
       "type": "cis_benchmark",
+      "references": [
+        {
+          "description": "CIS",
+          "url": "https://www.cisecurity.org/cis-benchmarks/"
+        }
+      ],
       "@deprecated": {
         "message": "Use Compliance object with Check object instead.",
         "since": "1.5.0"
@@ -1201,8 +1219,14 @@
     },
     "cis_benchmark_result": {
       "caption": "CIS Benchmark Result",
-      "description": "The CIS Benchmark Result object captures results generated from benchmark evaluations as defined by the Center for Internet Security (<a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>CIS</a>).",
+      "description": "The CIS Benchmark Result object captures results generated from benchmark evaluations as defined by the Center for Internet Security.",
       "type": "cis_benchmark_result",
+      "references": [
+        {
+          "description": "CIS",
+          "url": "https://www.cisecurity.org/cis-benchmarks/"
+        }
+      ],
       "@deprecated": {
         "message": "Use Compliance object with Check object instead.",
         "since": "1.5.0"
@@ -1538,8 +1562,14 @@
     },
     "content_type": {
       "caption": "HTTP Content Type",
-      "description": "The request header that identifies the original <a target='_blank' href='https://www.iana.org/assignments/media-types/media-types.xhtml'>media type </a> of the resource (prior to any content encoding applied for sending).",
-      "type": "string_t"
+      "description": "The HTTP request header that identifies the original media type of the resource (prior to any content encoding applied for sending).",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "IANA Media Types",
+          "url": "https://www.iana.org/assignments/media-types/media-types.xhtml"
+        }
+      ]
     },
     "contents": {
       "caption": "Clipboard Contents",
@@ -1565,8 +1595,14 @@
     },
     "coordinates": {
       "caption": "Coordinates",
-      "description": "A two-element array, containing a longitude/latitude pair. The format conforms with <a target='_blank' href='https://geojson.org'>GeoJSON</a>. For example: <code>[-73.983, 40.719]</code>.",
+      "description": "A two-element array, containing a longitude/latitude pair. The format conforms with GeoJSON. For example: <code>[-73.983, 40.719]</code>.",
       "type": "float_t",
+      "references": [
+        {
+          "description": "GeoJSON",
+          "url": "https://geojson.org"
+        }
+      ],
       "@deprecated": {
         "message": "Use specific <code>lat, long</code> attributes instead.",
         "since": "1.2.0"
@@ -1613,8 +1649,14 @@
     },
     "cpe_name": {
       "caption": "The product CPE identifier",
-      "description": "The Common Platform Enumeration (CPE) name as described by (<a target='_blank' href='https://nvd.nist.gov/products/cpe'>NIST</a>) For example: <code>cpe:/a:apple:safari:16.2</code>.",
-      "type": "string_t"
+      "description": "The Common Platform Enumeration (CPE) name. For example: <code>cpe:/a:apple:safari:16.2</code>.",
+      "type": "string_t",
+      "references": [
+        {
+        "description": "NIST Products",
+        "url": "https://nvd.nist.gov/products/cpe"
+        }
+      ]
     },
     "cpid": {
       "caption": "Common Process Identifier",
@@ -1728,30 +1770,60 @@
     },
     "cve": {
       "caption": "CVE",
-      "description": "The Common Vulnerabilities and Exposures (<a target='_blank' href='https://cve.mitre.org/'>CVE</a>) identifiers for the vulnerability.",
-      "type": "cve"
+      "description": "The Common Vulnerabilities and Exposures identifier for a vulnerability.",
+      "type": "cve",
+      "references": [
+        {
+          "description": "CVE",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "cves": {
       "caption": "CVE List",
-      "description": "List of Common Vulnerabilities and Exposures (<a target='_blank' href='https://cve.mitre.org/'>CVE</a>).",
+      "description": "List of Common Vulnerabilities and Exposures identifiers.",
       "type": "cve",
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "CVE",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "cvss": {
       "caption": "CVSS Score",
-      "description": "The CVSS object details Common Vulnerability Scoring System (<a target='_blank' href='https://www.first.org/cvss/'>CVSS</a>) scores from the advisory that are related to the vulnerability.",
+      "description": "The CVSS object details Common Vulnerability Scoring System scores from the advisory that are related to the vulnerability.",
       "type": "cvss",
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "CVSS",
+          "url": "https://www.first.org/cvss/"
+        }
+      ]
     },
     "cwe": {
       "caption": "CWE",
-      "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
-      "type": "cwe"
+      "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the Common Weakness Enumeration (CWE) catalog.",
+      "type": "cwe",
+      "references": [
+        {
+          "description": "CWE",
+          "url": "https://cwe.mitre.org/"
+        }
+      ]
     },
     "cwe_uid": {
       "caption": "CWE UID",
-      "description": "The <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> unique identifier. For example: <code>CWE-787</code>.",
+      "description": "The Common Weakness Enumeration (CWE) unique identifier. For example: <code>CWE-787</code>.",
       "type": "string_t",
+      "references": [
+        {
+          "description": "CWE",
+          "url": "https://cwe.mitre.org/"
+        }
+      ],
       "@deprecated": {
         "message": "Use the <code>related_cwes</code> object attributes instead.",
         "since": "1.1.0"
@@ -2589,8 +2661,14 @@
     },
     "epss": {
       "caption": "EPSS",
-      "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild. (<a target='_blank' href='https://www.first.org/epss/'>EPSS</a>).",
-      "type": "epss"
+      "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild.",
+      "type": "epss",
+      "references": [
+        {
+          "description": "EPSS",
+          "url": "https://www.first.org/epss/"
+        }
+      ]
     },
     "error": {
       "caption": "Error Code",
@@ -3027,8 +3105,14 @@
     },
     "geohash": {
       "caption": "Geohash",
-      "description": "<p>Geohash of the geo-coordinates (latitude and longitude).</p><a target='_blank' href='https://en.wikipedia.org/wiki/Geohash'>Geohashing</a> is a geocoding system used to encode geographic coordinates in decimal degrees, to a single string.",
-      "type": "string_t"
+      "description": "<p>Geohash of the geo-coordinates (latitude and longitude).</p>Geohashing is a geocoding system used to encode geographic coordinates in decimal degrees, to a single string.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Geohash",
+          "url": "https://en.wikipedia.org/wiki/Geohash"
+        }
+      ]
     },
     "given_name": {
       "caption": "Given Name",
@@ -3151,8 +3235,14 @@
     },
     "http_status": {
       "caption": "HTTP Status",
-      "description": "The Hypertext Transfer Protocol (HTTP) <a target='_blank' href='https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml'>status code</a> returned to the client.",
+      "description": "The Hypertext Transfer Protocol (HTTP) status code returned to the client.",
       "type": "integer_t",
+      "references": [
+        {
+          "description": "HTTP Status Codes",
+          "url": "https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml"
+        }
+      ],
       "@deprecated": {
         "message": "Use the <code>http_response.code</code> attribute instead.",
         "since": "1.1.0"
@@ -3801,9 +3891,15 @@
     },
     "kill_chain": {
       "caption": "Kill Chain",
-      "description": "The <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a> provides a detailed description of each phase and its associated activities within the broader context of a cyber attack.",
+      "description": "The Kill Chain provides a detailed description of each phase and its associated activities within the broader context of a cyber attack.",
       "type": "kill_chain_phase",
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "Cyber Kill Chain®",
+          "url": "https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html"
+        }
+      ]
     },
     "key_name": {
       "caption": "Key Name",
@@ -3818,8 +3914,14 @@
     },
     "lang": {
       "caption": "Language",
-      "description": "The two letter lower case language codes, as defined by <a target='_blank' href='https://en.wikipedia.org/wiki/ISO_639-1'>ISO 639-1</a>. For example: <code>en</code> (English), <code>de</code> (German), or <code>fr</code> (French).",
-      "type": "string_t"
+      "description": "The two letter lower case language codes, as defined by ISO 639-1. For example: <code>en</code> (English), <code>de</code> (German), or <code>fr</code> (French).",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "ISO 639-1",
+          "url": "https://en.wikipedia.org/wiki/ISO_639-1"
+        }
+      ]
     },
     "last_authentication_time": {
       "caption": "Last Authentication Time",
@@ -3931,8 +4033,14 @@
     },
     "license": {
       "caption": "Software License",
-      "description": "The name or identifier of the license applied on package or software. See <a target='_blank' href='https://spdx.org/licenses/'>SPDX License List</a>.",
-      "type": "string_t"
+      "description": "The name or identifier of the license applied on package or software. For example <code>Apache-2.0</code>.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "SPDX License List",
+          "url": "https://spdx.org/licenses/"
+        }
+      ]
     },
     "license_url": {
       "caption": "Software License URL",
@@ -4560,6 +4668,12 @@
           "description": "The DNS Opcode is not defined by the RFC. See the <code>opcode</code> attribute, which contains a data source specific value."
         }
       },
+      "references": [
+        {
+          "description": "RFC 5395",
+          "url": "https://www.rfc-editor.org/rfc/rfc5395.html"  
+        }
+      ],
       "suppress_checks": [
         "enum_convention"
       ]
@@ -5457,15 +5571,27 @@
     },
     "related_cves": {
       "caption": "Related CVEs",
-      "description": "Describes Common Vulnerabilities and Exposures <a target='_blank' href='https://cve.mitre.org/'>(CVE)</a> entries that are related to an entity. See specific usage.",
+      "description": "Describes Common Vulnerabilities and Exposures entries that are related to an entity. See specific usage.",
       "type": "cve",
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "CVE",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "related_cwes": {
       "caption": "Related CWEs",
-      "description": "Describes Common Weakness Enumeration <a target='_blank' href='https://cwe.mitre.org/'>(CWE)</a> entries that are related to an entity. See specific usage.",
+      "description": "Describes Common Weakness Enumeration entries that are related to an entity. See specific usage.",
       "type": "cwe",
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "CWE",
+          "url": "https://cwe.mitre.org/"
+        }
+      ]
     },
     "related_events": {
       "caption": "Related Events/Findings",
@@ -5838,33 +5964,33 @@
     },
     "scim": {
       "caption": "SCIM",
-      "description": "The System for Cross-domain Identity Management (SCIM) resource object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
+      "description": "The System for Cross-domain Identity Management (SCIM) resource object as defined in RFC 7634 provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications.",
       "type": "scim",
       "references": [
         {
-          "description": "System for Cross-domain Identity Management (SCIM) RFC.",
+          "description": "RFC 7634.",
           "url": "https://datatracker.ietf.org/doc/html/rfc7643"
         }
       ]
     },
     "scim_group_schema": {
       "caption": "SCIM Group Schema",
-      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. This attribute will capture key-value pairs for the scheme implemented in a SCIM resource.",
+      "description": "SCIM provides a schema for representing groups, identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:Group</code> as defined in RFC 7634. This attribute will capture key-value pairs for the scheme implemented in a SCIM resource.",
       "type": "json_t",
       "references": [
         {
-          "description": "System for Cross-domain Identity Management (SCIM) RFC spec.",
+          "description": "RFC 7634",
           "url": "https://datatracker.ietf.org/doc/html/rfc7643"
         }
       ]
     },
     "scim_user_schema": {
       "caption": "SCIM User Schema",
-      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>. his attribute will capture key-value pairs for the scheme implemented in a SCIM resource. This object is inclusive of both the basic and Enterprise User Schema Extension.",
+      "description": "SCIM provides a resource type for user resources. The core schema for user is identified using the following schema URI: <code>urn:ietf:params:scim:schemas:core:2.0:User</code> as defined in RFC 7634. This attribute will capture key-value pairs for the scheme implemented in a SCIM resource. This object is inclusive of both the basic and Enterprise User Schema Extension.",
       "type": "json_t",
       "references": [
         {
-          "description": "System for Cross-domain Identity Management (SCIM) RFC spec.",
+          "description": "RFC 7634",
           "url": "https://datatracker.ietf.org/doc/html/rfc7643"
         }
       ]
@@ -6478,9 +6604,15 @@
     },
     "stratum_id": {
       "caption": "Stratum ID",
-      "description": "The normalized identifier of the stratum level, as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc5905.html'>RFC-5905</a>.",
+      "description": "The normalized identifier of the stratum level of an NTP server's time source, as defined in RFC 5905. Levels range from 0 to 16, with lower numbers representing higher accuracy and greater proximity to the root clock.",
       "sibling": "stratum",
       "type": "integer_t",
+      "references": [
+        {
+          "description": "RFC 5905",
+          "url": "https://www.rfc-editor.org/rfc/rfc5905.html"
+        }
+      ],
       "enum": {
         "0": {
           "caption": "Unknown",
@@ -6590,7 +6722,7 @@
     },
     "tactic": {
       "caption": "MITRE Tactic",
-      "description": "The Tactic object describes the MITRE ATT&CK® or ATLAS™ Tactic ID and/or name that is associated to an attack.",
+      "description": "The Tactic object describes the Tactic ID and/or name associated to an attack.",
       "type": "tactic",
       "references": [
         {
@@ -6605,13 +6737,19 @@
     },
     "tactics": {
       "caption": "Tactics",
-      "description": "The Tactic object describes the tactic ID and/or tactic name that are associated with the attack technique, as defined by <a target='_blank' href='https://attack.mitre.org/wiki/ATT&CK_Matrix'>ATT&CK® Matrix</a>.",
+      "description": "The Tactics associated with the attack technique.",
       "type": "tactic",
       "@deprecated": {
         "message": "Use the <code>tactic</code> attribute instead.",
         "since": "1.1.0"
       },
-      "is_array": true
+      "is_array": true,
+      "references": [
+        {
+          "description": "ATT&CK® Matrix",
+          "url": "https://attack.mitre.org/wiki/ATT&CK_Matrix"
+        }
+      ]
     },
     "tag": {
       "caption": "Image Tag",
@@ -6782,8 +6920,14 @@
     },
     "tlp": {
       "caption": "Traffic Light Protocol",
-      "description": "The <a target='_blank' href='https://www.first.org/tlp/'>Traffic Light Protocol</a> was created to facilitate greater sharing of potentially sensitive information and more effective collaboration. TLP provides a simple and intuitive schema for indicating with whom potentially sensitive information can be shared.",
-      "type": "string_t"
+      "description": "The Traffic Light Protocol (TLP) was created to facilitate greater sharing of potentially sensitive information and more effective collaboration. TLP provides a simple and intuitive schema for indicating with whom potentially sensitive information can be shared.",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "Traffic Light Protocol",
+          "url": "https://www.first.org/tlp/"
+        }
+      ]
     },
     "tls": {
       "caption": "TLS",
@@ -7007,8 +7151,14 @@
     },
     "unmanned_aerial_system": {
       "caption": "Unmanned Aerial System",
-      "description": "The Unmanned Aerial System object describes the characteristics, Position Location Information (PLI), and other metadata of Unmanned Aerial Systems (UAS) and other unmanned and drone systems used in Remote ID. Remote ID is defined in the Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a) <a target='_blank' href='https://cdn.standards.iteh.ai/samples/112830/71297057ac42432880a203654f213709/ASTM-F3411-22a.pdf'>ASTM F3411-22a</a>.",
-      "type": "unmanned_aerial_system"
+      "description": "The Unmanned Aerial System object describes the characteristics, Position Location Information (PLI), and other metadata of Unmanned Aerial Systems (UAS) and other unmanned and drone systems used in Remote ID. Remote ID is defined in the Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a).",
+      "type": "unmanned_aerial_system",
+      "references": [
+        {
+          "description": "ASTM F3411-22a",
+          "url": "https://cdn.standards.iteh.ai/samples/112830/71297057ac42432880a203654f213709/ASTM-F3411-22a.pdf"
+        }
+      ]
     },
     "unmanned_system_operating_area": {
       "caption": "UAS Operating Area",
@@ -7399,10 +7549,16 @@
       },
       "datetime_t": {
         "caption": "Datetime",
-        "description": "The Internet Date/Time format as defined in <a target='_blank' href='https://www.rfc-editor.org/rfc/rfc3339.html'>RFC-3339</a>. For example:<br><code>2024-09-10T23:20:50.520Z</code>,<br><code>2024-09-10 23:20:50.520789Z</code>.",
+        "description": "The Internet Date/Time format as defined in RFC 3339. For example:<br><code>2024-09-10T23:20:50.520Z</code>,<br><code>2024-09-10 23:20:50.520789Z</code>.",
         "regex": "^\\d{4}-\\d{2}-\\d{2}[Tt]\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?([Zz]|[\\+-]\\d{2}:\\d{2})?$",
         "type": "string_t",
-        "type_name": "String"
+        "type_name": "String",
+        "references": [
+          {
+            "description": "RFC 3339",
+            "url": "https://www.rfc-editor.org/rfc/rfc3339.html"
+          }
+        ]
       },
       "email_t": {
         "observable": 5,
@@ -7459,7 +7615,13 @@
       },
       "json_t": {
         "caption": "JSON",
-        "description": "Embedded JSON value. A value can be a string, or a number, or true or false or null, or an object or an array. These structures can be nested. See <a target='_blank' href='https://www.json.org'>www.json.org</a>."
+        "description": "Embedded JSON value. A value can be a string, or a number, or true or false or null, or an object or an array. These structures can be nested.",
+        "references": [
+          {
+            "description": "JSON",
+            "url": "ttps://www.json.org"
+          }
+        ]
       },
       "long_t": {
         "caption": "Long",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -37,10 +37,16 @@
       "requirement": "optional"
     },
     "attacks": {
-      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Incident.",
+      "description": "An array describing the tactics, techniques & sub-techniques associated to the Incident.",
       "group": "context",
       "requirement": "optional",
-      "profile": null
+      "profile": null,
+      "references": [
+        {
+          "description": "MITRE ATT&CK®",
+          "url": "https://attack.mitre.org"
+        }
+      ]
     },
     "comment": {
       "description": "Additional user supplied details for updating or closing the incident.",

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -37,7 +37,7 @@
       "requirement": "optional"
     },
     "attacks": {
-      "description": "An array describing the tactics, techniques & sub-techniques associated to the Incident.",
+      "description": "An array of attack objects, each describing a tactic, technique, and/or sub-technique associated with the Incident.",
       "group": "context",
       "requirement": "optional",
       "profile": null,

--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -31,7 +31,7 @@
       "requirement": "recommended"
     },
     "attacks": {
-      "description": "An array describing the tactics, techniques & sub-techniques associated to the Finding.",
+      "description": "An array of attack objects, each describing a tactic, technique, and/or sub-technique associated with the Finding.",
       "group": "context",
       "requirement": "optional",
       "profile": null,

--- a/events/findings/security_finding.json
+++ b/events/findings/security_finding.json
@@ -31,10 +31,16 @@
       "requirement": "recommended"
     },
     "attacks": {
-      "description": "An array of <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> objects describing the tactics, techniques & sub-techniques associated to the Finding.",
+      "description": "An array describing the tactics, techniques & sub-techniques associated to the Finding.",
       "group": "context",
       "requirement": "optional",
-      "profile": null
+      "profile": null,
+      "references": [
+        {
+          "description": "MITRE ATT&CK®",
+          "url": "https://attack.mitre.org"
+        }
+      ]
     },
     "cis_csc": {
       "group": "context",

--- a/events/network/dns_activity.json
+++ b/events/network/dns_activity.json
@@ -201,7 +201,13 @@
           "caption": "Other",
           "description": "The dns response code is not defined by the RFC."
         }
-      }
+      },
+      "references": [
+        {
+          "description": "RFC 6895",
+          "url": "https://datatracker.ietf.org/doc/html/rfc6895"
+        }
+      ]
     },
     "response_time": {
       "group": "occurrence",

--- a/events/remediation/file_remediation_activity.json
+++ b/events/remediation/file_remediation_activity.json
@@ -1,9 +1,15 @@
 {
   "uid": 2,
   "caption": "File Remediation Activity",
-  "description": "File Remediation Activity events report on attempts at remediating files. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Sub-techniques will include File, such as File Removal or Restore File.",
+  "description": "File Remediation Activity events report on attempts at remediating files. Sub-techniques of countermeasures will include File, such as File Removal or Restore File.",
   "extends": "remediation_activity",
   "name": "file_remediation_activity",
+  "references": [
+    {
+      "description": "Countermeasures as defined by the D3FEND™ Matrix",
+      "url": "https://d3fend.mitre.org/"
+    }
+  ],
   "attributes": {
     "file": {
       "description": "The file that pertains to the remediation event.",

--- a/events/remediation/network_remediation_activity.json
+++ b/events/remediation/network_remediation_activity.json
@@ -1,9 +1,15 @@
 {
   "uid": 4,
   "caption": "Network Remediation Activity",
-  "description": "Network Remediation Activity events report on attempts at remediating computer networks. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Techniques and Sub-techniques will include Network, such as Network Isolation or Network Traffic Filtering.",
+  "description": "Network Remediation Activity events report on attempts at remediating computer networks. Techniques and Sub-techniques of countermeasures will include Network, such as Network Isolation or Network Traffic Filtering.",
   "extends": "remediation_activity",
   "name": "network_remediation_activity",
+  "references": [
+    {
+      "description": "Countermeasures as defined by the D3FEND™ Matrix",
+      "url": "https://d3fend.mitre.org/"
+    }
+  ],
   "attributes": {
     "connection_info": {
       "description": "The network connection that pertains to the remediation event.",

--- a/events/remediation/process_remediation_activity.json
+++ b/events/remediation/process_remediation_activity.json
@@ -1,9 +1,15 @@
 {
   "uid": 3,
   "caption": "Process Remediation Activity",
-  "description": "Process Remediation Activity events report on attempts at remediating processes. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>. Sub-techniques will include Process, such as Process Termination or Kernel-based Process Isolation.",
+  "description": "Process Remediation Activity events report on attempts at remediating processes. Sub-techniques of countermeasures will include Process, such as Process Termination or Kernel-based Process Isolation.",
   "extends": "remediation_activity",
   "name": "process_remediation_activity",
+  "references": [
+    {
+      "description": "Countermeasures as defined by the D3FEND™ Matrix",
+      "url": "https://d3fend.mitre.org/"
+    }
+  ],
   "attributes": {
     "process": {
       "description": "The process that pertains to the remediation event.",

--- a/events/remediation/process_remediation_activity.json
+++ b/events/remediation/process_remediation_activity.json
@@ -1,7 +1,7 @@
 {
   "uid": 3,
   "caption": "Process Remediation Activity",
-  "description": "Process Remediation Activity events report on attempts at remediating processes. Sub-techniques of countermeasures will include Process, such as Process Termination or Kernel-based Process Isolation.",
+  "description": "Process Remediation Activity events report on attempts at remediating processes. Sub-techniques of countermeasures will include Process Eviction, such as Process Termination or Kernel-based Process Isolation.",
   "extends": "remediation_activity",
   "name": "process_remediation_activity",
   "references": [

--- a/events/remediation/remediation_activity.json
+++ b/events/remediation/remediation_activity.json
@@ -2,32 +2,78 @@
   "uid": 1,
   "caption": "Remediation Activity",
   "category": "remediation",
-  "description": "Remediation Activity events report on attempts at remediating a compromised device or computer network. It follows the MITRE countermeasures defined by the D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/'>Matrix</a>.",
+  "description": "Remediation Activity events report on attempts at remediating a compromised device or computer network.",
   "extends": "base_event",
   "name": "remediation_activity",
+  "references": [
+    {
+      "description": "Countermeasures defined by the D3FEND™ Matrix",
+      "url": "https://d3fend.mitre.org/"
+    }
+  ],
   "attributes": {
     "activity_id": {
-      "description": "Matches the MITRE D3FEND™ Tactic. Note: the Model and Detect Tactics are not supported as remediations by the OCSF Remediation event class.",
+      "description": "Matches the countermeasure tactic. Note: the Model tactic is not supported by the OCSF Remediation event class.",
       "enum": {
         "1": {
           "caption": "Isolate",
-          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Isolate/'>d3f:Isolate</a>."
+          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Isolate",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Isolate/"
+            }
+          ]
         },
         "2": {
           "caption": "Evict",
-          "description": "Removes an adversary or malicious resource from a device or computer network. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Evict/'>d3f:Evict</a>."
+          "description": "Removes an adversary or malicious resource from a device or computer network.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Evict",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Evict/"
+            }
+          ]
         },
         "3": {
           "caption": "Restore",
-          "description": "Returns the system to a better state. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Restore/'>d3f:Restore</a>."
+          "description": "Returns the system to a better state.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Restore",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Restore/"
+            }
+          ]
         },
         "4": {
           "caption": "Harden",
-          "description": "Increases the opportunity cost of computer network exploitation. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Harden/'>d3f:Harden</a>."
+          "description": "Increases the opportunity cost of computer network exploitation.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Harden",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Harden/"
+            }
+          ]
         },
         "5": {
           "caption": "Detect",
-          "description": "Further identify adversary access to or unauthorized activity on computer networks. Defined by D3FEND™ <a target='_blank' href='https://d3fend.mitre.org/tactic/d3f:Detect/'>d3f:Detect</a>."
+          "description": "Identify adversary access to or unauthorized activity on computer networks.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Detect",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Detect/"
+            }
+          ]
+        },
+        "6": {
+          "caption": "Deceive",
+          "description": "Advertise, entice, and allow potential attackers access to an observed or controlled environment.<p>",
+          "references": [
+            {
+              "description": "Defined by D3FEND™ Deceive",
+              "url": "https://d3fend.mitre.org/tactic/d3f:Deceive/"
+            }
+          ]
         }
       }
     },

--- a/events/remediation/remediation_activity.json
+++ b/events/remediation/remediation_activity.json
@@ -17,7 +17,7 @@
       "enum": {
         "1": {
           "caption": "Isolate",
-          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses.<p>",
+          "description": "Creates logical or physical barriers in a system which reduces opportunities for adversaries to create further accesses.",
           "references": [
             {
               "description": "Defined by D3FEND™ Isolate",
@@ -27,7 +27,7 @@
         },
         "2": {
           "caption": "Evict",
-          "description": "Removes an adversary or malicious resource from a device or computer network.<p>",
+          "description": "Removes an adversary or malicious resource from a device or computer network.",
           "references": [
             {
               "description": "Defined by D3FEND™ Evict",
@@ -37,7 +37,7 @@
         },
         "3": {
           "caption": "Restore",
-          "description": "Returns the system to a better state.<p>",
+          "description": "Returns the system to a better state.",
           "references": [
             {
               "description": "Defined by D3FEND™ Restore",
@@ -47,7 +47,7 @@
         },
         "4": {
           "caption": "Harden",
-          "description": "Increases the opportunity cost of computer network exploitation.<p>",
+          "description": "Increases the opportunity cost of computer network exploitation.",
           "references": [
             {
               "description": "Defined by D3FEND™ Harden",
@@ -57,7 +57,7 @@
         },
         "5": {
           "caption": "Detect",
-          "description": "Identify adversary access to or unauthorized activity on computer networks.<p>",
+          "description": "Identify adversary access to or unauthorized activity on computer networks.",
           "references": [
             {
               "description": "Defined by D3FEND™ Detect",
@@ -67,7 +67,7 @@
         },
         "6": {
           "caption": "Deceive",
-          "description": "Advertise, entice, and allow potential attackers access to an observed or controlled environment.<p>",
+          "description": "Advertise, entice, and allow potential attackers access to an observed or controlled environment.",
           "references": [
             {
               "description": "Defined by D3FEND™ Deceive",

--- a/events/unmanned_systems/airborne_broadcast_activity.json
+++ b/events/unmanned_systems/airborne_broadcast_activity.json
@@ -1,9 +1,19 @@
 {
   "uid": 2,
   "caption": "Airborne Broadcast Activity",
-  "description": "Airborne Broadcast Activity events report the activity of any aircraft or unmanned system as reported and tracked by Automatic Dependent Surveillance - Broadcast (ADS-B) receivers. Based on the ADS-B standards described in <a target='_blank' href='https://www.ecfr.gov/current/title-14/chapter-I/subchapter-F/part-91#91.225'>Code of Federal Regulations (CFR) Title 14 Chapter I Subchapter F Part 91</a> and in other general Federal Aviation Administration (FAA) supplemental orders and guidance described <a target='_blank' href='https://www.faa.gov/about/office_org/headquarters_offices/avs/offices/afx/afs/afs400/afs410/ads-b'>here</a>.",
+  "description": "Airborne Broadcast Activity events report the activity of any aircraft or unmanned system as reported and tracked by Automatic Dependent Surveillance - Broadcast (ADS-B) receivers. Based on the ADS-B standards described in Code of Federal Regulations (CFR) Title 14 Chapter I Subchapter F Part 91 and in other general Federal Aviation Administration (FAA) supplemental orders and guidance.",
   "extends": "unmanned_systems",
   "name": "airborne_broadcast_activity",
+  "references": [
+    {
+      "description": "(CFR) Title 14 Chapter I Subchapter F Part 91",
+      "url": "https://www.ecfr.gov/current/title-14/chapter-I/subchapter-F/part-91#91.225"
+    },
+    {
+      "description": "(FAA) supplemental orders and guidance",
+      "url": "https://www.faa.gov/about/office_org/headquarters_offices/avs/offices/afx/afs/afs400/afs410/ads-b"
+    }
+  ],
   "attributes": {
     "activity_id": {
       "group": "primary",

--- a/events/unmanned_systems/drone_flights_activity.json
+++ b/events/unmanned_systems/drone_flights_activity.json
@@ -1,9 +1,15 @@
 {
   "uid": 1,
   "caption": "Drone Flights Activity",
-  "description": "Drone Flights Activity events report the activity of Unmanned Aerial Systems (UAS), their Operators, and mission-planning and authorization metadata as reported by the UAS platforms themselves, by Counter-UAS (CUAS) systems, or other remote monitoring or sensing infrastructure. Based on the Remote ID defined in Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a) <a target='_blank' href='https://cdn.standards.iteh.ai/samples/112830/71297057ac42432880a203654f213709/ASTM-F3411-22a.pdf'>ASTM F3411-22a</a>",
+  "description": "Drone Flights Activity events report the activity of Unmanned Aerial Systems (UAS), their Operators, and mission-planning and authorization metadata as reported by the UAS platforms themselves, by Counter-UAS (CUAS) systems, or other remote monitoring or sensing infrastructure. Based on the Remote ID defined in Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a).",
   "extends": "unmanned_systems",
   "name": "drone_flights_activity",
+  "references": [
+    {
+      "description": "ASTM F3411-22a",
+      "url": "https://store.astm.org/f3411-22a.html"
+    }
+  ],
   "attributes": {
     "activity_id": {
       "group": "primary",

--- a/extensions/windows/objects/registry_value.json
+++ b/extensions/windows/objects/registry_value.json
@@ -42,8 +42,14 @@
       "requirement": "optional"
     },
     "type": {
-      "description": "A string representation of the value type as specified in <a target='_blank' href='https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types'>Registry Value Types</a>.",
-      "requirement": "optional"
+      "description": "A string representation of the value type as specified in Windows Registry Value Types.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "Windows Registry Value Types",
+          "url": "https://learn.microsoft.com/en-us/windows/win32/sysinfo/registry-value-types"
+        }
+      ]
     },
     "type_id": {
       "description": "The value type ID.",

--- a/objects/advisory.json
+++ b/objects/advisory.json
@@ -53,12 +53,24 @@
       "requirement": "recommended"
     },
     "related_cves": {
-      "description": "A list of Common Vulnerabilities and Exposures <a target='_blank' href='https://cve.mitre.org/'>(CVE)</a> identifiers related to the vulnerabilities disclosed in the Advisory.",
-      "requirement": "optional"
+      "description": "A list of Common Vulnerabilities and Exposures (CVE) identifiers related to the vulnerabilities disclosed in the Advisory.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "CVE Advisory",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "related_cwes": {
-      "description": "A list of Common Weakness Enumeration <a target='_blank' href='https://cwe.mitre.org/'>(CWE)</a> identifiers related to the vulnerabilities disclosed in the Advisory.",
-      "requirement": "optional"
+      "description": "A list of Common Weakness Enumeration (CWE) identifiers related to the vulnerabilities disclosed in the Advisory.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "CWE Advisory",
+          "url": "https://cwe.mitre.org/"
+        }
+      ]
     },
     "size": {
       "description": "The size in bytes for the Advisory. Usually populated for a KB Article patch.",

--- a/objects/advisory.json
+++ b/objects/advisory.json
@@ -58,7 +58,7 @@
       "references": [
         {
           "description": "CVE Advisory",
-          "url": "https://cve.mitre.org/"
+          "url": "https://cve.org/"
         }
       ]
     },

--- a/objects/attack.json
+++ b/objects/attack.json
@@ -1,6 +1,6 @@
 {
-  "caption": "MITRE ATT&CK® & ATLAS™",
-  "description": "The MITRE ATT&CK® & ATLAS™ object describes the tactic, technique, sub-technique & mitigation associated to an attack.",
+  "caption": "Attack Tactics & Techniques",
+  "description": "The Attack object describes the tactic, technique, sub-technique & mitigation associated to an attack.",
   "extends": "object",
   "name": "attack",
   "attributes": {

--- a/objects/cis_benchmark.json
+++ b/objects/cis_benchmark.json
@@ -1,8 +1,18 @@
 {
   "caption": "CIS Benchmark",
-  "description": "The CIS Benchmark object describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the <a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>Center for Internet Security</a>. See also <a target='_blank' href='https://www.cisecurity.org/insights/blog/getting-to-know-the-cis-benchmarks'>Getting to Know the CIS Benchmarks</a>.",
+  "description": "The CIS Benchmark object describes best practices for securely configuring IT systems, software, networks, and cloud infrastructure as defined by the Center for Internet Security. See also Getting to Know the CIS Benchmarks.",
   "extends": "object",
   "name": "cis_benchmark",
+  "references": [
+    {
+      "description": "CIS Benchmarks",
+      "url": "https://www.cisecurity.org/cis-benchmarks/"
+    },
+    {
+      "description": "Getting to Know the CIS Benchmarks",
+      "url": "https://www.cisecurity.org/insights/blog/getting-to-know-the-cis-benchmarks"
+    }
+  ],
   "@deprecated": {
     "message": "Use the Compliance object with Checks object instead.",
     "since": "1.5.0"

--- a/objects/cis_benchmark_result.json
+++ b/objects/cis_benchmark_result.json
@@ -1,8 +1,14 @@
 {
   "caption": "CIS Benchmark Result",
-  "description": "The CIS Benchmark Result object contains information as defined by the Center for Internet Security (<a target='_blank' href='https://www.cisecurity.org/cis-benchmarks/'>CIS</a>) benchmark result. CIS Benchmarks are a collection of best practices for securely configuring IT systems, software, networks, and cloud infrastructure.",
+  "description": "The CIS Benchmark Result object contains information as defined by the Center for Internet Security (CIS) benchmark result. CIS Benchmarks are a collection of best practices for securely configuring IT systems, software, networks, and cloud infrastructure.",
   "extends": "object",
   "name": "cis_benchmark_result",
+  "references": [
+    {
+      "description": "CIS Benchmarks",
+      "url": "https://www.cisecurity.org/cis-benchmarks/"
+    }
+  ],
   "@deprecated": {
     "message": "Use the Compliance object with Checks object instead.",
     "since": "1.5.0"

--- a/objects/cis_control.json
+++ b/objects/cis_control.json
@@ -1,8 +1,14 @@
 {
   "caption": "CIS Control",
-  "description": "The CIS Control (aka Critical Security Control) object describes a prioritized set of actions to protect your organization and data from cyber-attack vectors. The <a target='_blank' href='https://www.cisecurity.org/controls'>CIS Controls</a> are defined by the Center for Internet Security.",
+  "description": "The CIS Control (aka Critical Security Control) object describes a prioritized set of actions to protect your organization and data from cyber-attack vectors. The CIS Controls are defined by the Center for Internet Security.",
   "extends": "object",
   "name": "cis_control",
+  "references": [
+    {
+      "description": "CIS Controls",
+      "url": "https://www.cisecurity.org/controls"      
+    }
+  ],
   "attributes": {
     "desc": {
       "description": "The CIS Control description. For example: <i>Uninstall or disable unnecessary services on enterprise assets and software, such as an unused file sharing service, web application module, or service function.</i>",

--- a/objects/cis_csc.json
+++ b/objects/cis_csc.json
@@ -1,8 +1,14 @@
 {
   "caption": "CIS CSC",
-  "description": "The CIS Critical Security Control (CSC) contains information as defined by the Center for Internet Security Critical Security Control <a target='_blank' href='https://www.cisecurity.org/controls'>(CIS CSC)</a>. Prioritized set of actions to protect your organization and data from cyber-attack vectors.",
+  "description": "The CIS Critical Security Control (CSC) contains information as defined by the Center for Internet Security Critical Security Controls (CIS CSC). Prioritized set of actions to protect your organization and data from cyber-attack vectors.",
   "extends": "object",
   "name": "cis_csc",
+  "references": [
+    {
+      "description": "CIS Critical Security Controls",
+      "url": "https://www.cisecurity.org/controls"
+    }
+  ],
   "@deprecated": {
     "message": "Use the cis_control object instead.",
     "since": "1.5.0"

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -1,8 +1,14 @@
 {
   "caption": "CVE",
-  "description": "The Common Vulnerabilities and Exposures (CVE) object represents publicly disclosed cybersecurity vulnerabilities defined in CVE Program catalog (<a target='_blank' href='https://cve.mitre.org/'>CVE</a>). There is one CVE Record for each vulnerability in the catalog.",
+  "description": "The Common Vulnerabilities and Exposures (CVE) object represents publicly disclosed cybersecurity vulnerabilities defined in CVE Program catalog (CVE). There is one CVE Record for each vulnerability in the catalog.",
   "extends": "object",
   "name": "cve",
+  "references": [
+    {
+      "description": "CVE Program catalog",
+      "url": "https://cve.mitre.org/"
+    }
+  ],
   "attributes": {
     "created_time": {
       "description": "The Record Creation Date identifies when the CVE ID was issued to a CVE Numbering Authority (CNA) or the CVE Record was published on the CVE List. Note that the Record Creation Date does not necessarily indicate when this vulnerability was discovered, shared with the affected vendor, publicly disclosed, or updated in CVE.",
@@ -44,8 +50,14 @@
       "requirement": "recommended"
     },
     "related_cwes": {
-      "description": "Describes the Common Weakness Enumeration <a target='_blank' href='https://cwe.mitre.org/'>(CWE)</a> details related to the CVE Record.",
-      "requirement": "optional"
+      "description": "Describes the Common Weakness Enumeration details related to the CVE Record.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "Common Weakness Enumberation (CWE)",
+          "url": "https://cwe.mitre.org/"
+        }
+      ]
     },
     "title": {
       "description": "A title or a brief phrase summarizing the CVE record.",
@@ -53,8 +65,14 @@
     },
     "type": {
       "caption": "Vulnerability Type",
-      "description": "<p>The vulnerability type as selected from a large dropdown menu during CVE refinement.</p>Most frequently used vulnerability types are: <code>DoS</code>, <code>Code Execution</code>, <code>Overflow</code>, <code>Memory Corruption</code>, <code>Sql Injection</code>, <code>XSS</code>, <code>Directory Traversal</code>, <code>Http Response Splitting</code>, <code>Bypass something</code>, <code>Gain Information</code>, <code>Gain Privileges</code>, <code>CSRF</code>, <code>File Inclusion</code>. For more information see <a target='_blank' href='https://www.cvedetails.com/vulnerabilities-by-types.php'>Vulnerabilities By Type</a> distributions.",
-      "requirement": "recommended"
+      "description": "<p>The vulnerability type as selected from a large dropdown menu during CVE refinement.</p>Most frequently used vulnerability types are: <code>DoS</code>, <code>Code Execution</code>, <code>Overflow</code>, <code>Memory Corruption</code>, <code>Sql Injection</code>, <code>XSS</code>, <code>Directory Traversal</code>, <code>Http Response Splitting</code>, <code>Bypass something</code>, <code>Gain Information</code>, <code>Gain Privileges</code>, <code>CSRF</code>, <code>File Inclusion</code>. For more information see Vulnerabilities By Type distributions.",
+      "requirement": "recommended",
+      "references": [
+        {
+          "description": "Vulnerabilities by Type distributions",
+          "url": "https://www.cvedetails.com/vulnerabilities-by-types.php"
+        }
+      ]
     },
     "uid": {
       "observable": 18,

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -6,7 +6,7 @@
   "references": [
     {
       "description": "CVE Program catalog",
-      "url": "https://cve.mitre.org/"
+      "url": "https://cve.org/"
     }
   ],
   "attributes": {

--- a/objects/cve.json
+++ b/objects/cve.json
@@ -54,7 +54,7 @@
       "requirement": "optional",
       "references": [
         {
-          "description": "Common Weakness Enumberation (CWE)",
+          "description": "Common Weakness Enumeration (CWE)",
           "url": "https://cwe.mitre.org/"
         }
       ]
@@ -65,7 +65,7 @@
     },
     "type": {
       "caption": "Vulnerability Type",
-      "description": "<p>The vulnerability type as selected from a large dropdown menu during CVE refinement.</p>Most frequently used vulnerability types are: <code>DoS</code>, <code>Code Execution</code>, <code>Overflow</code>, <code>Memory Corruption</code>, <code>Sql Injection</code>, <code>XSS</code>, <code>Directory Traversal</code>, <code>Http Response Splitting</code>, <code>Bypass something</code>, <code>Gain Information</code>, <code>Gain Privileges</code>, <code>CSRF</code>, <code>File Inclusion</code>. For more information see Vulnerabilities By Type distributions.",
+      "description": "<p>The vulnerability type as classified in the CVE catalog.</p>Most frequently used vulnerability types are: <code>DoS</code>, <code>Code Execution</code>, <code>Overflow</code>, <code>Memory Corruption</code>, <code>Sql Injection</code>, <code>XSS</code>, <code>Directory Traversal</code>, <code>Http Response Splitting</code>, <code>Bypass something</code>, <code>Gain Information</code>, <code>Gain Privileges</code>, <code>CSRF</code>, <code>File Inclusion</code>. For more information see Vulnerabilities By Type distributions.",
       "requirement": "recommended",
       "references": [
         {

--- a/objects/cvss.json
+++ b/objects/cvss.json
@@ -1,8 +1,14 @@
 {
   "caption": "CVSS Score",
-  "description": "The Common Vulnerability Scoring System (<a target='_blank' href='https://www.first.org/cvss/'>CVSS</a>) object provides a way to capture the principal characteristics of a vulnerability and produce a numerical score reflecting its severity.",
+  "description": "The Common Vulnerability Scoring System (CVSS) object provides a way to capture the principal characteristics of a vulnerability and produce a numerical score reflecting its severity.",
   "extends": "object",
   "name": "cvss",
+  "references": [
+    {
+      "description": "Common Vulnerability Scoring System (CVSS)",
+      "url": "https://www.first.org/cvss/"
+    }
+  ],
   "attributes": {
     "base_score": {
       "description": "The CVSS base score. For example: <code>9.1</code>.",

--- a/objects/cwe.json
+++ b/objects/cwe.json
@@ -1,8 +1,14 @@
 {
   "caption": "CWE",
-  "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the <a target='_blank' href='https://cwe.mitre.org/'>Common Weakness Enumeration (CWE)</a> catalog.",
+  "description": "The CWE object represents a weakness in a software system that can be exploited by a threat actor to perform an attack. The CWE object is based on the Common Weakness Enumeration (CWE) catalog.",
   "extends": "object",
   "name": "cwe",
+  "references": [
+    {
+      "description": "Common Weakness Enumeration (CWE)",
+      "url": "https://cwe.mitre.org/"
+    }
+  ],
   "attributes": {
     "caption": {
       "description": "The caption assigned to the Common Weakness Enumeration unique identifier.",

--- a/objects/d3f_tactic.json
+++ b/objects/d3f_tactic.json
@@ -1,6 +1,6 @@
 {
-  "caption": "MITRE D3FEND™ Tactic",
-  "description": "The MITRE D3FEND™ Tactic object describes the tactic ID and/or name that is associated to an attack.",
+  "caption": "Defensive Tactic",
+  "description": "The Defensive Tactic object describes the tactic ID and/or name that is associated to an attack.",
   "extends": "_entity",
   "name": "d3f_tactic",
   "attributes": {
@@ -8,8 +8,15 @@
       "description": "The tactic name that is associated with the defensive technique. For example: <code>Isolate</code>."
     },
     "src_url": {
-      "description": "The versioned permalink of the defensive tactic. For example: <code>https://d3fend.mitre.org/tactic/d3f:Isolate/</code>.",
-      "requirement": "optional"
+      "description": "The versioned permalink of the defensive tactic. For example: <code>https://d3fend.mitre.org/tactic/d3f:Isolate/</code>",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "Example: Isolate tactic",
+          "url": "https://d3fend.mitre.org/tactic/d3f:Isolate/"
+        }
+      ],
+      "source": "https://d3fend.mitre.org/tactic/d3f:Isolate/"
     },
     "uid": {
       "description": "The unique identifier of the defensive tactic."

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -1,6 +1,6 @@
 {
-  "caption": "MITRE D3FEND™ Technique",
-  "description": "The MITRE D3FEND™ Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
+  "caption": "Defensive Technique",
+  "description": "The Defensive Technique object describes the leaf defensive technique ID and/or name associated to a countermeasure.",
   "extends": "_entity",
   "name": "d3f_technique",
   "attributes": {
@@ -8,8 +8,15 @@
       "description": "The name of the defensive technique. For example: <code>IO Port Restriction</code>."
     },
     "src_url": {
-      "description": "The versioned permalink of the defensive technique. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>.",
-      "requirement": "optional"
+      "description": "The versioned permalink of the defensive technique. For example: <code>https://d3fend.mitre.org/technique/d3f:IOPortRestriction/</code>",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "Example: IOPortRestriction technique",
+          "url": ""
+        }
+      ],
+      "source": "https://d3fend.mitre.org/technique/d3f:IOPortRestriction/"
     },
     "uid": {
       "description": "The unique identifier of the defensive technique. For example: <code>D3-IOPR</code>."

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -25,7 +25,7 @@
   "references": [
     {
       "description": "D3FEND™ Matrix",
-      "url": "href='https://d3fend.mitre.org"
+      "url": "https://d3fend.mitre.org"
     }
   ]
 }

--- a/objects/d3f_technique.json
+++ b/objects/d3f_technique.json
@@ -13,7 +13,7 @@
       "references": [
         {
           "description": "Example: IOPortRestriction technique",
-          "url": ""
+          "url": "https://d3fend.mitre.org/technique/d3f:IOPortRestriction/"
         }
       ],
       "source": "https://d3fend.mitre.org/technique/d3f:IOPortRestriction/"

--- a/objects/d3fend.json
+++ b/objects/d3fend.json
@@ -1,6 +1,6 @@
 {
-  "caption": "MITRE D3FEND™",
-  "description": "The MITRE D3FEND™ object describes the tactic & technique associated with a countermeasure.",
+  "caption": "Defensive Countermeasures",
+  "description": "The Defensive Countermeasures object describes the tactic & technique associated with a countermeasure.",
   "extends": "object",
   "name": "d3fend",
   "attributes": {

--- a/objects/d3fend.json
+++ b/objects/d3fend.json
@@ -1,6 +1,6 @@
 {
-  "caption": "Defensive Countermeasures",
-  "description": "The Defensive Countermeasures object describes the tactic & technique associated with a countermeasure.",
+  "caption": "Defensive Countermeasure",
+  "description": "The Defensive Countermeasure object describes the tactic & technique associated with a countermeasure.",
   "extends": "object",
   "name": "d3fend",
   "attributes": {

--- a/objects/dns_answer.json
+++ b/objects/dns_answer.json
@@ -55,6 +55,11 @@
     {
       "description": "D3FEND™ Ontology d3f:InboundInternetDNSResponseTraffic.",
       "url": "https://d3fend.mitre.org/dao/artifact/d3f:InboundInternetDNSResponseTraffic/"
+    },
+    {
+      "description": "RFC 1035 — DNS Implementation and Specification.",
+      "url": "https://www.rfc-editor.org/rfc/rfc1035.txt"
+
     }
   ]
 }

--- a/objects/dns_resource_record.json
+++ b/objects/dns_resource_record.json
@@ -3,6 +3,12 @@
   "description": "The DNS Resource Record object represents a single resource record as defined in RFC 1035. It is used in the Answer, Authority, and Additional sections of a DNS message.",
   "extends": "object",
   "name": "dns_resource_record",
+  "references": [
+    {
+      "description": "RFC 1035 — DNS Implementation and Specification.",
+      "url": "https://www.rfc-editor.org/rfc/rfc1035.txt"
+    }
+  ],
   "attributes": {
     "class": {
       "caption": "Resource Record Class",
@@ -22,13 +28,13 @@
     "type": {
       "caption": "Resource Record Type",
       "description": "The type of data contained in this resource record. See RFC 1035. For example: <code>CNAME</code>.",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "references": [
+        {
+          "description": "RFC 1035 — DNS Implementation and Specification.",
+          "url": "https://www.rfc-editor.org/rfc/rfc1035.txt"
+        }
+      ]
     }
-  },
-  "references": [
-    {
-      "description": "RFC 1035 — DNS Implementation and Specification.",
-      "url": "https://www.rfc-editor.org/rfc/rfc1035.txt"
-    }
-  ]
+  }
 }

--- a/objects/download_info.json
+++ b/objects/download_info.json
@@ -21,8 +21,14 @@
       "requirement": "optional"
     },
     "type_id": {
-      "description": "The download type ID. The values correspond to the five permitted values of the <code>ZoneId</code> property in the <a target='_blank' href='https://en.wikipedia.org/wiki/Mark_of_the_Web'>Mark of the Web</a> metadata of a downloaded file on Windows. Note however that each numeric value is 1 greater than its <code>ZoneId</code> equivalent.",
+      "description": "The download type ID. The values correspond to the five permitted values of the <code>ZoneId</code> property in the Mark of the Web metadata of a downloaded file on Windows. Note however that each numeric value is 1 greater than its <code>ZoneId</code> equivalent.",
       "requirement": "recommended",
+      "references": [
+        {
+          "description": "Mark of the Web",
+          "url": "https://en.wikipedia.org/wiki/Mark_of_the_Web"
+        }
+      ],
       "enum": {
         "0": {
           "caption": "Unknown",

--- a/objects/download_info.json
+++ b/objects/download_info.json
@@ -23,12 +23,6 @@
     "type_id": {
       "description": "The download type ID. The values correspond to the five permitted values of the <code>ZoneId</code> property in the Mark of the Web metadata of a downloaded file on Windows. Note however that each numeric value is 1 greater than its <code>ZoneId</code> equivalent.",
       "requirement": "recommended",
-      "references": [
-        {
-          "description": "Mark of the Web",
-          "url": "https://en.wikipedia.org/wiki/Mark_of_the_Web"
-        }
-      ],
       "enum": {
         "0": {
           "caption": "Unknown",

--- a/objects/endpoint.json
+++ b/objects/endpoint.json
@@ -77,63 +77,138 @@
       "enum": {
         "1": {
           "caption": "Server",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Server/'>server</a>."
+          "references": [
+            {
+              "description": "Server",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:Server/"
+            }
+          ]
         },
         "2": {
           "caption": "Desktop",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:DesktopComputer/'>desktop computer</a>."
+          "references": [
+            {
+              "description": "Desktop Computer",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:DesktopComputer/"
+            }
+          ]
         },
         "3": {
           "caption": "Laptop",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:LaptopComputer/'>laptop computer</a>."
+          "references": [
+            {
+              "description": "Laptop Computer",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:LaptopComputer"
+            }
+          ]
         },
         "4": {
           "caption": "Tablet",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:TabletComputer/'>tablet computer</a>."
+          "references": [
+            {
+              "description": "Tablet Computer",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:TabletComputer/"
+            }
+          ]
         },
         "5": {
           "caption": "Mobile",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:MobilePhone/'>mobile phone</a>."
+          "references": [
+            {
+              "description": "Mobile Phone",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:MobilePhone/"
+            }
+          ]
         },
         "6": {
           "caption": "Virtual",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:VirtualizationSoftware/'>virtual machine</a>."
+          "references": [
+            {
+              "description": "Virtual Machine",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:VirtualizationSoftware/"
+            }
+          ]
         },
         "7": {
           "caption": "IOT",
-          "description": "An <a target='_blank' href='https://www.techtarget.com/iotagenda/definition/IoT-device'>IOT (Internet of Things) device</a>."
+          "references": [
+            {
+              "description": "IOT (Internet of Things) Device",
+              "url": "https://www.techtarget.com/iotagenda/definition/IoT-device"
+            }
+          ]
         },
         "8": {
           "caption": "Browser",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Browser/'>web browser</a>."
+          "references": [
+            {
+              "description": "Web Browser",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:Browser/"
+            }
+          ]
         },
         "9": {
           "caption": "Firewall",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Firewall/'>networking firewall</a>."
+          "references": [
+            {
+              "description": "Network Firewall",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:Firewall/"
+            }
+          ]
         },
         "10": {
           "caption": "Switch",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Switch/'>networking switch</a>."
+          "references": [
+            {
+              "description": "Networking Switch",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:Switch/"
+            }
+          ]
         },
         "11": {
           "caption": "Hub",
-          "description": "A <a target='_blank' href='https://en.wikipedia.org/wiki/Ethernet_hub'>networking hub</a>."
+          "references": [
+            {
+              "description": "Networking Hub",
+              "url": "https://en.wikipedia.org/wiki/Ethernet_hub"
+            }
+          ]
         },
         "12": {
           "caption": "Router",
-          "description": "A <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:Router/'>networking router</a>."
+          "references": [
+            {
+              "description": "Networking Router",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:Router/"
+            }
+          ]
         },
         "13": {
           "caption": "IDS",
-          "description": "An <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:IntrusionDetectionSystem/'>intrusion detection system</a>."
+          "references": [
+            {
+              "description": "Intrustion Detection System",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:IntrusionDetectionSystem/"
+            }
+          ]
         },
         "14": {
           "caption": "IPS",
-          "description": "An <a target='_blank' href='https://d3fend.mitre.org/dao/artifact/d3f:IntrusionPreventionSystem/'>intrusion prevention system</a>."
+          "references": [
+            {
+              "description": "Intrusion Prevention System",
+              "url": "https://d3fend.mitre.org/dao/artifact/d3f:IntrusionPreventionSystem/"
+            }
+          ]
         },
         "15": {
           "caption": "Load Balancer",
-          "description": "A <a target='_blank' href='https://en.wikipedia.org/wiki/Load_balancing_(computing)'>Load Balancer device.</a>"
+          "references": [
+            {
+              "description": "Load Balancer Device",
+              "url": "https://en.wikipedia.org/wiki/Load_balancing_(computing)"
+            }
+          ]
         }
       }
     },

--- a/objects/epss.json
+++ b/objects/epss.json
@@ -1,8 +1,14 @@
 {
   "caption": "EPSS",
-  "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild. (<a target='_blank' href='https://www.first.org/epss/'>EPSS</a>).",
+  "description": "The Exploit Prediction Scoring System (EPSS) object describes the estimated probability a vulnerability will be exploited. EPSS is a community-driven effort to combine descriptive information about vulnerabilities (CVEs) with evidence of actual exploitation in-the-wild.",
   "extends": "object",
   "name": "epss",
+  "references": [
+    {
+      "description": "Exploit Prediction Scoring System (EPSS)",
+      "url": "https://www.first.org/epss/"
+    }
+  ],
   "attributes": {
     "created_time": {
       "description": "The timestamp indicating when the EPSS score was calculated.",

--- a/objects/extension.json
+++ b/objects/extension.json
@@ -1,8 +1,14 @@
 {
   "caption": "Schema Extension",
-  "description": "The OCSF Schema Extension object provides detailed information about the schema extension used to construct the event. The schema extensions are registered in the <a target='_blank' href='https://github.com/ocsf/ocsf-schema/blob/main/extensions.md'>extensions.md</a> file.",
+  "description": "The OCSF Schema Extension object provides detailed information about the schema extension used to construct the event. The schema extensions are registered in the <code>extensions.md</code> file.",
   "extends": "_entity",
   "name": "extension",
+  "references": [
+    {
+      "description": "OCSF Extensions",
+      "url": "https://github.com/ocsf/ocsf-schema/blob/main/extensions.md"
+    }
+  ],
   "attributes": {
     "name": {
       "description": "The schema extension name. For example: <code>dev</code>."

--- a/objects/file.json
+++ b/objects/file.json
@@ -63,8 +63,18 @@
       "requirement": "optional"
     },
     "internal_name": {
-      "description": "The name of the file as identified within the file itself. This contrasts with the name by which the file is known on disk. Where available, the internal name is widely used by security practitioners and detection content because the on-disk file name is not reliable. On the Windows OS, most PE files contain a <a href=\"https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource\">VERSIONINFO</a> resource from which the internal name can be obtained. On macOS, binaries can optionally embed a copy of the application's Info.plist file which in turn contains the name of the executable.",
-      "requirement": "optional"
+      "description": "The name of the file as identified within the file itself. This contrasts with the name by which the file is known on disk. Where available, the internal name is widely used by security practitioners and detection content because the on-disk file name is not reliable. On the Windows OS, most PE files contain a <code>VERSIONINFO</code> resource from which the internal name can be obtained. On macOS, binaries can optionally embed a copy of the application's <code>Info.plist</code> file which in turn contains the name of the executable.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "VERSIONINFO resource",
+          "url": "https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource"
+        },
+        {
+          "description": "Info.plist file",
+          "url": "https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Introduction/Introduction.html"
+        }
+      ]
     },
     "is_deleted": {
       "description": "Indicates if the file was deleted from the filesystem.",

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -12,8 +12,14 @@
       "requirement": "optional"
     },
     "attacks": {
-      "description": "The <a target='_blank' href='https://attack.mitre.org'>MITRE ATT&CK®</a> technique and associated tactics related to the finding.",
-      "requirement": "optional"
+      "description": "The technique and associated tactics related to the finding.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "MITRE ATT&CK®",
+          "url": "https://attack.mitre.org"
+        }
+      ]
     },
     "created_time": {
       "description": "The time when the finding was created.",

--- a/objects/finding_info.json
+++ b/objects/finding_info.json
@@ -12,7 +12,7 @@
       "requirement": "optional"
     },
     "attacks": {
-      "description": "The technique and associated tactics related to the finding.",
+      "description": "An array of attack objects, each describing a tactic, technique, and/or sub-technique associated with the finding.",
       "requirement": "optional",
       "references": [
         {

--- a/objects/http_request.json
+++ b/objects/http_request.json
@@ -17,7 +17,7 @@
     },
     "http_method": {
       "caption": "HTTP Method",
-      "description": "The <a target='_blank' href='https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods'>HTTP request method</a> indicates the desired action to be performed for a given resource.",
+      "description": "The HTTP request method indicates the desired action to be performed for a given resource.",
       "requirement": "recommended",
       "enum": {
         "CONNECT": {
@@ -185,6 +185,10 @@
         {
           "description": "IANA HTTP Method Registry",
           "url": "https://www.iana.org/assignments/http-methods/http-methods.xhtml"
+        },
+        {
+          "description": "HTTP Request method",
+          "url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods"
         }
       ]
     },

--- a/objects/ja4_fingerprint.json
+++ b/objects/ja4_fingerprint.json
@@ -17,8 +17,14 @@
       "requirement": "optional"
     },
     "type": {
-      "description": "The JA4+ fingerprint type as defined by <a href='https://blog.foxio.io/ja4+-network-fingerprinting target='_blank'>FoxIO</a>, normalized to the caption of 'type_id'. In the case of 'Other', it is defined by the event source.",
-      "requirement": "optional"
+      "description": "The JA4+ fingerprint type as defined by FoxIO, normalized to the caption of 'type_id'. In the case of 'Other', it is defined by the event source.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "JA4+ Fingerprint (blog)",
+          "url": "https://blog.foxio.io/ja4+-network-fingerprinting"
+        }
+      ]
     },
     "type_id": {
       "description": "The identifier of the JA4+ fingerprint type.",

--- a/objects/kill_chain_phase.json
+++ b/objects/kill_chain_phase.json
@@ -1,8 +1,14 @@
 {
   "caption": "Kill Chain Phase",
-  "description": "The Kill Chain Phase object represents a single phase of a cyber attack, including the initial reconnaissance and planning stages up to the final objective of the attacker. It provides a detailed description of each phase and its associated activities within the broader context of a cyber attack. See <a target='_blank' href='https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html'>Cyber Kill Chain®</a>.",
+  "description": "The Kill Chain Phase object represents a single phase of a cyber attack, including the initial reconnaissance and planning stages up to the final objective of the attacker. It provides a detailed description of each phase and its associated activities within the broader context of a cyber attack.",
   "extends": "object",
   "name": "kill_chain_phase",
+  "references": [
+    {
+      "description": "Cyber Kill Chain®",
+      "url": "https://www.lockheedmartin.com/en-us/capabilities/cyber/cyber-kill-chain.html"
+    }
+  ],
   "attributes": {
     "phase": {
       "requirement": "recommended"

--- a/objects/malware.json
+++ b/objects/malware.json
@@ -84,8 +84,14 @@
       "requirement": "optional"
     },
     "cves": {
-      "description": "The list of Common Vulnerabilities and Exposures (CVE) identifiers associated with the malware. Reference: <a target='_blank' href='https://cve.mitre.org/'>CVE</a>",
-      "requirement": "optional"
+      "description": "The list of Common Vulnerabilities and Exposures (CVE) identifiers associated with the malware.",
+      "requirement": "optional",
+      "references": [
+        {
+          "description": "CVE",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "files": {
       "description": "The list of file objects representing files that were identified as infected by the malware.",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -134,7 +134,7 @@
       "requirement": "required",
       "references": [
         {
-          "description": "Semantic Versioning Specificaiton (SemVer)",
+          "description": "Semantic Versioning Specification (SemVer)",
           "url": "https://semver.org"
         }
       ]

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -130,8 +130,14 @@
       "requirement": "optional"
     },
     "version": {
-      "description": "The version of the OCSF schema, using Semantic Versioning Specification (<a target='_blank' href='https://semver.org'>SemVer</a>). For example: <code>1.0.0.</code> Event consumers use the version to determine the available event attributes.",
-      "requirement": "required"
+      "description": "The version of the OCSF schema, using Semantic Versioning Specification (SemVer). For example: <code>1.0.0.</code> Event consumers use the version to determine the available event attributes.",
+      "requirement": "required",
+      "references": [
+        {
+          "description": "Semantic Versioning Specificaiton (SemVer)",
+          "url": "https://semver.org"
+        }
+      ]
     }
   },
   "profiles": [

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -130,7 +130,7 @@
       "requirement": "optional"
     },
     "version": {
-      "description": "The version of the OCSF schema, using Semantic Versioning Specification (SemVer). For example: <code>1.0.0.</code> Event consumers use the version to determine the available event attributes.",
+      "description": "The version of the OCSF schema, using Semantic Versioning Specification (SemVer). For example: <code>1.0.0</code>. Event consumers use the version to determine the available event attributes.",
       "requirement": "required",
       "references": [
         {

--- a/objects/osint.json
+++ b/objects/osint.json
@@ -161,9 +161,15 @@
     },
     "tlp": {
       "caption": "Traffic Light Protocol",
-      "description": "The <a target='_blank' href='https://www.first.org/tlp/'>Traffic Light Protocol</a> was created to facilitate greater sharing of potentially sensitive information and more effective collaboration. TLP provides a simple and intuitive schema for indicating with whom potentially sensitive information can be shared.",
+      "description": "The Traffic Light Protocol (TLP) was created to facilitate greater sharing of potentially sensitive information and more effective collaboration. TLP provides a simple and intuitive schema for indicating with whom potentially sensitive information can be shared.",
       "requirement": "recommended",
       "type": "string_t",
+      "references": [
+        {
+          "description": "Traffic Light Protocol (TLP)",
+          "url": "https://www.first.org/tlp/"
+        }
+      ],
       "enum": {
         "AMBER": {
           "caption": "TLP:AMBER",

--- a/objects/scim.json
+++ b/objects/scim.json
@@ -1,8 +1,14 @@
 {
   "caption": "SCIM",
-  "description": "The System for Cross-domain Identity Management (SCIM) Configuration object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc7643'>RFC-7634</a>",
+  "description": "The System for Cross-domain Identity Management (SCIM) Configuration object provides a structured set of attributes related to SCIM protocols used for identity provisioning and management across cloud-based platforms. It standardizes user and group provisioning details, enabling identity synchronization and lifecycle management with compatible Identity Providers (IdPs) and applications. SCIM is defined in RFC 7634.",
   "extends": "object",
   "name": "scim",
+  "references": [
+    {
+      "description": "System for Cross-domain Identity Management (SCIM)",
+      "url": "https://datatracker.ietf.org/doc/html/rfc7643"
+    }
+  ],
   "attributes": {
     "auth_protocol": {
       "description": "The authorization protocol as defined by the caption of <code>auth_protocol_id</code>. In the case of <code>Other</code>, it is defined by the event source.",

--- a/objects/tls_extension.json
+++ b/objects/tls_extension.json
@@ -13,8 +13,14 @@
       "requirement": "optional"
     },
     "type_id": {
-      "description": "The TLS extension type identifier. See <a target='_blank' href='https://datatracker.ietf.org/doc/html/rfc8446#page-35'>The Transport Layer Security (TLS) extension page</a>.",
+      "description": "The TLS extension type identifier.",
       "requirement": "required",
+      "references": [
+        {
+          "description": "Transport Layer Security (TLS) extension page",
+          "url": "https://datatracker.ietf.org/doc/html/rfc8446#page-35"
+        }
+      ],
       "enum": {
         "0": {
           "caption": "server_name",

--- a/objects/unmanned_aerial_system.json
+++ b/objects/unmanned_aerial_system.json
@@ -1,8 +1,14 @@
 {
   "caption": "Unmanned Aerial System",
-  "description": "The Unmanned Aerial System object describes the characteristics, Position Location Information (PLI), and other metadata of Unmanned Aerial Systems (UAS) and other unmanned and drone systems used in Remote ID. Remote ID is defined in the Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a) <a target='_blank' href='https://cdn.standards.iteh.ai/samples/112830/71297057ac42432880a203654f213709/ASTM-F3411-22a.pdf'>ASTM F3411-22a</a>.",
+  "description": "The Unmanned Aerial System object describes the characteristics, Position Location Information (PLI), and other metadata of Unmanned Aerial Systems (UAS) and other unmanned and drone systems used in Remote ID. Remote ID is defined in the Standard Specification for Remote ID and Tracking (ASTM Designation: F3411-22a).",
   "extends": "aircraft",
   "name": "unmanned_aerial_system",
+  "references": [
+    {
+      "description": "ASTM F3411-22a",
+      "url": "https://store.astm.org/f3411-22a.html"
+    }
+  ],
   "attributes": {
     "hw_info": {
       "caption": "UAS Hardware Information",

--- a/objects/vulnerability.json
+++ b/objects/vulnerability.json
@@ -18,12 +18,24 @@
       "requirement": "optional"
     },
     "cve": {
-      "description": "Describes the Common Vulnerabilities and Exposures <a target='_blank' href='https://cve.mitre.org/'>(CVE)</a> details related to the vulnerability.",
-      "requirement": "recommended"
+      "description": "Describes the Common Vulnerabilities and Exposures (CVE) details related to the vulnerability.",
+      "requirement": "recommended",
+      "references": [
+        {
+          "description": "CVE",
+          "url": "https://cve.mitre.org/"
+        }
+      ]
     },
     "cwe": {
-      "description": "Describes the Common Weakness Enumeration <a target='_blank' href='https://cwe.mitre.org/'>(CWE)</a> details related to the vulnerability.",
-      "requirement": "recommended"
+      "description": "Describes the Common Weakness Enumeration (CWE) details related to the vulnerability.",
+      "requirement": "recommended",
+      "references": [
+        {
+          "description": "CWE",
+          "url": "https://cwe.mitre.org/"
+        }
+      ]
     },
     "dependency_chain": {
       "requirement": "optional"


### PR DESCRIPTION
#### Related Issue: 1604, 1607

In order to comply with ITU ratification standards, a number of areas in the schema need to be adjusted in order to be "normative" for an ITU ratification. Two issues are addressed in this PR:
1. URLs cannot be required as part of a description as not all countries have access to some of these URLs. The process for converting the OCSF schema to the ITU document format is automated, and hence, moving these URLs to a `references` section allows them to be combined into an appendix, which doesn't qualify as part of the normative schema standard.
2. Trademarks and registrations cannot be part of the normative schema. Hence, wherever a proprietary name was in a caption or description, those captions and descriptions were modified to be generic, maintaining the original name with registration or trademark in an associated `references` section. This is to ensure that the open standard doesn't include proprietary names. This was mostly MITRE ATT&CK, ATLAS and D3FEND objects and descriptions.

#### Description of changes:
- Removed embedded URLs from descriptions where they are not examples and moved them to a References section. 
- Fixed a few bad URLs for F3411-22a (unmanned systems). 
- Changed the MITRE proprietary captions for attack and d3fend objects, keeping the registered and trademarked names in a References section.
