### PR TITLE
issue-1640: Change ai_agent.uid requirement from required to recommended

### DIFF
--- a/objects/ai_agent.json
+++ b/objects/ai_agent.json
@@ -7,7 +7,7 @@
     "uid": {
       "caption": "AI Agent ID",
       "description": "The stable logical identifier for the agent, assigned by the agent's authoritative source (e.g., its control plane, registry, or issuing identity provider). Persists across restarts and instances. Producers populate this from whatever identity they observe: for a runtime that owns the agent, this is its issued ID; for a gateway or proxy, it is typically derived from the agent's credential. Multiple producers logging the same agent should converge on the same <code>uid</code> when they share an authoritative source.",
-      "requirement": "required"
+      "requirement": "recommended"
     },
     "instance_uid": {
       "caption": "AI Agent Instance ID",


### PR DESCRIPTION
## Summary
- Changes `ai_agent.uid` requirement from `required` to `recommended`, aligning with the same-purpose `uid` attribute on other `_entity`-derived objects (e.g. `device`, `user`), which are `recommended` rather than `required`.
- No constraint changes needed: `_entity` (which `ai_agent` extends) already declares `at_least_one: [name, uid]`, so this is inherited automatically.

## Test plan
- [x] Validated `objects/ai_agent.json` is well-formed JSON
- [x] Confirmed the `at_least_one` name/uid constraint is inherited from `_entity` rather than needing local redeclaration