### PR TITLE
pre-req for #1707, updating metaschema for deprecated attr

### DIFF
--- a/metaschema/deprecated.schema.json
+++ b/metaschema/deprecated.schema.json
@@ -25,7 +25,6 @@
   },
   "required": [
     "message",
-    "since",
-    "superseded_by"
+    "since"
   ]
 }

--- a/metaschema/deprecated.schema.json
+++ b/metaschema/deprecated.schema.json
@@ -13,10 +13,19 @@
     "since": {
       "description": "The version after which this attribute or object is deprecated.",
       "$ref": "semver.schema.json"
+    },
+    "superseded_by": {
+      "description": "The attribute(s), object(s), class(es), or enum value(s) that supersede this deprecated item. Each entry is a reference to a replacement: a dictionary or sibling attribute name (e.g. \"application\"), a dotted attribute path into another object or class (e.g. \"cpu_info_list[*].cores\"), a class or object name, or an enum value key. Use an empty array when the item is removed with no replacement.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   },
   "required": [
     "message",
-    "since"
+    "since",
+    "superseded_by"
   ]
 }


### PR DESCRIPTION
#### Related Issue: 

This is a pre-req for #1707 

#### Description of changes

1. Metaschema (metaschema/deprecated.schema.json)
> Adds superseded_by: an array of strings, each naming a replacement.
    Makes it required (in 1707, optional for now) alongside message and since. An empty array [] explicitly states the item is removed with no replacement (no entry in the current schema needs this).
    
Changelog updates will be rolled up in #1707
