### PR TITLE
Add log_facility and log_facility_id to the metadata object

### DIFF
--- a/.github/.project-words.txt
+++ b/.github/.project-words.txt
@@ -12,6 +12,7 @@ ASTM
 Auditd
 auid
 Authenticode
+authpriv
 Backint
 BADALG
 BADCOOKIE
@@ -209,6 +210,7 @@ Unsynchronized
 unsynchronized
 UPDATEREDIRECTREF
 utun
+uucp
 Verkada
 VERSIONINFO
 VHASH

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `log_facility` and `log_facility_id` attributes to the `metadata` object. [#1720](https://github.com/ocsf/ocsf-schema/pull/1720)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added

--- a/dictionary.json
+++ b/dictionary.json
@@ -4327,7 +4327,7 @@
     },
     "log_facility_id": {
       "caption": "Log Facility ID",
-      "description": "The facility that generated the message, as defined for the syslog protocol in RFC 5424. The facility identifies the originating subsystem independently of severity, so it is not recoverable from <code>severity_id</code>. Note that there is no <code>Unknown</code> value, because <code>0</code> is the kernel facility.",
+      "description": "The facility of the source syslog message, identifying the originating subsystem that generated it. The facility is independent of severity and is not recoverable from <code>severity_id</code>. A relay may rewrite or regenerate a message, so this reflects the source (original) facility rather than a value guaranteed to be stable across hops, and it should be populated only when the source is syslog or an equivalent facility mapping is unambiguous. There is no <code>Unknown</code> value: <code>0</code> is the kernel (<code>kern</code>) facility, so an absent or malformed PRI must not be mapped to <code>0</code>; use <code>99</code> (Other) for a known nonstandard or source-defined facility.",
       "sibling": "log_facility",
       "type": "integer_t",
       "enum": {
@@ -4388,12 +4388,12 @@
           "description": "Log audit."
         },
         "14": {
-          "caption": "alert",
-          "description": "Log alert."
+          "caption": "console",
+          "description": "Console messages, per the RFC 5427 SyslogFacility mapping. RFC 5424 Table 1 lists facility 14 as 'log alert'."
         },
         "15": {
-          "caption": "clock",
-          "description": "Clock daemon, distinguished from facility 9 by convention."
+          "caption": "cron2",
+          "description": "A second cron or clock daemon facility used by some systems such as Solaris, distinct from facility 9, per the RFC 5427 SyslogFacility mapping. RFC 5424 Table 1 lists facility 15 as 'clock daemon'."
         },
         "16": {
           "caption": "local0",
@@ -4434,8 +4434,12 @@
       },
       "references": [
         {
-          "description": "RFC 5424, Section 6.2.1, Syslog Message Facility",
+          "description": "RFC 5424, Section 6.2.1, Syslog Message Facility (numeric facility range)",
           "url": "https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1"
+        },
+        {
+          "description": "RFC 5427, SyslogFacility textual convention (canonical facility label-to-code mapping)",
+          "url": "https://datatracker.ietf.org/doc/html/rfc5427"
         }
       ],
       "suppress_checks": [

--- a/dictionary.json
+++ b/dictionary.json
@@ -4263,6 +4263,128 @@
       "type": "location",
       "is_array": true
     },
+    "log_facility": {
+      "caption": "Log Facility",
+      "description": "The normalized caption of <code>log_facility_id</code>.",
+      "type": "string_t"
+    },
+    "log_facility_id": {
+      "caption": "Log Facility ID",
+      "description": "The facility that generated the message, as defined for the syslog protocol in RFC 5424. The facility identifies the originating subsystem independently of severity, so it is not recoverable from <code>severity_id</code>. Note that there is no <code>Unknown</code> value, because <code>0</code> is the kernel facility.",
+      "sibling": "log_facility",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "kern",
+          "description": "Kernel messages."
+        },
+        "1": {
+          "caption": "user",
+          "description": "User-level messages."
+        },
+        "2": {
+          "caption": "mail",
+          "description": "Mail system."
+        },
+        "3": {
+          "caption": "daemon",
+          "description": "System daemons."
+        },
+        "4": {
+          "caption": "auth",
+          "description": "Security and authorization messages."
+        },
+        "5": {
+          "caption": "syslog",
+          "description": "Messages generated internally by the syslog process."
+        },
+        "6": {
+          "caption": "lpr",
+          "description": "Line printer subsystem."
+        },
+        "7": {
+          "caption": "news",
+          "description": "Network news subsystem."
+        },
+        "8": {
+          "caption": "uucp",
+          "description": "UUCP subsystem."
+        },
+        "9": {
+          "caption": "cron",
+          "description": "Clock daemon."
+        },
+        "10": {
+          "caption": "authpriv",
+          "description": "Security and authorization messages, distinguished from facility 4 by convention and conventionally reserved for privileged access."
+        },
+        "11": {
+          "caption": "ftp",
+          "description": "FTP daemon."
+        },
+        "12": {
+          "caption": "ntp",
+          "description": "NTP subsystem."
+        },
+        "13": {
+          "caption": "audit",
+          "description": "Log audit."
+        },
+        "14": {
+          "caption": "alert",
+          "description": "Log alert."
+        },
+        "15": {
+          "caption": "clock",
+          "description": "Clock daemon, distinguished from facility 9 by convention."
+        },
+        "16": {
+          "caption": "local0",
+          "description": "Local use 0."
+        },
+        "17": {
+          "caption": "local1",
+          "description": "Local use 1."
+        },
+        "18": {
+          "caption": "local2",
+          "description": "Local use 2."
+        },
+        "19": {
+          "caption": "local3",
+          "description": "Local use 3."
+        },
+        "20": {
+          "caption": "local4",
+          "description": "Local use 4."
+        },
+        "21": {
+          "caption": "local5",
+          "description": "Local use 5."
+        },
+        "22": {
+          "caption": "local6",
+          "description": "Local use 6."
+        },
+        "23": {
+          "caption": "local7",
+          "description": "Local use 7."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The facility is not mapped. See the <code>log_facility</code> attribute, which contains a data source specific value."
+        }
+      },
+      "references": [
+        {
+          "description": "RFC 5424, Section 6.2.1, Syslog Message Facility",
+          "url": "https://datatracker.ietf.org/doc/html/rfc5424#section-6.2.1"
+        }
+      ],
+      "suppress_checks": [
+        "enum_convention"
+      ]
+    },
     "log_format": {
       "caption": "Log Format",
       "description": "The format of data in the log. See specific usage.",

--- a/objects/metadata.json
+++ b/objects/metadata.json
@@ -32,6 +32,12 @@
       "description": "The list of labels attached to the event. For example: <code>[\"sample\", \"dev\"]</code>",
       "requirement": "optional"
     },
+    "log_facility": {
+      "requirement": "optional"
+    },
+    "log_facility_id": {
+      "requirement": "optional"
+    },
     "log_format": {
       "caption": "Log Source Format",
       "description": "The format of data in the log where the data originated. For example CSV, XML, Windows Multiline, JSON, syslog or Cisco Log Schema.",


### PR DESCRIPTION
#### Related Issue:
Closes #1717

#### Description of changes:

Adds two optional attributes to the `metadata` object so that the syslog facility survives normalization.

| attribute | type | requirement |
|---|---|---|
| `log_facility` | `string_t` | optional |
| `log_facility_id` | `integer_t` | optional |

Both are added to `dictionary.json`. `log_facility_id` carries the enum of the 24 RFC 5424 facility codes plus `99 Other`, with `log_facility` as its sibling, matching the convention used elsewhere in the schema. RFC 5424 is cited by name in the description, with the URL in a `references` array.

The names follow the existing `log_*` family already on `metadata`: `log_name`, `log_level`, `log_provider`, `log_version`, `log_format`, `log_source`.

Sample event and full rationale are in #1717. In short, a syslog PRI of `<188>` decomposes to facility 23 and severity 4. The severity half survives as `severity_id`, the facility half is currently discarded, and `auth` at severity 4 versus `cron` at severity 4 are very different events.

One deliberate choice worth flagging for review: `suppress_checks: ["enum_convention"]` is set, because RFC 5424 facility `0` is `kern`, a real value rather than `Unknown`. If the group prefers to shift the codes to preserve the convention instead, I am happy to change it, but that would break the direct mapping to the RFC.

Files touched: `dictionary.json`, `objects/metadata.json`, `.github/.project-words.txt`, `CHANGELOG.md`.

The wordlist change adds `authpriv` and `uucp`, which are RFC 5424 facility names not present in the cspell dictionaries.

#### On the enum captions

RFC 5424 Table 1 reuses the same description twice. Codes 4 and 10 are both "security/authorization messages", and codes 9 and 15 are both "clock daemon". Using the RFC wording directly as captions would therefore produce duplicate captions, and `log_facility` is a sibling string that has to resolve back to a single id.

So the captions are the unique keywords syslog implementations actually emit (`kern`, `auth`, `authpriv`, `cron`, `audit`, `alert`, `clock`, `local0` through `local7`), and every one of the 25 enum values carries a `description` holding the RFC wording. That keeps the sibling round-trippable without losing the spec text. Happy to switch to the literal RFC strings if the group would rather accept the duplicates.

#### Confirmations

1. `Unreleased` entry added to `CHANGELOG.md`.
2. Contribution guidelines followed.
3. Validated locally:
   - `python -m ocsf_validator .` passes
   - `ocsf-schema-compiler .` compiles with zero errors and zero warnings, in both default and browser mode
   - `python -m ocsf.validate.compatibility` against `main` passes all five checks
   - `cspell` with the repository config reports no unknown words
   - a local `ocsf-server` boots against the compiled schema, serves HTTP 200 and produces zero log output
4. PR title matches the description.
5. Captions and descriptions follow the normative and neutral style.

