### PR TITLE
Alternative: Add `attestation` object and `record_integrity` profile

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -447,6 +447,11 @@
       "description": "The delivery attempt.",
       "type": "integer_t"
     },
+    "attestation_authority_uid": {
+      "caption": "Attestation Authority Unique ID",
+      "description": "The unique identifier of an attestation authority. See specific usage.",
+      "type": "string_t"
+    },
     "attestation_list": {
       "caption": "Attestation List",
       "description": "An array of <code>attestation</code> objects, each of which is a cryptographic attestation providing integrity, authenticity, and non-repudiation of the containing event.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -447,6 +447,12 @@
       "description": "The delivery attempt.",
       "type": "integer_t"
     },
+    "attestation_list": {
+      "caption": "Attestation List",
+      "description": "An array of <code>attestation</code> objects, each of which is a cryptographic attestation providing integrity, authenticity, and non-repudiation of the containing event.",
+      "type": "attestation",
+      "is_array": true
+    },
     "attributes": {
       "caption": "Attributes",
       "description": "The bitmask value that represents the file attributes.",

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -9,6 +9,7 @@
       "profiles/datetime.json",
       "profiles/host.json",
       "profiles/osint.json",
+      "profiles/record_integrity.json",
       "profiles/security_control.json"
     ],
     "activity_id": {
@@ -167,6 +168,7 @@
     "datetime",
     "host",
     "osint",
+    "record_integrity",
     "security_control"
   ]
 }

--- a/events/findings/attestation_finding.json
+++ b/events/findings/attestation_finding.json
@@ -1,7 +1,7 @@
 {
   "uid": 9,
   "caption": "Attestation Finding",
-  "description": "Attestation Finding events are [appropriate description goes here].",
+  "description": "Attestation Finding events report the addition of a new <code>attestation</code> object to the <code>attestation_list</code> array in the events referenced by <code>finding_info.related_events</code>.",
   "extends": "finding",
   "name": "attestation_finding",
   "attributes": {

--- a/events/findings/attestation_finding.json
+++ b/events/findings/attestation_finding.json
@@ -5,5 +5,9 @@
   "extends": "finding",
   "name": "attestation_finding",
   "attributes": {
+    "attestation_authority_uid": {
+      "description": "The unique identifier of the attestation authority that generated this finding. In events referenced by <code>finding_info.related_events</code>, the current finding relates to those elements of the <code>attestion_list</code> array where <code>attestion_authority_uid</code> matches this value.",
+      "requirement": "required"
+    }
   }
 }

--- a/events/findings/attestation_finding.json
+++ b/events/findings/attestation_finding.json
@@ -1,0 +1,9 @@
+{
+  "uid": 9,
+  "caption": "Attestation Finding",
+  "description": "Attestation Finding events are [appropriate description goes here].",
+  "extends": "finding",
+  "name": "attestation_finding",
+  "attributes": {
+  }
+}

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -10,7 +10,7 @@
     },
     "parent_uid": {
       "caption": "Parent Unique ID",
-      "description": "Identifies the `metadata.uid` of an Attestation Finding that defines an ordered sequence of events that have been attested to by a verifiable authority.",
+      "description": "Identifies the <code>metadata.uid</code> of an Attestation Finding that defines an ordered sequence of events that have been attested to by a verifiable authority.",
       "requirement": "optional"
     }
   }

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -4,6 +4,10 @@
   "extends": "object",
   "description": "A cryptographic attestation that an event has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. It is domain-agnostic and may be applied to any event class.",
   "attributes": {
+    "attestation_authority_uid": {
+      "description": "The unique identifier of the attestation authority that issued this attestation.",
+      "requirement": "required"
+    },
     "signatures": {
       "description": "One or more digital signatures of a canonical serialization of the event, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
       "requirement": "required"

--- a/objects/attestation.json
+++ b/objects/attestation.json
@@ -1,0 +1,17 @@
+{
+  "caption": "Attestation",
+  "name": "attestation",
+  "extends": "object",
+  "description": "A cryptographic attestation that an event has not been altered since it was produced and was produced by the holder of a verifiable identity, providing integrity, authenticity, and non-repudiation. It is domain-agnostic and may be applied to any event class.",
+  "attributes": {
+    "signatures": {
+      "description": "One or more digital signatures of a canonical serialization of the event, each bound to a verifiable identity. The first entry is typically the producer; additional entries carry co-signatures such as a notary or witness over the same record. The signing algorithm, certificate or public-key material, and signing time are carried within each <code>digital_signature</code> object.",
+      "requirement": "required"
+    },
+    "parent_uid": {
+      "caption": "Parent Unique ID",
+      "description": "Identifies the `metadata.uid` of an Attestation Finding that defines an ordered sequence of events that have been attested to by a verifiable authority.",
+      "requirement": "optional"
+    }
+  }
+}

--- a/profiles/record_integrity.json
+++ b/profiles/record_integrity.json
@@ -1,0 +1,12 @@
+{
+  "caption": "Record Integrity",
+  "description": "The Record Integrity profile adds a cryptographic attestation to an event, providing integrity, authenticity, and non-repudiation independent of any domain-specific content.",
+  "meta": "profile",
+  "name": "record_integrity",
+  "attributes": {
+    "attestation_list": {
+      "group": "context",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
As promised during today's Network+AI call, I've created this draft PR to show what an alternative approach to #1661 might look like.

This diagram tries to get the idea across.

<img width="1000" height="976" alt="image" src="https://github.com/user-attachments/assets/519ed1d7-7657-4b59-8349-8d8970549027" />

* The first `Attestation Finding` event (top left) links to the `Web Resources Activity` event and to the `API Activity` event from its `related_events` array.
* The second `Attestation Finding` event (bottom left) links to the `API Activity` event and to the `Datastore Activity` event from its `related_events` array.
* Each `Attestation Finding` event carries an attestation to its own integrity in its `attestation_list` array.
* The `Web Resource Activity` event (top right) is linked to from the first `Attestation Finding` event. It carries one `attestation` object in its `attestation_list` array. This links back to the first `Attestation Finding` event.
* The `API Activity` event (middle right) is linked to from both `Attestation Finding` events. It carries two `attestation` objects in its `attestation_list` array. These link back to the two `Attestation Finding` events.
* The `Datastore Activity` event (bottom right) is linked to from the second `Attestation Finding` event. It carries one `attestation` object in its `attestation_list` array. This links back to the second `Attestation Finding` event.

The schema landing page showing the new `Attestation Finding` event class in the `Findings` category:

<img width="2866" height="1562" alt="image" src="https://github.com/user-attachments/assets/36a65ef7-4e30-49ef-9648-bb23dd39d984" />

The `Attestation Finding` event showing the `attestation_authority_uid` and the `attestation_list`:

<img width="2868" height="1727" alt="image" src="https://github.com/user-attachments/assets/2e0a2806-bc69-456b-b5cd-e47dc10eb31b" />

The `attestation_list` as it appears in a randomly chosen event class:

<img width="2866" height="1823" alt="image" src="https://github.com/user-attachments/assets/63a2eac6-3755-47f1-b637-220e155de5e6" />

The new `attestation` object itself:

<img width="2875" height="838" alt="image" src="https://github.com/user-attachments/assets/abc68abe-15a2-4d00-a1f8-dc439f6c7186" />

