### PR TITLE
Add `encoding_id` to `fingerprint` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Thankyou! -->
   1. Removed the abstract `_dns` object; `class`, `type`, and the deprecated `packet_uid` attribute now live directly on `dns_query`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `peripheral_devices` to `device`. [#1645](https://github.com/ocsf/ocsf-schema/pull/1645)
   1. Added `serialization` and `serialization_id` to the `digital_signature` object to record the canonical signing input (JCS, JWS, COSE, DSSE, Authenticode). [#1662](https://github.com/ocsf/ocsf-schema/pull/1662)
+  1. Added `encoding` and `encoding_id` to the `fingerprint` object to record how the raw hash bytes are represented as the `value` string (Hex, Base64, Base64URL). [#1684](https://github.com/ocsf/ocsf-schema/pull/1684)
   1. Added `uid_numeric` to `_entity` so that a numeric `uid` value can be represented natively. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Extended `http_method` attribute in the `http_request` object to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `prompt_text` and `response_text` attributes to the `message_context` object, complementing the existing `prompt_tokens` and `completion_tokens` metrics with the verbatim prompt and response text. [#1674](https://github.com/ocsf/ocsf-schema/pull/1674)

--- a/objects/fingerprint.json
+++ b/objects/fingerprint.json
@@ -197,6 +197,48 @@
         }
       }
     },
+    "encoding": {
+      "description": "The encoding of the <code>value</code> attribute, normalized to the caption of <code>encoding_id</code>. In the case of <code>Other</code>, it is defined by the event source.",
+      "requirement": "optional"
+    },
+    "encoding_id": {
+      "description": "The normalized identifier of the encoding used to represent the fingerprint bytes as the string in <code>value</code>. A verifier must decode <code>value</code> using this encoding to recover the raw hash bytes.",
+      "requirement": "recommended",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The encoding of the fingerprint value is not known."
+        },
+        "1": {
+          "caption": "Hex",
+          "description": "The fingerprint value is encoded as a lowercase or uppercase hexadecimal string."
+        },
+        "2": {
+          "caption": "Base64",
+          "description": "The fingerprint value is encoded using standard Base64.",
+          "references": [
+            {
+              "description": "RFC 4648, Section 4",
+              "url": "https://www.rfc-editor.org/rfc/rfc4648#section-4"
+            }
+          ]
+        },
+        "3": {
+          "caption": "Base64URL",
+          "description": "The fingerprint value is encoded using URL- and filename-safe Base64.",
+          "references": [
+            {
+              "description": "RFC 4648, Section 5",
+              "url": "https://www.rfc-editor.org/rfc/rfc4648#section-5"
+            }
+          ]
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The encoding of the fingerprint value is not mapped. See the <code>encoding</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "value": {
       "description": "The fingerprint value.<p><b>Note:</b> This uses type <code>file_hash_t</code> (&quot;Hash&quot;), which has been generalized for all fingerprints but retains the same name and caption for backwards compatibility.</p>",
       "requirement": "required",


### PR DESCRIPTION
## Problem

Follow-up to #1661. During review, @Aniak5 pointed out (flagged as unrelated to that PR) that `fingerprint.value` is a string, but nothing says how the underlying hash bytes are encoded (hex, base64, base64url) — that's ambiguous for a verifier trying to recover the raw bytes.

## Change

Adds `encoding`/`encoding_id` to the `fingerprint` object, reusing the existing dictionary attribute pair (already used by `packet.encoding_id`) with a fingerprint-specific enum override:

- `0` Unknown
- `1` Hex
- `2` Base64
- `3` Base64URL
- `99` Other

Same pattern #1662 used for `serialization_id` on `digital_signature`. `encoding_id` is `recommended`, not `required`, so this is backward compatible.

Scope is intentionally narrow — encoding metadata only, no other changes to `fingerprint`.

## Changes

- `objects/fingerprint.json` — added `encoding`/`encoding_id`
- `CHANGELOG.md` — entry under `Improved > Objects`