### PR TITLE
issue-1697: Per-node authority fields for the delegation object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Improved
+* #### Objects
+  1. Added per-node authority attributes `scopes`, `audience`, and `expiration_time` to the `delegation` object, so each hop in the chain of authority records what was granted, for whom, and until when. [#1705](https://github.com/ocsf/ocsf-schema/pull/1705)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added
@@ -121,7 +125,6 @@ Thankyou! -->
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Objects
-  1. Added per-node authority attributes `scopes`, `audience`, and `expiration_time` to the `delegation` object, so each hop in the chain of authority records what was granted, for whom, and until when. [#1705](https://github.com/ocsf/ocsf-schema/pull/1705)
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_triggers` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `type_id` attribute to the `job` object to describe mechanism that executes the job. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ Thankyou! -->
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Objects
+  1. Added per-node authority attributes `scopes`, `audience`, and `expiration_time` to the `delegation` object, so each hop in the chain of authority records what was granted, for whom, and until when. [#1705](https://github.com/ocsf/ocsf-schema/pull/1705)
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_triggers` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `type_id` attribute to the `job` object to describe mechanism that executes the job. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ Thankyou! -->
 * #### Profiles
   1. Added `ai_agent` attribute to the `ai_operation` profile. [#1641](https://github.com/ocsf/ocsf-schema/pull/1641)
 * #### Objects
+  1. Added per-node authority attributes `scopes`, `audience`, and `expiration_time` to the `delegation` object, so each hop in the chain of authority records what was granted, for whom, and until when. [#1705](https://github.com/ocsf/ocsf-schema/pull/1705)
   1. Added `job_actions` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `job_triggers` array of objects to the `job` object. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)
   1. Added `type_id` attribute to the `job` object to describe mechanism that executes the job. [#1597](https://github.com/ocsf/ocsf-schema/pull/1597)

--- a/dictionary.json
+++ b/dictionary.json
@@ -471,6 +471,11 @@
       "description": "The audit user assigned at login by the audit subsystem.",
       "type": "integer_t"
     },
+    "audience": {
+      "caption": "Audience",
+      "description": "The intended audience of a grant or token - the party or resource the authorization is meant to be presented to. See specific usage.",
+      "type": "string_t"
+    },
     "auth_factors": {
       "caption": "Authentication Factors",
       "description": "Describes a category of methods used for identity verification. See specific usage.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -466,15 +466,22 @@
       "description": "The bitmask value that represents the file attributes.",
       "type": "integer_t"
     },
+    "audience": {
+      "caption": "Audience",
+      "description": "The service or resource a grant or token may be exercised against - the relying party that should accept it, and that should reject it if presented elsewhere. See specific usage.",
+      "source": "aud",
+      "type": "string_t",
+      "references": [
+        {
+          "description": "JSON Web Token (JWT) Audience Claim.",
+          "url": "https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3"
+        }
+      ]
+    },
     "auid": {
       "caption": "Audit User ID",
       "description": "The audit user assigned at login by the audit subsystem.",
       "type": "integer_t"
-    },
-    "audience": {
-      "caption": "Audience",
-      "description": "The service or resource a grant or token may be exercised against - the relying party that should accept it, and that should reject it if presented elsewhere. Corresponds to the <code>aud</code> claim in OAuth and JWT. See specific usage.",
-      "type": "string_t"
     },
     "auth_factors": {
       "caption": "Authentication Factors",

--- a/dictionary.json
+++ b/dictionary.json
@@ -473,7 +473,7 @@
     },
     "audience": {
       "caption": "Audience",
-      "description": "The intended audience of a grant or token - the party or resource the authorization is meant to be presented to. See specific usage.",
+      "description": "The service or resource a grant or token may be exercised against - the relying party that should accept it, and that should reject it if presented elsewhere. Corresponds to the <code>aud</code> claim in OAuth and JWT. See specific usage.",
       "type": "string_t"
     },
     "auth_factors": {

--- a/dictionary.json
+++ b/dictionary.json
@@ -488,6 +488,11 @@
       "description": "The audit user assigned at login by the audit subsystem.",
       "type": "integer_t"
     },
+    "audience": {
+      "caption": "Audience",
+      "description": "The intended audience of a grant or token - the party or resource the authorization is meant to be presented to. See specific usage.",
+      "type": "string_t"
+    },
     "auth_factors": {
       "caption": "Authentication Factors",
       "description": "Describes a category of methods used for identity verification. See specific usage.",

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -4,9 +4,17 @@
   "extends": "object",
   "name": "delegation",
   "attributes": {
+    "audience": {
+      "description": "The intended audience of this delegation - the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an issued token).",
+      "requirement": "optional"
+    },
     "created_time": {
       "description": "The time when the delegation was issued by the issuing authority.",
       "requirement": "recommended"
+    },
+    "expiration_time": {
+      "description": "The time when this delegation's granted authority expires. After this time the delegation no longer conveys authority, independent of any revocation.",
+      "requirement": "optional"
     },
     "issuer_uid": {
       "description": "The unique identifier of the trusted issuing authority (e.g., an OAuth authorization server, cloud STS, IAM broker, orchestration gateway, or SDK wrapper) that generated this delegation. Enables verification that delegation IDs were issued by an authorized component rather than self-asserted by the delegate.",
@@ -15,6 +23,10 @@
     "parent_uid": {
       "caption": "Parent Delegation ID",
       "description": "The delegation identifier of the parent delegation, if this delegation was created by re-delegating authority to another party (e.g., a downstream service or automated process). This creates a parent-child relationship that enables tracking the complete chain of delegation ancestry. Does not indicate that the delegate was instantiated or spawned by the parent's delegate; that relationship, if any, is tracked separately.",
+      "requirement": "optional"
+    },
+    "scopes": {
+      "description": "The scopes granted at this delegation node - the specific permissions the delegate is authorized to exercise on the principal's behalf. Comparing a delegation's scopes with its parent's reveals scope attenuation across the chain.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -5,7 +5,7 @@
   "name": "delegation",
   "attributes": {
     "audience": {
-      "description": "The intended audience of this delegation: the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an OAuth or JWT token, typically a URI or service identifier).",
+      "description": "The service or resource this delegation may be exercised against - the relying party that should accept it, and that should reject it if presented anywhere else. This is the <code>aud</code> claim of an issued OAuth or JWT token, typically a URI or service identifier such as <code>https://api.payments.example.com</code>. The issuer populates it at delegation time from the grant it minted, so an issuer that scopes a delegation to a particular relying party already holds the value; issuers that mint unscoped delegations omit it, which is why the attribute is optional. Note this is the party the authority is <em>exercised on</em>, not the party that later reads or audits the record - a delegation restricted to one payments API keeps that restriction on record regardless of who consumes the event afterwards.",
       "requirement": "optional"
     },
     "created_time": {

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -5,7 +5,7 @@
   "name": "delegation",
   "attributes": {
     "audience": {
-      "description": "The intended audience of this delegation - the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an issued token).",
+      "description": "The intended audience of this delegation: the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an OAuth or JWT token, typically a URI or service identifier).",
       "requirement": "optional"
     },
     "created_time": {
@@ -26,7 +26,7 @@
       "requirement": "optional"
     },
     "scopes": {
-      "description": "The scopes granted at this delegation node - the specific permissions the delegate is authorized to exercise on the principal's behalf. Comparing a delegation's scopes with its parent's reveals scope attenuation across the chain.",
+      "description": "The authorization scopes granted at this delegation node, bounding what the delegate is authorized to do on the principal's behalf (e.g., OAuth scope labels). Comparing a delegation's scopes with its parent's scopes reveals scope attenuation across the chain.",
       "requirement": "optional"
     },
     "uid": {

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -21,6 +21,18 @@
     "issuer_uid": {
       "description": "The unique identifier of the trusted issuing authority (e.g., an OAuth authorization server, cloud STS, IAM broker, orchestration gateway, or SDK wrapper) that generated this delegation. Enables verification that delegation IDs were issued by an authorized component rather than self-asserted by the delegate.",
       "requirement": "recommended"
+    },
+    "scopes": {
+      "description": "The scopes granted at this delegation node - the specific permissions the delegate is authorized to exercise on the principal's behalf. Comparing a delegation's scopes with its parent's reveals scope attenuation across the chain.",
+      "requirement": "optional"
+    },
+    "audience": {
+      "description": "The intended audience of this delegation - the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an issued token).",
+      "requirement": "optional"
+    },
+    "expiration_time": {
+      "description": "The time when this delegation's granted authority expires. After this time the delegation no longer conveys authority, independent of any revocation.",
+      "requirement": "optional"
     }
   }
 }

--- a/objects/delegation.json
+++ b/objects/delegation.json
@@ -23,11 +23,11 @@
       "requirement": "recommended"
     },
     "scopes": {
-      "description": "The scopes granted at this delegation node - the specific permissions the delegate is authorized to exercise on the principal's behalf. Comparing a delegation's scopes with its parent's reveals scope attenuation across the chain.",
+      "description": "The authorization scopes granted at this delegation node, bounding what the delegate is authorized to do on the principal's behalf (e.g., OAuth scope labels). Comparing a delegation's scopes with its parent's scopes reveals scope attenuation across the chain.",
       "requirement": "optional"
     },
     "audience": {
-      "description": "The intended audience of this delegation - the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an issued token).",
+      "description": "The intended audience of this delegation: the service, resource, or party the delegated authority is meant to be exercised against (e.g., the <code>aud</code> claim of an OAuth or JWT token, typically a URI or service identifier).",
       "requirement": "optional"
     },
     "expiration_time": {


### PR DESCRIPTION
#1665 has merged; this is rebased on `main` and ready for review.

## Problem

The `delegation` object (#1665) records that authority moved, but not **what** was granted at each node. To reconstruct a chain of authority after the fact — or map runtime enforcement records onto OCSF without dropping their authority content — each hop needs its granted authority.

## Change

Three additive, optional attributes on `delegation`:

- `scopes` *(existing attribute, reused)* — permissions granted at this node; comparing with the parent's reveals scope attenuation across the chain
- `audience` *(new)* — who the delegated authority is meant to be exercised against (e.g. the `aud` claim of an issued token)
- `expiration_time` *(existing attribute, reused)* — when the granted authority lapses

`authorization_details` (RFC 9396) is deliberately **not** included — it is a typed array that needs its own design pass, per the discussion in #1697.

Closes #1697
