### PR TITLE
[Post Release] Version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="ocsf.png" alt="OCSF Logo" width="32"/> Open Cybersecurity Schema Framework
 
-[![Version](https://img.shields.io/badge/version-1.9.0-blue.svg)](version.json)
+[![Version](https://img.shields.io/badge/version-1.10.0--dev-blue.svg)](version.json)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 [![Schema Browser](https://img.shields.io/badge/schema-browser-orange.svg)](https://schema.ocsf.io)
 

--- a/extensions/linux/extension.json
+++ b/extensions/linux/extension.json
@@ -3,5 +3,5 @@
   "caption": "Linux",
   "description": "The Linux extension defines Linux specific attributes, profiles, objects, and classes.",
   "name": "linux",
-  "version": "1.9.0"
+  "version": "1.10.0-dev"
 }

--- a/extensions/macos/extension.json
+++ b/extensions/macos/extension.json
@@ -3,5 +3,5 @@
   "caption": "macOS",
   "description": "The macOS extension defines macOS specific attributes, profiles, objects, and classes.",
   "name": "macos",
-  "version": "1.9.0"
+  "version": "1.10.0-dev"
 }

--- a/extensions/windows/extension.json
+++ b/extensions/windows/extension.json
@@ -3,5 +3,5 @@
   "caption": "Windows",
   "description": "The Windows extension defines Windows specific attributes, objects, and classes.",
   "name": "win",
-  "version": "1.9.0"
+  "version": "1.10.0-dev"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "1.9.0"
+  "version": "1.10.0-dev"
 }


### PR DESCRIPTION
#### Related Issue: n/a

#### Description of changes:

Version bump to `v1.10.0-dev` across all version files. 

---

@ocsf/ocsf-maintainers Maybe a topic to consider for the next release - do platform extensions need their own version? I am leaning towards a no
