### PR TITLE
Expand the application object with `src_url` and time based attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,7 +124,7 @@ Thankyou! -->
   1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `created_time`, `first_seen_time`, `last_seen_time`, `modified_time`, and `src_url` attributes to the `application` object.
+  1. Added `created_time`, `first_seen_time`, `last_seen_time`, `modified_time`, and `src_url` attributes to the `application` object. [#1683](https://github.com/ocsf/ocsf-schema/pull/1683)
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,7 @@ Thankyou! -->
   1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
+  1. Added `created_time`, `first_seen_time`, `last_seen_time`, `modified_time`, and `src_url` attributes to the `application` object.
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ Thankyou! -->
 -->
 
 ## [Unreleased]
+### Added
+* #### Categories
+* #### Event Classes
+* #### Profiles
+* #### Objects
+* #### Observables
+* #### Platform Extensions
+* #### Dictionary Attributes
+
+### Improved
+* #### Categories
+* #### Event Classes
+* #### Profiles
+* #### Objects
+  1. Added `created_time`, `first_seen_time`, `last_seen_time`, `modified_time`, `src_url`, and `criticality_id` attributes to the `application` object. [#1683](https://github.com/ocsf/ocsf-schema/pull/1683)
+* #### Observables
+* #### Platform Extensions
+* #### Dictionary Attributes
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/objects/application.json
+++ b/objects/application.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "application",
   "attributes": {
+    "created_time": {
+      "description": "The time when the application was known to have been created.",
+      "requirement": "optional"
+    },
     "criticality": {
       "caption": "Business Criticality",
       "description": "The criticality of the application as defined by the event source.",
@@ -18,6 +22,10 @@
       "description": "A description or commentary for an application, usually retrieved from an upstream system.",
       "requirement": "optional"
     },
+    "first_seen_time": {
+      "description": "The initial discovery time of the application.",
+      "requirement": "optional"
+    },
     "group": {
       "description": "The name of the related application or associated resource group.",
       "requirement": "optional"
@@ -28,6 +36,14 @@
     },
     "labels": {
       "description": "The list of labels associated to the application.",
+      "requirement": "optional"
+    },
+    "last_seen_time": {
+      "description": "The most recent discovery time of the application.",
+      "requirement": "optional"
+    },
+    "modified_time": {
+      "description": "The time when the application was last known to have been modified.",
       "requirement": "optional"
     },
     "name": {
@@ -61,6 +77,10 @@
     "sbom": {
       "caption": "Related SBOM",
       "description": "The Software Bill of Materials (SBOM) associated with the application",
+      "requirement": "optional"
+    },
+    "src_url": {
+      "description": "URL pointing to the source of the application in the event source.",
       "requirement": "optional"
     },
     "tags": {

--- a/objects/application.json
+++ b/objects/application.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "name": "application",
   "attributes": {
+    "created_time": {
+      "description": "The time when the application was known to have been created.",
+      "requirement": "optional"
+    },
     "criticality": {
       "caption": "Business Criticality",
       "description": "The criticality of the application as defined by the event source.",
@@ -18,6 +22,10 @@
       "description": "A description or commentary for an application, usually retrieved from an upstream system.",
       "requirement": "optional"
     },
+    "first_seen_time": {
+      "description": "The initial discovery time of the application.",
+      "requirement": "optional"
+    },
     "group": {
       "description": "The name of the related application or associated resource group.",
       "requirement": "optional"
@@ -28,6 +36,14 @@
     },
     "labels": {
       "description": "The list of labels associated to the application.",
+      "requirement": "optional"
+    },
+    "last_seen_time": {
+      "description": "The most recent discovery time of the application.",
+      "requirement": "optional"
+    },
+    "modified_time": {
+      "description": "The time when the application was last known to have been modified.",
       "requirement": "optional"
     },
     "name": {
@@ -65,6 +81,10 @@
     "sbom": {
       "caption": "Related SBOM",
       "description": "The Software Bill of Materials (SBOM) associated with the application",
+      "requirement": "optional"
+    },
+    "src_url": {
+      "description": "URL pointing to the source of the application in the event source.",
       "requirement": "optional"
     },
     "tags": {

--- a/objects/application.json
+++ b/objects/application.json
@@ -10,7 +10,9 @@
     },
     "criticality": {
       "caption": "Business Criticality",
-      "description": "The criticality of the application as defined by the event source.",
+      "requirement": "optional"
+    },
+    "criticality_id": {
       "requirement": "optional"
     },
     "data": {
@@ -84,7 +86,7 @@
       "requirement": "optional"
     },
     "src_url": {
-      "description": "URL pointing to the source of the application in the event source.",
+      "description": "The URL to the application's record or detail page within the reporting event source (e.g., a link to the application in the security tool's UI).",
       "requirement": "optional"
     },
     "tags": {


### PR DESCRIPTION
#### Summary:
Today there is no first class support for time based attributes or the `src_url` attribute in the `application` object. This creates a problem where this information is lost when mapping data returned about an application from an application security tool. This PR aims to solve this problem by adding first class support for these attributes.

#### Design notes:
- Time based attributes
  - The specific time based attributes added in this PR were chosen in order to keep the `application` objects time based attributes in line with other objects time based attributes such as the `device` object.
- `src_url`
  - While the `application` object already contains the `url` attribute it does not contain an attribute to hold information regarding the url of the object in the events source system. The `src_url` attribute was chosen to solve this issue because of its use in other objects such as the `finding_info` object.

#### Description of changes:
- Addition of the `created_time`, `first_seen_time`, `last_seen_time`, `modified_time`, and `src_url` attributes to the `application` object

