### PR TITLE
Add icmp_type, icmp_code and icmp_uid to network_connection_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `icmp_type`, `icmp_code` and `icmp_uid` attributes to the `network_connection_info` object. [#1719](https://github.com/ocsf/ocsf-schema/pull/1719)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
-  1. Added `icmp_type`, `icmp_code` and `icmp_uid` attributes to the `network_connection_info` object. [#1719](https://github.com/ocsf/ocsf-schema/pull/1719)
+  1. Added `icmp_type`, `icmp_code` and `icmp_uid` attributes. [#1719](https://github.com/ocsf/ocsf-schema/pull/1719)
 
 ### Improved
 * #### Event Classes
@@ -56,6 +56,7 @@ Thankyou! -->
 * #### Objects
   1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `icmp_type`, `icmp_code` and `icmp_uid` to the `network_connection_info` object. [#1719](https://github.com/ocsf/ocsf-schema/pull/1719)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -3427,6 +3427,33 @@
       "description": "The Integrated Circuit Card Identification of a mobile device. Typically it is a unique 18 to 22 digit number that identifies a SIM card.",
       "type": "string_t"
     },
+    "icmp_code": {
+      "caption": "ICMP Code",
+      "description": "The control message code, which qualifies <code>icmp_type</code>. Applies to both ICMP and ICMPv6, as defined by the Internet Assigned Numbers Authority (IANA).",
+      "type": "integer_t",
+      "references": [
+        {
+          "description": "IANA ICMP Type Numbers",
+          "url": "https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml"
+        }
+      ]
+    },
+    "icmp_type": {
+      "caption": "ICMP Type",
+      "description": "The control message type. Applies to both ICMP and ICMPv6, as defined by the Internet Assigned Numbers Authority (IANA). For example: <code>8</code> for an Echo Request.",
+      "type": "integer_t",
+      "references": [
+        {
+          "description": "IANA ICMP Type Numbers",
+          "url": "https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml"
+        }
+      ]
+    },
+    "icmp_uid": {
+      "caption": "ICMP Identifier",
+      "description": "The identifier carried in an Echo Request and repeated in the matching Echo Reply, used to correlate the two messages.",
+      "type": "integer_t"
+    },
     "identifier_cookie": {
       "caption": "Identifier Cookie",
       "description": "The client identifier cookie during client/server exchange.",

--- a/objects/network_connection_info.json
+++ b/objects/network_connection_info.json
@@ -22,6 +22,15 @@
     "flag_history": {
       "requirement": "optional"
     },
+    "icmp_code": {
+      "requirement": "optional"
+    },
+    "icmp_type": {
+      "requirement": "optional"
+    },
+    "icmp_uid": {
+      "requirement": "optional"
+    },
     "protocol_name": {
       "caption": "Protocol Name",
       "description": "The IP protocol name in lowercase, as defined by the Internet Assigned Numbers Authority (IANA). For example: <code>tcp</code> or <code>udp</code>.",


### PR DESCRIPTION
#### Related Issue:
Closes #1716

#### Description of changes:

Adds three optional attributes to the `network_connection_info` object so that ICMP and ICMPv6 events can be represented beyond `protocol_num: 1`.

| attribute | type | requirement |
|---|---|---|
| `icmp_type` | `integer_t` | optional |
| `icmp_code` | `integer_t` | optional |
| `icmp_uid` | `integer_t` | optional |

Three matching entries are added to `dictionary.json`. IANA is cited by name in the descriptions, with the URL in a `references` array, per the caption and description style guide.

No class changes are required, since `connection_info` is already present on every Network Activity class. These sit alongside the existing `tcp_flags` and `flag_history`, which set the precedent for protocol specific detail on this object.

Sample event and full rationale are in #1716. In short, an inbound Echo Request and an outbound traceroute are currently indistinguishable in OCSF, and `icmp_uid` is what pairs a request with its reply, which is how ICMP tunnelling is detected.

Files touched: `dictionary.json`, `objects/network_connection_info.json`, `CHANGELOG.md`.

#### Confirmations

1. `Unreleased` entry added to `CHANGELOG.md`.
2. Contribution guidelines followed. Attribute names are lower case with underscores, no abbreviations beyond the well accepted `icmp` and `uid`.
3. Validated locally:
   - `python -m ocsf_validator .` passes
   - `ocsf-schema-compiler .` compiles with zero errors and zero warnings, in both default and browser mode
   - `python -m ocsf.validate.compatibility` against `main` passes all five checks, including no removed elements, no increased requirements and no added required attributes
   - `cspell` with the repository config reports no unknown words
   - a local `ocsf-server` built from `ocsf/ocsf-server` boots against the compiled schema, serves HTTP 200 and produces zero log output
4. PR title matches the description.
5. Captions and descriptions follow the normative and neutral style. No authoritative URLs in descriptions, no trademark marks, no company or product names.
