### PR TITLE
Added a rule attribute to discovery_details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ Thankyou! -->
   1. Added `App Package (6)` enum value to `algorithm_id` and `App Package (8)` enum value to `serialization_id` in the `digital_signature` object. [#1692](https://github.com/ocsf/ocsf-schema/pull/1692)
   1. Added `serialization` and `serialization_id` to the `fingerprint` object, mirroring `digital_signature`, so a verifier knows the canonical serialization scheme used to produce the fingerprinted byte sequence. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
   1. Added `Flat (1)` enum value to `serialization_id` in the `digital_signature` and `fingerprint` objects for flat hashes or signatures over a raw byte sequence; the later `serialization_id` values shift up by one (`JCS (2)` through `App Package (8)`), keeping the two enums identical. [#1661](https://github.com/ocsf/ocsf-schema/pull/1661)
+  1. Added `rule` attribute to `discovery_details`. [#1706](https://github.com/ocsf-schema/pull/1706)
+  
 * #### Observables
 * #### Platform Extensions
   1. Added `prev_win_service` attribute to Windows Service Activity Class in order to store previous state of the Windows service. [#1663](https://github.com/ocsf/ocsf-schema/pull/1663)

--- a/objects/discovery_details.json
+++ b/objects/discovery_details.json
@@ -1,6 +1,6 @@
 {
   "caption": "Discovery Details",
-  "description": "The Discovery Details object describes results of a discovery task/job.",
+  "description": "The Discovery Details object describes results of a discovery task/job. Each result may be due to the violation of a <code>rule</code> associated with a <code>policy</code> and have multiple <code>occurrences</code>.",
   "extends": "object",
   "name": "discovery_details",
   "attributes": {
@@ -19,6 +19,10 @@
     "occurrences": {
       "description": "Details about where in the target entity, specified information was discovered. Only the attributes, relevant to the target entity type should be populated.",
       "requirement": "optional"
+    },
+    "rule": {
+      "description": "The rule associated with this discovery, usually part of the higher level <code>policy</code> from an enclosing class or object.",
+      "requirement": "recommended"
     },
     "type": {
       "description": "The specific type of information that was discovered. e.g.<code> name, phone_number, etc.</code>",


### PR DESCRIPTION
#### Related Issue: 1635
#### Related PR: 1648 (draft)

#### Description of changes:
Per above issue, a `data_security` object has a single `policy` but doesn't account for what triggered each individual `discovery_details` as part of the object. This PR adds a `rule` attribute to `discovery_details` which itself is of array type in `data_security`. In this way, an overarching policy can be composed of multiple rules, and each discovery is directly associated to its rule.

This approach is a simpler solution to the problem in Issue #135 than the draft PR.