### PR TITLE
Rollback file_result deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ Thankyou! -->
 * #### Event Classes
   1. Added `updated_job` in `Scheduled Job Activity` class to reflect the actual or attempted state of the job upon update activity. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `iam_role` and role management support to `group_management`, `authorize_session`. Filled out the `group_management` class with complete lifecycle as well as added `resources`, `policies` to the discrete activities. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
-  1. Added `updated_*` attributes to `Entity Management`, `File Activity`, `File Hosting`, and `Web Resources Activity` for class-specific update result reporting. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
+  1. Added `updated_*` attributes to `Entity Management` and `Web Resources Activity` for class-specific update result reporting. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
   1. Added `initiator_id` and `initiator` to `Network Activity` with network-specific enums `Source Endpoint (1)` and `Destination Endpoint (2)`, and updated `src_endpoint` and `dst_endpoint` descriptions to reflect bi-flow and asymmetric flow scenarios. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
   1. Added `transaction_id`, `opcode_id`/`opcode`, `flag_ids`/`flags`, `authority`, `query_additional`, and `response_additional` to `DNS Activity`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@ Thankyou! -->
   1. Added `speed_mhz` for compute unit clock speed in MHz. [#1630](https://github.com/ocsf/ocsf-schema/pull/1630)
   1. Added `cpu_info_list` as an array of `cpu_info` objects. [#1630](https://github.com/ocsf/ocsf-schema/pull/1630)
   1. Added `iam_role`, `iam_roles`, `updated_role`, `updated_group`, `updated_user` attributes. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
-  1. Added `updated_entity`, `updated_file`, `updated_resources`, and `updated_web_resources` attributes for reporting intended or actual post-update state. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
+  1. Added `updated_entity`, `updated_resources`, and `updated_web_resources` attributes for reporting intended or actual post-update state. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
   1. Added `initiator` and `initiator_id` attributes for identifying which endpoint initiated a network communication, with generic `Unknown (0)` and `Other (99)` enums. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
   1. Added `transaction_id`, `query_additional`, `response_additional`, `authority`, and `key_name` dictionary attributes for DNS Activity restructuring. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `peripheral_devices` for a set of peripherals. [#1645](https://github.com/ocsf/ocsf-schema/pull/1645)
@@ -130,7 +130,7 @@ Thankyou! -->
 ### Deprecated
 1. Deprecated `is_src_dst_assignment_known` dictionary attribute and its usage in `Network Activity` in favour of `initiator_id`. [#1598](https://github.com/ocsf/ocsf-schema/pull/1598)
 1. Deprecated `message` attribute in the `http_response` object. The `code` and `status` attributes already convey the HTTP status code and reason phrase. [#1616](https://github.com/ocsf/ocsf-schema/pull/1616)
-1. Deprecated `entity_result`, `file_result`, `resources_result`, and `web_resources_result` in favor of the corresponding `updated_*` attributes. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
+1. Deprecated `entity_result`, `resources_result`, and `web_resources_result` in favor of the corresponding `updated_*` attributes. [#1618](https://github.com/ocsf/ocsf-schema/pull/1618)
 1. Deprecated `resource` in `Group Management` in favor of `resources`. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
 1. Deprecated usage of `cmd_line` attribute in favor of `job_actions.cmd_line` in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
 1. Deprecated usage of `last_run_time` attribute in favor of `job_triggers.last_run_time` in the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/dictionary.json
+++ b/dictionary.json
@@ -2818,11 +2818,7 @@
     "file_result": {
       "caption": "File Result",
       "description": "The result of the file change. It should contain the new values of the changed attributes.",
-      "type": "file",
-      "@deprecated": {
-        "message": "Use the <code>updated_file</code> attribute instead.",
-        "since": "1.9.0"
-      }
+      "type": "file"
     },
     "files": {
       "caption": "Files",
@@ -7087,11 +7083,6 @@
       "caption": "Updated Entity",
       "description": "The updated entity. See specific usage.",
       "type": "managed_entity"
-    },
-    "updated_file": {
-      "caption": "Updated File",
-      "description": "The updated file. See specific usage.",
-      "type": "file"
     },
     "updated_group": {
       "caption": "Updated Group",

--- a/events/application/file_hosting.json
+++ b/events/application/file_hosting.json
@@ -146,11 +146,6 @@
       "description": "The endpoint that performed the activity on the target file.",
       "group": "primary",
       "requirement": "required"
-    },
-    "updated_file": {
-      "description": "The intended state of the <code>file</code> after the update, including the <code>Update</code>, <code>Rename</code>, and <code>Move</code> activities. On <code>Success</code>, represents the actual post-update state.",
-      "group": "context",
-      "requirement": "optional"
     }
   }
 }

--- a/events/system/file_activity.json
+++ b/events/system/file_activity.json
@@ -100,11 +100,6 @@
       "description": "The resulting file object when the activity was allowed and successful.",
       "group": "primary",
       "requirement": "recommended"
-    },
-    "updated_file": {
-      "description": "The intended state of the <code>file</code> after the update, including the <code>Update</code>, <code>Rename</code>, <code>Set Attributes</code> and <code>Set Security</code> activities. On <code>Success</code>, represents the actual post-update state.",
-      "group": "primary",
-      "requirement": "recommended"
     }
   },
   "references": [


### PR DESCRIPTION
#### Description of changes: 

Rolls back `file_result` within the 1.9 release cycle originally introduced in #1618. Discussion and conclusion here: https://github.com/ocsf/ocsf-schema/pull/1663#issuecomment-4723900557