### PR TITLE
issue-1696: Add ai_status object (stop reason + agent scalars) to the ai_operation profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,11 +45,11 @@ Thankyou! -->
 
 ### Added
 * #### Dictionary Attributes
-  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added generic `stop_reason` and `stop_reason_id` attributes for the reason an activity or operation stopped, defined per the dictionary convention with only `Unknown` and `Other` so each usage supplies its own values. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 
 ### Improved
 * #### Profiles
-  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, recording why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, captioned `AI Stop Reason`, with a normalized enum (`End of Turn`, `Token Limit`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ Thankyou! -->
 * #### Platform Extensions
 * #### Dictionary Attributes
   1. Added `attestation_list`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -120,6 +121,7 @@ Thankyou! -->
   1. Added the `record_integrity` profile to the `base_event` class so every event class can optionally carry a cryptographic `attestation` over the event. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
+  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, recording why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 * #### Objects
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_triggers` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+
+### Improved
+* #### Profiles
+  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, recording why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added
@@ -75,7 +83,6 @@ Thankyou! -->
 * #### Platform Extensions
 * #### Dictionary Attributes
   1. Added `attestation_list`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
-  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
@@ -121,7 +128,6 @@ Thankyou! -->
   1. Added the `record_integrity` profile to the `base_event` class so every event class can optionally carry a cryptographic `attestation` over the event. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
-  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, recording why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 * #### Objects
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_triggers` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ Thankyou! -->
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
-  1. Added generic `stop_reason` and `stop_reason_id` attributes for the reason an activity or operation stopped, defined per the dictionary convention with only `Unknown` and `Other` so each usage supplies its own values. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added `ai_stop_reason` as a `string_t`, normalized to the caption of `ai_stop_reason_id`. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added `ai_stop_reason_id` as an `integer_t` enum for the reason a model completion ended, with values Unknown (0), End of Turn (1), Token Limit (2), Tool Use (3), Session Stop (4), Content Filter (5), Other (99). [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 
 ### Improved
 * #### Event Classes
@@ -57,7 +58,7 @@ Thankyou! -->
   1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 * #### Profiles
-  1. Added `stop_reason`/`stop_reason_id` sibling attributes to the `ai_operation` profile, captioned `AI Stop Reason`, with a normalized enum (`End of Turn`, `Token Limit`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added `ai_stop_reason` (optional) and `ai_stop_reason_id` (recommended) to the `ai_operation` profile in the `context` group, for the reason a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ Thankyou! -->
 * #### Platform Extensions
 * #### Dictionary Attributes
   1. Added `attestation_list`, `prev_event`, `authority_uid`, and `chain_uid` attributes for the `record_integrity` profile. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
-  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
+  1. Added `stop_reason` and `stop_reason_id` attributes with a normalized enum (`Stop`, `Length`, `Tool Use`, `Session Stop`) for why a model completion ended. [#1704](https://github.com/ocsf/ocsf-schema/pull/1704)
   1. Added `com_class_uuid` attribute to reflect Class Identifier of a Component Object Model. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `event_codes` that is a set of event identifiers. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `log_sources` that is a set of log systems. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/dictionary.json
+++ b/dictionary.json
@@ -242,6 +242,47 @@
       "sibling": "ai_role",
       "type": "integer_t"
     },
+    "ai_stop_reason": {
+      "caption": "AI Stop Reason",
+      "description": "The reason a model completion ended, normalized to the caption of the <code>ai_stop_reason_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "ai_stop_reason_id": {
+      "caption": "AI Stop Reason ID",
+      "description": "The normalized reason a model completion ended.",
+      "sibling": "ai_stop_reason",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The completion ended without the producer being able to determine why, so the state of the operation at termination is not established."
+        },
+        "1": {
+          "caption": "End of Turn",
+          "description": "The model reached the end of its turn: it completed its response naturally or emitted a configured stop sequence, and is not waiting on anything further."
+        },
+        "2": {
+          "caption": "Token Limit",
+          "description": "The completion was truncated by a token or length limit before the model finished, so the response is incomplete."
+        },
+        "3": {
+          "caption": "Tool Use",
+          "description": "The completion paused to invoke a tool. The turn is not finished; the model expects the tool result and will continue."
+        },
+        "4": {
+          "caption": "Session Stop",
+          "description": "The completion ended because the session or connection carrying it terminated - for example the caller cancelled, the client disconnected, or the transport closed - rather than because the model reached a stopping point. The session state at termination is therefore known, which distinguishes this from <code>Unknown</code> and lets a consumer decide whether the operation needs investigation or can simply be reclaimed."
+        },
+        "5": {
+          "caption": "Content Filter",
+          "description": "The completion was stopped by a safety, policy, or content moderation mechanism rather than by the model reaching a stopping point or by the caller. This includes a refusal raised by a safety classifier and a guardrail intervening on the request or the response."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The stop reason is not mapped. See the <code>ai_stop_reason</code> attribute, which contains a data source specific value."
+        }
+      }
+    },
     "aircraft": {
       "caption": "Aircraft",
       "description": "The Aircraft object represents any aircraft or otherwise airborne asset such as an unmanned system, airplane, balloon, spacecraft, or otherwise. The Aircraft object is intended to normalized data captured or otherwise logged from active radar, passive radar, multi-spectral systems, or the Automatic Dependant Broadcast - Surveillance (ADS-B), and/or Mode S systems.",
@@ -6929,27 +6970,6 @@
         "99": {
           "caption": "Other",
           "description": "The status is not mapped. See the <code>status</code> attribute, which contains a data source specific value."
-        }
-      }
-    },
-    "stop_reason": {
-      "caption": "Stop Reason",
-      "description": "The reason an activity or operation stopped, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is defined by the event source. See specific usage.",
-      "type": "string_t"
-    },
-    "stop_reason_id": {
-      "caption": "Stop Reason ID",
-      "description": "The normalized reason an activity or operation stopped. See specific usage.",
-      "sibling": "stop_reason",
-      "type": "integer_t",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The stop reason is unknown."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains a data source specific value."
         }
       }
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -6882,13 +6882,13 @@
     },
     "stop_reason_id": {
       "caption": "Stop Reason ID",
-      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set.",
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Beyond describing a single completion, this attribute is a leading indicator: a run of completions ending for reasons other than <code>Stop</code> - and particularly a rise in <code>Unknown</code> - can be the earliest signal that operations are being interrupted or manipulated, so consumers may monitor its distribution rather than only individual events.",
       "sibling": "stop_reason",
       "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The stop reason is unknown."
+          "description": "The stop reason is unknown. The completion ended without the producer being able to determine why, so the state of the operation at termination is not established."
         },
         "1": {
           "caption": "Stop",
@@ -6901,6 +6901,10 @@
         "3": {
           "caption": "Tool Use",
           "description": "The completion stopped to invoke a tool."
+        },
+        "4": {
+          "caption": "Session Stop",
+          "description": "The completion ended because the session or connection carrying it terminated - for example the caller cancelled, the client disconnected, or the transport closed - rather than because the model reached a stopping point. The session state at termination is therefore known, which distinguishes this from <code>Unknown</code> and lets a consumer decide whether the operation needs investigation or can simply be reclaimed."
         },
         "99": {
           "caption": "Other",

--- a/dictionary.json
+++ b/dictionary.json
@@ -6877,38 +6877,22 @@
     },
     "stop_reason": {
       "caption": "Stop Reason",
-      "description": "The reason the model completion ended, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "description": "The reason an activity or operation stopped, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is defined by the event source. See specific usage.",
       "type": "string_t"
     },
     "stop_reason_id": {
       "caption": "Stop Reason ID",
-      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Beyond describing a single completion, this attribute is a leading indicator: a run of completions ending for reasons other than <code>Stop</code> - and particularly a rise in <code>Unknown</code> - can be the earliest signal that operations are being interrupted or manipulated, so consumers may monitor its distribution rather than only individual events.",
+      "description": "The normalized reason an activity or operation stopped. See specific usage.",
       "sibling": "stop_reason",
       "type": "integer_t",
       "enum": {
         "0": {
           "caption": "Unknown",
-          "description": "The stop reason is unknown. The completion ended without the producer being able to determine why, so the state of the operation at termination is not established."
-        },
-        "1": {
-          "caption": "Stop",
-          "description": "The completion ended naturally or hit a stop sequence."
-        },
-        "2": {
-          "caption": "Length",
-          "description": "The completion was truncated by a token or length limit."
-        },
-        "3": {
-          "caption": "Tool Use",
-          "description": "The completion stopped to invoke a tool."
-        },
-        "4": {
-          "caption": "Session Stop",
-          "description": "The completion ended because the session or connection carrying it terminated - for example the caller cancelled, the client disconnected, or the transport closed - rather than because the model reached a stopping point. The session state at termination is therefore known, which distinguishes this from <code>Unknown</code> and lets a consumer decide whether the operation needs investigation or can simply be reclaimed."
+          "description": "The stop reason is unknown."
         },
         "99": {
           "caption": "Other",
-          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains the event source's value."
+          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains a data source specific value."
         }
       }
     },

--- a/dictionary.json
+++ b/dictionary.json
@@ -6875,6 +6875,39 @@
         }
       }
     },
+    "stop_reason": {
+      "caption": "Stop Reason",
+      "description": "The reason the model completion ended, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "stop_reason_id": {
+      "caption": "Stop Reason ID",
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set.",
+      "sibling": "stop_reason",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The stop reason is unknown."
+        },
+        "1": {
+          "caption": "Stop",
+          "description": "The completion ended naturally or hit a stop sequence."
+        },
+        "2": {
+          "caption": "Length",
+          "description": "The completion was truncated by a token or length limit."
+        },
+        "3": {
+          "caption": "Tool Use",
+          "description": "The completion stopped to invoke a tool."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains the event source's value."
+        }
+      }
+    },
     "storage_class": {
       "caption": "Storage Class",
       "description": "The storage class of the entity. See specific usage.",

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -28,7 +28,7 @@
       "requirement": "optional"
     },
     "stop_reason_id": {
-      "description": "The normalized reason the model completion ended (natural stop, length limit, tool invocation). Populate on completion events.",
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label.",
       "group": "context",
       "requirement": "recommended"
     }

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -23,43 +23,15 @@
       "group": "context",
       "requirement": "optional"
     },
-    "stop_reason": {
-      "caption": "AI Stop Reason",
-      "description": "The reason the model completion ended, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is the event source's native label, e.g. <code>end_turn</code> or <code>max_tokens</code>.",
+    "ai_stop_reason": {
+      "description": "The reason the model completion ended, normalized to the caption of the <code>ai_stop_reason_id</code> value. In the case of 'Other', it is the event source's native label, e.g. <code>end_turn</code> or <code>max_tokens</code>.",
       "group": "context",
       "requirement": "optional"
     },
-    "stop_reason_id": {
-      "caption": "AI Stop Reason ID",
-      "description": "The normalized reason the model completion ended - not the reason the event's own subject stopped. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because completion behavior is bound to the configuration that produced it, a shift in this attribute's distribution is more meaningful when weighed against that configuration: <code>ai_model.version</code> for direct model invocations, and <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code> for agent-mediated operations.",
+    "ai_stop_reason_id": {
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>ai_stop_reason</code> to the event source's native label. Because completion behavior is bound to the configuration that produced it, a shift in this attribute's distribution is more meaningful when weighed against that configuration: <code>ai_model.version</code> for direct model invocations, and <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code> for agent-mediated operations.",
       "group": "context",
-      "requirement": "recommended",
-      "enum": {
-        "0": {
-          "caption": "Unknown",
-          "description": "The completion ended without the producer being able to determine why, so the state of the operation at termination is not established."
-        },
-        "1": {
-          "caption": "End of Turn",
-          "description": "The model reached the end of its turn: it completed its response naturally or emitted a configured stop sequence, and is not waiting on anything further."
-        },
-        "2": {
-          "caption": "Token Limit",
-          "description": "The completion was truncated by a token or length limit before the model finished, so the response is incomplete."
-        },
-        "3": {
-          "caption": "Tool Use",
-          "description": "The completion paused to invoke a tool. The turn is not finished; the model expects the tool result and will continue."
-        },
-        "4": {
-          "caption": "Session Stop",
-          "description": "The completion ended because the session or connection carrying it terminated - for example the caller cancelled, the client disconnected, or the transport closed - rather than because the model reached a stopping point. The session state at termination is therefore known, which distinguishes this from <code>Unknown</code> and lets a consumer decide whether the operation needs investigation or can simply be reclaimed."
-        },
-        "99": {
-          "caption": "Other",
-          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains the event source's value."
-        }
-      }
+      "requirement": "recommended"
     }
   }
 }

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -22,6 +22,15 @@
     "message_context": {
       "group": "context",
       "requirement": "optional"
+    },
+    "stop_reason": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "stop_reason_id": {
+      "description": "The normalized reason the model completion ended (natural stop, length limit, tool invocation). Populate on completion events.",
+      "group": "context",
+      "requirement": "recommended"
     }
   }
 }

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -24,13 +24,42 @@
       "requirement": "optional"
     },
     "stop_reason": {
+      "caption": "AI Stop Reason",
+      "description": "The reason the model completion ended, normalized to the caption of the <code>stop_reason_id</code> value. In the case of 'Other', it is the event source's native label, e.g. <code>end_turn</code> or <code>max_tokens</code>.",
       "group": "context",
       "requirement": "optional"
     },
     "stop_reason_id": {
-      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because completion behavior is bound to the configuration that produced it, a shift in this attribute's distribution is more meaningful when weighed against that configuration: <code>ai_model.version</code> for direct model invocations, and <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code> for agent-mediated operations.",
+      "caption": "AI Stop Reason ID",
+      "description": "The normalized reason the model completion ended - not the reason the event's own subject stopped. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because completion behavior is bound to the configuration that produced it, a shift in this attribute's distribution is more meaningful when weighed against that configuration: <code>ai_model.version</code> for direct model invocations, and <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code> for agent-mediated operations.",
       "group": "context",
-      "requirement": "recommended"
+      "requirement": "recommended",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The completion ended without the producer being able to determine why, so the state of the operation at termination is not established."
+        },
+        "1": {
+          "caption": "End of Turn",
+          "description": "The model reached the end of its turn: it completed its response naturally or emitted a configured stop sequence, and is not waiting on anything further."
+        },
+        "2": {
+          "caption": "Token Limit",
+          "description": "The completion was truncated by a token or length limit before the model finished, so the response is incomplete."
+        },
+        "3": {
+          "caption": "Tool Use",
+          "description": "The completion paused to invoke a tool. The turn is not finished; the model expects the tool result and will continue."
+        },
+        "4": {
+          "caption": "Session Stop",
+          "description": "The completion ended because the session or connection carrying it terminated - for example the caller cancelled, the client disconnected, or the transport closed - rather than because the model reached a stopping point. The session state at termination is therefore known, which distinguishes this from <code>Unknown</code> and lets a consumer decide whether the operation needs investigation or can simply be reclaimed."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The stop reason is not mapped. See the <code>stop_reason</code> attribute, which contains the event source's value."
+        }
+      }
     }
   }
 }

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -28,7 +28,7 @@
       "requirement": "optional"
     },
     "stop_reason_id": {
-      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label.",
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because an agent's behavior is bound to its configuration, a shift in this attribute's distribution is more meaningful when weighed against <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code>.",
       "group": "context",
       "requirement": "recommended"
     }

--- a/profiles/ai_operation.json
+++ b/profiles/ai_operation.json
@@ -28,7 +28,7 @@
       "requirement": "optional"
     },
     "stop_reason_id": {
-      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because an agent's behavior is bound to its configuration, a shift in this attribute's distribution is more meaningful when weighed against <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code>.",
+      "description": "The normalized reason the model completion ended. Producers map their runtime's native value into this set. Populate on completion events; when the value is 'Other', set <code>stop_reason</code> to the event source's native label. Because completion behavior is bound to the configuration that produced it, a shift in this attribute's distribution is more meaningful when weighed against that configuration: <code>ai_model.version</code> for direct model invocations, and <code>ai_agent.version</code>, <code>ai_agent.charter</code>, and <code>ai_agent.instance_uid</code> for agent-mediated operations.",
       "group": "context",
       "requirement": "recommended"
     }


### PR DESCRIPTION
#### Related Issue:

Closes #1696

#### Description of changes:

Per the 9 Sep Network+AI call and the 15 Sep general-session review, the stop-reason pair moves off the profile root and into a container object, so agent-related scalars do not proliferate as discrete attributes at the event root and there is exactly one way to express stop reason.

- **`objects/ai_status.json`** (new): `ai_status` container object contributed by the `ai_operation` profile. Seeded with `stop_reason` / `stop_reason_id` carrying the agreed taxonomy (Unknown (0), End of Turn (1), Token Limit (2), Tool Use (3), Session Stop (4), Content Filter (5), Other (99)), plus `permission_result_id`, `compaction_reason_id`, and `subagent_stop_reason_id` placeholders whose taxonomies are still to be defined.
- **`profiles/ai_operation.json`**: adds `ai_status` (optional, `context` group); the former root-level `ai_stop_reason` / `ai_stop_reason_id` attributes are removed.
- **`dictionary.json`**: the `ai_stop_reason` / `ai_stop_reason_id` entries are removed (now defined on the object).
- **`CHANGELOG.md`**: entries updated.

This gives Dave's AI Agent Activity class (#1754) a single object to adopt instead of redefining stop info independently (`ai_agent_stop_info`), per Paul's review.

**Review history:**
- `Session Stop (4)` added per @Aniak5 / @rabbidave.
- `Stop` → `End of Turn`, `Length` → `Token Limit` per @Aniak5.
- Renamed `stop_reason` → `ai_stop_reason` per @davemcatcisco / @Aniak5; then moved into `ai_status` per the 15 Sep review so the profile contributes one object, not root-level pairs.
- `Content Filter (5)` added per discussion.
- `ai_status` container proposed by @davemcatcisco on the 9 Sep Network+AI call to avoid scalar proliferation.
