### PR TITLE
feat(schema): Add likelihood enum to detection findings and labels to node/edge objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,15 +45,15 @@ Thankyou! -->
 
 ### Added
 * #### Dictionary Attributes
-  1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
-  1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99), aligned with the NIST SP 800-30 Rev. 1 qualitative likelihood scale. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+  1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99), aligned with the NIST SP 800-30 Rev. 1 qualitative likelihood scale. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 
 ### Improved
 * #### Event Classes
-  1. Added `likelihood` and `likelihood_id` as optional attributes in the `context` group on `Detection Finding` (class 2004). [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+  1. Added `likelihood` and `likelihood_id` as optional attributes in the `context` group on `Detection Finding` (class 2004). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 * #### Objects
-  1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
-  1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+  1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ Thankyou! -->
 ### Added
 * #### Dictionary Attributes
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
-  1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99), aligned with the NIST SP 800-30 Rev. 1 qualitative likelihood scale. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 
 ### Improved
 * #### Event Classes
-  1. Added `likelihood` and `likelihood_id` as optional attributes in the `context` group on `Detection Finding` (class 2004). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `likelihood`, `likelihood_id`, and `likelihood_score` as optional attributes in the `context` group on `Detection Finding` (class 2004). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
 * #### Objects
   1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+  1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99), aligned with the NIST SP 800-30 Rev. 1 qualitative likelihood scale. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+
+### Improved
+* #### Event Classes
+  1. Added `likelihood` and `likelihood_id` as optional attributes in the `context` group on `Detection Finding` (class 2004). [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+* #### Objects
+  1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+  1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#0000](https://github.com/ocsf/ocsf-schema/pull/0000)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added

--- a/dictionary.json
+++ b/dictionary.json
@@ -4221,8 +4221,9 @@
     },
     "likelihood_id": {
       "caption": "Likelihood ID",
-      "description": "The normalized likelihood of the finding. Per NIST SP 800-30 Rev. 1, this is a weighted factor based on a subjective analysis of the probability that a given threat source is capable of exploiting a given vulnerability or set of vulnerabilities, or of successfully carrying out a threat event.",
+      "description": "The normalized likelihood of the finding, representing a subjective assessment of the probability that the reported threat activity will occur or succeed.",
       "sibling": "likelihood",
+      "source": "likelihood of occurrence",
       "type": "integer_t",
       "enum": {
         "0": {
@@ -4231,23 +4232,23 @@
         },
         "1": {
           "caption": "Very Low",
-          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is very low."
+          "description": "The probability that the reported threat activity will occur or succeed is very low."
         },
         "2": {
           "caption": "Low",
-          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is low."
+          "description": "The probability that the reported threat activity will occur or succeed is low."
         },
         "3": {
           "caption": "Moderate",
-          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is moderate."
+          "description": "The probability that the reported threat activity will occur or succeed is moderate."
         },
         "4": {
           "caption": "High",
-          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is high."
+          "description": "The probability that the reported threat activity will occur or succeed is high."
         },
         "5": {
           "caption": "Very High",
-          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is very high."
+          "description": "The probability that the reported threat activity will occur or succeed is very high."
         },
         "99": {
           "caption": "Other",
@@ -4264,6 +4265,11 @@
           "url": "https://csrc.nist.gov/glossary/term/likelihood"
         }
       ]
+    },
+    "likelihood_score": {
+      "caption": "Likelihood Score",
+      "description": "The likelihood score as reported by the event source.",
+      "type": "integer_t"
     },
     "lineage": {
       "caption": "Lineage",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4214,6 +4214,57 @@
       "description": "The URL pointing to the license applied on package or software. This is typically a <code>LICENSE.md</code> file within a repository.",
       "type": "url_t"
     },
+    "likelihood": {
+      "caption": "Likelihood",
+      "description": "The likelihood, normalized to the caption of the <code>likelihood_id</code> value. In the case of 'Other', it is defined by the event source.",
+      "type": "string_t"
+    },
+    "likelihood_id": {
+      "caption": "Likelihood ID",
+      "description": "The normalized likelihood of the finding. Per NIST, this is a weighted factor based on a subjective analysis of the probability that a given threat is capable of exploiting a given vulnerability or a set of vulnerabilities.",
+      "sibling": "likelihood",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The normalized likelihood is unknown."
+        },
+        "1": {
+          "caption": "Very Low",
+          "description": "The probability of the threat exploiting the vulnerability is very low."
+        },
+        "2": {
+          "caption": "Low",
+          "description": "The probability of the threat exploiting the vulnerability is low."
+        },
+        "3": {
+          "caption": "Moderate",
+          "description": "The probability of the threat exploiting the vulnerability is moderate."
+        },
+        "4": {
+          "caption": "High",
+          "description": "The probability of the threat exploiting the vulnerability is high."
+        },
+        "5": {
+          "caption": "Very High",
+          "description": "The probability of the threat exploiting the vulnerability is very high."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The likelihood is not mapped to the defined enum values. See the <code>likelihood</code> attribute, which contains a data source specific value."
+        }
+      },
+      "references": [
+        {
+          "description": "NIST SP 800-30 Rev. 1, Guide for Conducting Risk Assessments",
+          "url": "https://doi.org/10.6028/NIST.SP.800-30r1"
+        },
+        {
+          "description": "NIST Computer Security Resource Center",
+          "url": "https://csrc.nist.gov/glossary/term/likelihood"
+        }
+      ]
+    },
     "lineage": {
       "caption": "Lineage",
       "description": "The lineage of the process, represented by a list of paths for each ancestor process. For example: <code>['/usr/sbin/sshd', '/usr/bin/bash', '/usr/bin/whoami']</code>.",

--- a/dictionary.json
+++ b/dictionary.json
@@ -4221,7 +4221,7 @@
     },
     "likelihood_id": {
       "caption": "Likelihood ID",
-      "description": "The normalized likelihood of the finding. Per NIST, this is a weighted factor based on a subjective analysis of the probability that a given threat is capable of exploiting a given vulnerability or a set of vulnerabilities.",
+      "description": "The normalized likelihood of the finding. Per NIST SP 800-30 Rev. 1, this is a weighted factor based on a subjective analysis of the probability that a given threat source is capable of exploiting a given vulnerability or set of vulnerabilities, or of successfully carrying out a threat event.",
       "sibling": "likelihood",
       "type": "integer_t",
       "enum": {
@@ -4231,23 +4231,23 @@
         },
         "1": {
           "caption": "Very Low",
-          "description": "The probability of the threat exploiting the vulnerability is very low."
+          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is very low."
         },
         "2": {
           "caption": "Low",
-          "description": "The probability of the threat exploiting the vulnerability is low."
+          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is low."
         },
         "3": {
           "caption": "Moderate",
-          "description": "The probability of the threat exploiting the vulnerability is moderate."
+          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is moderate."
         },
         "4": {
           "caption": "High",
-          "description": "The probability of the threat exploiting the vulnerability is high."
+          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is high."
         },
         "5": {
           "caption": "Very High",
-          "description": "The probability of the threat exploiting the vulnerability is very high."
+          "description": "The probability of the threat source exploiting a vulnerability or carrying out a threat event is very high."
         },
         "99": {
           "caption": "Other",

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -59,6 +59,10 @@
       "group": "context",
       "requirement": "optional"
     },
+    "likelihood_score": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "malware": {
       "description": "Describes malware reported in a Detection Finding.",
       "group": "context",

--- a/events/findings/detection_finding.json
+++ b/events/findings/detection_finding.json
@@ -51,6 +51,14 @@
       "requirement": "recommended",
       "profile": null
     },
+    "likelihood": {
+      "group": "context",
+      "requirement": "optional"
+    },
+    "likelihood_id": {
+      "group": "context",
+      "requirement": "optional"
+    },
     "malware": {
       "description": "Describes malware reported in a Detection Finding.",
       "group": "context",

--- a/objects/edge.json
+++ b/objects/edge.json
@@ -12,6 +12,10 @@
       "description": "Indicates whether the edge is (<code>true</code>) or undirected (<code>false</code>).",
       "requirement": "optional"
     },
+    "labels": {
+      "description": "The list of labels attached to this edge. Labels can be used to categorize, filter, and group edges within a graph.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "The human-readable name or label for the edge.",
       "requirement": "recommended"

--- a/objects/node.json
+++ b/objects/node.json
@@ -12,6 +12,10 @@
       "description": "A human-readable description of the node's purpose or meaning in the graph.",
       "requirement": "optional"
     },
+    "labels": {
+      "description": "The list of labels attached to this node. Labels can be used to categorize, filter, and group nodes within a graph.",
+      "requirement": "optional"
+    },
     "name": {
       "description": "A human-readable name or label for the node. Should be descriptive and unique within the graph context.",
       "requirement": "recommended"


### PR DESCRIPTION
#### Related Issue:
N/A - New feature proposal

#### Description of changes:
This PR adds a normalized `likelihood` measure to findings and `labels` to the graph `node`/`edge` objects.

**`likelihood` / `likelihood_id` / `likelihood_score`** capture the normalized probability that the reported threat activity will occur or succeed. This complements the existing `impact`/`impact_id`/`impact_score`, `confidence`/`confidence_id`/`confidence_score`, and `risk_score` measures on findings. The `likelihood_id` enum uses Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99), with `likelihood` as the string sibling and `likelihood_score` as the integer score.

Per reviewer feedback, the `likelihood_id` description and its enum values are worded in vendor- and standard-agnostic terms; the NIST attribution is carried by the `source` metadata directive (`likelihood of occurrence`) and the `references` array rather than inline in the description.

**`labels`** on `node` and `edge` allow grouping graph elements into named subgraphs (for example, categorizing or filtering nodes and edges within a graph). `labels` is an existing core dictionary attribute, so this reuses it on the two graph objects.

**New Dictionary Attributes:**

| Attribute | Type | Description |
|-----------|------|-------------|
| `likelihood` | `string_t` | The likelihood, normalized to the caption of `likelihood_id`. |
| `likelihood_id` | `integer_t` (enum) | The normalized likelihood of the finding (Unknown/Very Low/Low/Moderate/High/Very High/Other). |
| `likelihood_score` | `integer_t` | The likelihood score as reported by the event source. |

**Modified Event Classes:**

| Class | Change |
|-------|--------|
| `detection_finding` (Detection Finding, 2004) | Added `likelihood`, `likelihood_id`, and `likelihood_score` as optional attributes in the `context` group. |

**Modified Objects:**

| Object | Change |
|--------|--------|
| `node` | Added optional `labels` attribute. |
| `edge` | Added optional `labels` attribute. |

**Design notes:**
- `likelihood_id` mirrors the `impact_id`/`confidence_id` sibling+enum convention already used on findings, and `likelihood_score` mirrors the `impact_score`/`confidence_score`/`risk_score` integer-score convention.
- The enum is a probability scale (Very Low → Very High); it intentionally has no "Critical" level, since likelihood measures probability rather than magnitude of harm.
- The `likelihood_id` description and enum values are kept vendor- and standard-agnostic. The `source` directive (`likelihood of occurrence`) plus the `references` array (NIST SP 800-30 Rev. 1 and the NIST CSRC glossary) carry the standard attribution instead of embedding it in the description.

---

#### Detection Finding — `likelihood` / `likelihood_id` / `likelihood_score`
<img width="1512" height="857" alt="detection_finding" src="https://github.com/user-attachments/assets/c0605303-630a-45ad-b01e-f1a67aaf0ca8" />

#### Dictionary — `likelihood_id` / `likelihood_score`
<img width="1512" height="790" alt="dictionary" src="https://github.com/user-attachments/assets/42f889a9-855b-4479-9551-96137edd03aa" />

#### Node — `labels`
<img width="1509" height="858" alt="node" src="https://github.com/user-attachments/assets/8860944a-0a6d-43ed-9feb-97542385c736" />

#### Edge — `labels`
<img width="1509" height="858" alt="edge" src="https://github.com/user-attachments/assets/33854896-b0fe-40ea-bce8-2abffbc68e9e" />

### Checklist:
- [x] Added entries to `Unreleased` section in CHANGELOG.md
- [x] Followed contribution guidelines
- [x] Ran local ocsf-server instance - no errors or warnings
- [x] PR title matches description
