### PR TITLE
Add threat_source_id and is_aggregate to Findings and Detection Findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ Thankyou! -->
 1. Deprecated the `account_change` and `user_access_management` classes in favor of the `user_management` class. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
 1. Deprecated the `user_result` attribute in favor of the `updated_user` attribute. [#1603](https://github.com/ocsf/ocsf-schema/pull/1603)
 1. Deprecated the `user` attribute in the `group_management` class in favor of `users`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
+1. Deprecated the `comment` attribute in the `finding` class and its extended classes, and the `incident_finding` class in favor of `notes`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
 ### Misc
 1. Added static anti-pattern detection, LLM-to-static learning pipeline, and deprecated attribute filtering to the automated PR review workflows. [#1599](https://github.com/ocsf/ocsf-schema/pull/1599)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Thankyou! -->
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `users` to `group_management` to replace deprecated `user`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
   1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
-  1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+  1. Added `resources` to `finding` for consistency and referencing within the class. Added `devices`, `endpoint_connections`, and `users` to `finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
   1. Added the `ai_operation` profile to the `system`, `network`, `application`, and `iam` base event classes so all System Activity, Network Activity, Application Activity, and Identity & Access Management events inherit agent attribution. Also added the profile to `email_activity` (which does not extend a base with the profile). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Thankyou! -->
   1. Added `dns_section` object to represent a DNS message section containing supplementary resource records and an optional TSIG record. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `tsig` object to represent a TSIG (Transaction Signature) record with structured fields for security analytics: `algorithm`, `key_name`, `error_id`, and `error`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Added `download_info` object with information pertaining to a downloaded file. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `note` object to capture a comment along with the user who made the comment and when the note was modified. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+
 * #### Observables
 * #### Platform Extensions
 * #### Dictionary Attributes
@@ -78,6 +80,7 @@ Thankyou! -->
   1. Added `binary_data`, `contents`, `clipboard_native_type`, `string_data`. [#1655](https://github.com/ocsf/ocsf-schema/pull/1655)
   1. Added `uid_numeric` attribute to enable a unique identifier that is numeric to be represented natively using the `long_t` data type. [#1643](https://github.com/ocsf/ocsf-schema/pull/1643)
   1. Added `download_info` attribute to `file` object. [#1658](https://github.com/ocsf/ocsf-schema/pull/1658)
+  1. Added `notes` attribute as an array of `Note` objects. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 
 ### Improved
 * #### Categories
@@ -89,6 +92,8 @@ Thankyou! -->
   1. Added `transaction_id`, `opcode_id`/`opcode`, `flag_ids`/`flags`, `authority`, `query_additional`, and `response_additional` to `DNS Activity`. [#1634](https://github.com/ocsf/ocsf-schema/pull/1634)
   1. Extended `activity_id` attribute in `HTTP Activity` to cover all methods in IANA HTTP Method Registry. [#1654](https://github.com/ocsf/ocsf-schema/pull/1654)
   1. Added `users` to `group_management` to replace deprecated `user`. [#1666](https://github.com/ocsf/ocsf-schema/pull/1666)
+  1. Added `notes` to `finding` and `incident_finding`. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
+  1. Added `resources` to `finding` for consistency and referencing within the class. [#1670](https://github.com/ocsf/ocsf-schema/pull/1670)
 * #### Profiles
 * #### Objects
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/dictionary.json
+++ b/dictionary.json
@@ -3481,6 +3481,11 @@
       "description": "The IP address, in either IPv4 or IPv6 format.",
       "type": "ip_t"
     },
+    "is_aggregate": {
+      "caption": "Aggregate",
+      "description": "Indicates that the event or finding represents an aggregated set. See specific usage.",
+      "type": "boolean_t"
+    },
     "is_alert": {
       "caption": "Alert",
       "description": "Indicates that the event is considered to be an alertable signal.",
@@ -6782,7 +6787,7 @@
     },
     "threat_actor": {
       "caption": "Threat Actor",
-      "description": "A threat actor is an individual or group that conducts malicious cyber activities, often with financial, political, or ideological motives.",
+      "description": "A threat actor is the technical representation of an individual or group that conducts malicious cyber activities, often with financial, political, or ideological motives.",
       "type": "threat_actor",
       "references": [
         {
@@ -6790,6 +6795,55 @@
           "url": "https://stixproject.github.io/data-model/1.2/ta/ThreatActorType/"
         }
       ]
+    },
+    "threat_source": {
+      "caption": "Threat Source",
+      "description": "The technology from where a threat (or multiple threats) is reported, or originates from, normalized to the caption of the threat_source_id value.",
+      "type": "string_t"
+    },
+    "threat_source_id": {
+      "caption": "Threat Source ID",
+      "description": "The technology from where a threat (or multiple threats) is reported, or originates.<p>Note: this does not imply that the threat source is the threat actor.</p>",
+      "sibling": "threat_source",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The threat source is unknown"
+        },
+        "1": {
+          "caption": "Network",
+          "description": "The threat is reported by, or originates from a network, firewall, or IPS sensor."
+        },
+        "2": {
+          "caption": "Endpoint",
+          "description": "The threat is reported by, or originates from an endpoint device."
+        },
+        "3": {
+          "caption": "Email",
+          "description": "The threat originates from an email or phishing exploit."
+        },
+        "4": {
+          "caption": "IAM",
+          "description": "The threat originates from an identity or privilege escalation exploit."
+        },
+        "5": {
+          "caption": "Proxy",
+          "description": "The threat is reported by a forward proxy."
+        },
+        "6": {
+          "caption": "Threat Intel",
+          "description": "The threat is reported by a threat intelligence feed or report."
+        },
+        "7": {
+          "caption": "Application",
+          "description": "The threat originates from an application."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The threat source is not mapped. See the <code>threat_source</code> attribute, which contains a data source specific value."
+        }
+      }
     },
     "ticket": {
       "caption": "Ticket",
@@ -6994,7 +7048,7 @@
     },
     "type_id": {
       "caption": "Type ID",
-      "description": "The normalized type identifier of an object. See specific usage.",
+      "description": "The normalized type identifier of an object or value. See specific usage.",
       "sibling": "type",
       "type": "integer_t",
       "enum": {
@@ -7018,6 +7072,12 @@
       "description": "The event/finding type ID. It identifies the event's semantics and structure. Producers and mappers <b>must</b> compute this as <code>class_uid * 100 + activity_id</code>. It uniquely identifies the combination of event class and activity across the entire schema. For example, <code>Detection Finding: Create</code> is <code>200401</code>.",
       "sibling": "type_name",
       "type": "long_t"
+    },
+    "type_uid_list": {
+      "caption": "Type ID List",
+      "description": "A list of <code>type_uid</code> integer values. See specific usage.",
+      "type": "long_t",
+      "is_array": true
     },
     "types": {
       "caption": "Types",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4378,6 +4378,12 @@
       "type": "string_t",
       "is_array": true
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the event or object. See specific usage.",
+      "type": "note",
+      "is_array": true
+    },
     "nodes": {
       "caption": "Nodes",
       "description": "The list of node objects that are part of the graph.",

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -75,7 +75,7 @@
     "resources": {
       "caption": "Affected Resources",
       "description": "Describes details about resources that were the target of the activity that triggered the finding.",
-      "group": "context",
+      "group": "primary",
       "requirement": "recommended"
     },
     "risk_details": {

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -98,6 +98,14 @@
       "requirement": "optional",
       "profile": null
     },
+    "threat_source": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "threat_source_id": {
+      "group": "context",
+      "requirement": "recommended"
+    },
     "vulnerabilities": {
       "description": "Describes vulnerabilities reported in a Detection Finding.",
       "group": "context",

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -56,7 +56,16 @@
       "description": "Describes the affected device/host. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",
       "group": "context",
       "requirement": "optional",
-      "profile": null
+      "profile": null,
+      "@deprecated": {
+        "message": "Use the <code>devices</code> attribute instead.",
+        "since": "1.9.0"
+      }
+    },
+    "devices": {
+      "description": "Describes the affected devices/hosts. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about AWS EC2 instances, that are affected by the Finding.</p><p>If a single device is the source of the Finding, use the <code>Host</code> profile.</p>",
+      "group": "context",
+      "requirement": "optional"
     },
     "end_time": {
       "description": "The time of the most recent event or finding that contributed to this finding.",

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -62,6 +62,12 @@
       "group": "primary",
       "requirement": "required"
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time, where an updated comment may not suffice.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "start_time": {
       "description": "The time of the earliest event or finding that contributed to this finding.",
       "requirement": "optional"

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -75,6 +75,11 @@
       "group": "context",
       "requirement": "optional"
     },
+    "is_aggregate": {
+      "description": "If set, indicates that the finding aggregates other findings. See <code>finding_info.related_events</code> when this value is <code>true</code> and the related events are findings.<p>Note that aggregated findings are similar to the <code>Incident Finding</code> if the <code>Incident</code> profile is applied.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "finding_info": {
       "group": "primary",
       "requirement": "required"
@@ -97,6 +102,11 @@
     },
     "time": {
       "description": "The finding creation time &mdash; when the finding was first generated, not when the underlying activity occurred. For the time range of contributing events, use <code>start_time</code> and <code>end_time</code>."
+    },
+    "type_uid_list": {
+      "caption": "Aggregate Types",
+      "description": "A unique list of <code>type_uid</code> values that represent the type of each group of findings when <code>finding_info.related_events</code> include other findings. This is a convenience that avoids walking the ist of <code>finding_info.related_events</code> to filter sets of similar findings that are not activities.",
+      "requirement": "optional"
     },
     "status": {
       "description": "The finding lifecycle status label, normalized to the caption of the <code>status_id</code> value. When <code>status_id</code> is <code>99</code> (Other), this <b>must</b> contain the source-specific status label.",

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -68,6 +68,12 @@
       "group": "context",
       "requirement": "optional"
     },
+    "resources": {
+      "caption": "Affected Resources",
+      "description": "Describes details about resources that were the target of the activity that triggered the finding.",
+      "group": "context",
+      "requirement": "recommended"
+    },
     "start_time": {
       "description": "The time of the earliest event or finding that contributed to this finding.",
       "requirement": "optional"

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -4,6 +4,9 @@
   "description": "The Finding event is a generic event that defines a set of attributes available in the Findings category.",
   "extends": "base_event",
   "name": "finding",
+  "profiles": [
+    "incident"
+  ],
   "attributes": {
     "$include": [
       "profiles/incident.json"
@@ -53,22 +56,23 @@
       "profile": null
     },
     "device": {
-      "description": "Describes the affected device/host. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about an AWS EC2 instance, that is affected by the Finding.</p>",
+      "description": "Describes the device/host relevant to the finding. <p>If applicable, it can be used in conjunction with <code>resources</code>. e.g. The role of the device as the target or the actor, its IP address etc.</p><p>If a single device is the source of the finding, rather than a targeted or affected device, use the <code>Host</code> profile and populate <code>device</code>.</p>",
       "group": "context",
       "requirement": "optional",
-      "profile": null,
-      "@deprecated": {
-        "message": "Use the <code>devices</code> attribute instead.",
-        "since": "1.9.0"
-      }
+      "profile": null
     },
     "devices": {
-      "description": "Describes the affected devices/hosts. If applicable, it can be used in conjunction with <code>Resource(s)</code>. <p> e.g. Specific details about AWS EC2 instances, that are affected by the Finding.</p><p>If a single device is the source of the Finding, use the <code>Host</code> profile.</p>",
+      "description": "Describes the devices/hosts relevant to the finding. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the devices as targets or actors, their IP addresses etc.</p><p>If a single device is the source of the finding, use the <code>Host</code> profile and populate <code>device</code>.</p>",
       "group": "context",
       "requirement": "optional"
     },
     "end_time": {
       "description": "The time of the most recent event or finding that contributed to this finding.",
+      "requirement": "optional"
+    },
+    "endpoint_connections": {
+      "description": "Describes the affected endpoint network connections, or network connection attempts. <p>If applicable, they can be used in conjunction with <code>resources</code>. e.g. The roles of the endpoints as targets or actors, their hostnames etc.</p>",
+      "group": "context",
       "requirement": "optional"
     },
     "finding_info": {
@@ -130,12 +134,14 @@
         }
       }
     },
+    "users": {
+      "description": "Describes the users that are affected by the finding.</p><p>If a single user is the source of the finding or activities behind the finding, use the <code>Host</code> profile and populate <code>actor.user</code>.</p>",
+      "group": "context",
+      "requirement": "optional"
+    },
     "vendor_attributes": {
       "group": "context",
       "requirement": "optional"
     }
-  },
-  "profiles": [
-    "incident"
-  ]
+  }
 }

--- a/events/findings/finding.json
+++ b/events/findings/finding.json
@@ -31,7 +31,11 @@
     "comment": {
       "description": "A user provided comment about the finding.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>notes</code> attribute instead.",
+        "since": "1.9.0"
+      }
     },
     "confidence": {
       "group": "context",
@@ -64,7 +68,7 @@
     },
     "notes": {
       "caption": "Notes",
-      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time, where an updated comment may not suffice.",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, the time when the note was created, and the time when the note was last modified (typically by the same user). Notes can be used to provide additional context, explanations, or observations by analysts related to the finding over time.",
       "group": "context",
       "requirement": "optional"
     },

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -91,6 +91,12 @@
       "group": "context",
       "requirement": "optional"
     },
+    "notes": {
+      "caption": "Notes",
+      "description": "Additional notes related to the incident. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time, where an updated comment may not suffice.",
+      "group": "context",
+      "requirement": "optional"
+    },
     "priority": {
       "group": "context",
       "requirement": "optional"

--- a/events/findings/incident_finding.json
+++ b/events/findings/incident_finding.json
@@ -45,7 +45,11 @@
     "comment": {
       "description": "Additional user supplied details for updating or closing the incident.",
       "group": "context",
-      "requirement": "optional"
+      "requirement": "optional",
+      "@deprecated": {
+        "message": "Use the <code>notes</code> attribute instead.",
+        "since": "1.9.0"
+      }
     },
     "confidence": {
       "group": "context",
@@ -93,7 +97,7 @@
     },
     "notes": {
       "caption": "Notes",
-      "description": "Additional notes related to the incident. Each note in the array can include a comment, the user who made the comment, and the time when the note was last modified. Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time, where an updated comment may not suffice.",
+      "description": "Additional notes related to the finding. Each note in the array can include a comment, the user who made the comment, the time when the note was created, and the time when the note was last modified (typically by the same user). Notes can be used to provide additional context, explanations, or observations by analysts related to the incident over time.",
       "group": "context",
       "requirement": "optional"
     },

--- a/objects/note.json
+++ b/objects/note.json
@@ -1,0 +1,20 @@
+{
+  "caption": "Note",
+  "description": "Represents a note or a comment in the system. Notes can be used to provide additional context, explanations, or observations related to an event, object, or any other entity in the system. They can be created and modified by users to capture important information that may not be directly represented in the structured data.",
+  "extends": "object",
+  "name": "note",
+  "attributes": {
+    "comment": {
+      "description": "A user provided comment.",
+      "requirement": "required"
+    },
+    "modified_time": {
+      "description": "The time when the note was last modified.",
+      "requirement": "recommended"
+    },
+    "user": {
+      "description": "The user who created or last modified the note.",
+      "requirement": "recommended"
+    }
+  }
+}

--- a/objects/note.json
+++ b/objects/note.json
@@ -8,6 +8,10 @@
       "description": "A user provided comment.",
       "requirement": "required"
     },
+    "created_time": {
+      "description": "The time when the note was created.",
+      "requirement":"recommended"
+    },
     "modified_time": {
       "description": "The time when the note was last modified.",
       "requirement": "recommended"

--- a/objects/note.json
+++ b/objects/note.json
@@ -16,8 +16,8 @@
       "description": "The time when the note was last modified.",
       "requirement": "recommended"
     },
-    "user": {
-      "description": "The user who created or last modified the note.",
+    "owner": {
+      "description": "The user who created or last modified the note. Typically the same user that created the note can modify the note.",
       "requirement": "recommended"
     }
   }


### PR DESCRIPTION
#### Related Issue: 1679

#### Description of changes:
Added an `is_aggregate` boolean to `finding.json` to indicate that a finding contains related findings.

Added a `threat_source_id` and sibling to `Detection Finding` to indicate the source of the detection finding:
- Endpoing
- Network
- Email
- IAM
- Proxy
- Threat Intel

This is for convenience to be able to categorize detection findings when they originate from a specific control point or technical source.

