### PR TITLE
update model

### DIFF
--- a/.github/scripts/review_descriptions.py
+++ b/.github/scripts/review_descriptions.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 COMMENT_MARKER = "<!-- ocsf-description-review -->"
-DEFAULT_MODEL = "claude-sonnet-4-20250514"
+DEFAULT_MODEL = "claude-sonnet-4-6"
 MAX_CONTEXT_CHARS = 400_000
 
 # Deterministic normative pre-check (rules 13–15).


### PR DESCRIPTION

## Changes
- `.github/scripts/review_descriptions.py`: bump `DEFAULT_MODEL` to `claude-sonnet-4-6`.
## Notes
- Uses the rolling `claude-sonnet-4-6` alias so it tracks the latest 4.6 snapshot. Can be swapped for a dated ID (`claude-sonnet-4-6-YYYYMMDD`) if we want to pin for reproducibility.
- The `CLAUDE_MODEL` env var override is unchanged, so the model can still be swapped per-run without a code change.
- Sonnet 4.6 