### PR TITLE
Add `App Package` to `digital_signature` enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,7 +125,7 @@ Thankyou! -->
   1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (7)` enum value to `serialization_id` in the `digital_signature` object. [#TBD](https://github.com/ocsf/ocsf-schema/pull/TBD)
+  1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (7)` enum value to `serialization_id` in the `digital_signature` object. [#1692](https://github.com/ocsf/ocsf-schema/pull/1692)
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,7 @@ Thankyou! -->
   1. Removed `Microsoft` from descriptions in `algorithm_id` and `serialization_id` in the `digital_signature` object. [#1668](https://github.com/ocsf/ocsf-schema/pull/1668)
   1. Added `ai_agent` to `process`. Added `hosted_ai_agent_list` to `process` for cases where a process hosts multiple agents that cannot be individually attributed. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
   1. Added `charter` attribute to `ai_agent` for the agent's durable role definition document (system prompt or constitution). [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
+  1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (7)` enum value to `serialization_id` in the `digital_signature` object. [#TBD](https://github.com/ocsf/ocsf-schema/pull/TBD)
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -49,7 +49,7 @@
         },
         "6": {
           "caption": "App Package",
-          "description": "Windows Application Pacakge Signing Algorithm.",
+          "description": "Application Package Signing Algorithm.",
           "references": [
             {
               "description": "Sign an MSIX package",

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -47,6 +47,16 @@
             }
           ]
         },
+        "6": {
+          "caption": "App Package",
+          "description": "Windows Application Pacakge Signing Algorithm.",
+          "references": [
+            {
+              "description": "Sign an MSIX package",
+              "url": "https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview"
+            }
+          ]
+        },
         "99": {
           "caption": "Other"
         }
@@ -133,6 +143,16 @@
             {
               "description": "TN3126: Inside Code Signing: Hashes",
               "url": "https://developer.apple.com/documentation/technotes/tn3126-inside-code-signing-hashes"
+            }
+          ]
+        },
+        "7": {
+          "caption": "App Package",
+          "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest,  and how that manifest is signed.",
+          "references": [
+            {
+              "description": "Sign an MSIX package",
+              "url": "https://learn.microsoft.com/en-us/windows/msix/package/signing-package-overview"
             }
           ]
         },

--- a/objects/digital_signature.json
+++ b/objects/digital_signature.json
@@ -148,7 +148,7 @@
         },
         "7": {
           "caption": "App Package",
-          "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest,  and how that manifest is signed.",
+          "description": "The Windows Application Package signing procedure that describes how file hashes are stored in the manifest, and how that manifest is signed.",
           "references": [
             {
               "description": "Sign an MSIX package",


### PR DESCRIPTION
#### Related Issue: 

[Microsoft Packaged App identification is needed in digital_signature object
 #1691](https://github.com/ocsf/ocsf-schema/issues/1691)

#### Description of changes:

Added `App Package` to `digital_signature` object enums.


<img width="993" height="349" alt="AppPackageSerial" src="https://github.com/user-attachments/assets/edf3e280-4b67-4749-8e5b-979f8fe010a7" />
<img width="2404" height="2088" alt="AppPackageAlgo" src="https://github.com/user-attachments/assets/461615c5-5c1d-4edd-8470-a50d52847c17" />
