### PR TITLE
Add the wifi object and reference it from network_endpoint and device

### DIFF
--- a/.github/.project-words.txt
+++ b/.github/.project-words.txt
@@ -24,11 +24,14 @@ BADVERS
 BINDACK
 bitness
 Bootkit
+BSSID
+bssid
 bytestring
 CAASM
 callsign
 CASB
 CBOR
+CCMP
 CDMA
 cdxgen
 CHECKIN
@@ -84,6 +87,7 @@ execve
 Flexera
 Forcepoint
 forwardability
+GCMP
 geohash
 Geohashing
 geolocation
@@ -119,6 +123,7 @@ memoizee
 metaschema
 Metaschema
 metaschemas
+milliwatts
 minifilter
 MISP
 MKACTIVITY
@@ -193,6 +198,7 @@ teardowns
 Tenzir
 timespan
 TKEY
+TKIP
 TLSH
 TOTP
 totp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Objects
+  1. Added the `wifi` object describing IEEE 802.11 network identity, radio and security attributes. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
+  1. Added the `wifi` attribute to the `network_endpoint` and `device` objects. Resolves #1463. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,11 @@ Thankyou! -->
 ### Added
 * #### Objects
   1. Added the `wifi` object describing IEEE 802.11 network identity, radio and security attributes. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
-  1. Added the `wifi` attribute to the `network_endpoint` and `device` objects. Resolves #1463. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
 * #### Dictionary Attributes
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added the `wifi` attribute referencing the `wifi` object. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
 
 ### Improved
 * #### Event Classes
@@ -58,6 +58,7 @@ Thankyou! -->
 * #### Objects
   1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `wifi` to the `network_endpoint` and `device` objects. Resolves #1463. [#1721](https://github.com/ocsf/ocsf-schema/pull/1721)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -340,6 +340,43 @@
       "type": "dns_answer",
       "is_array": true
     },
+    "ap_status": {
+      "caption": "Access Point Status",
+      "description": "The normalized caption of <code>ap_status_id</code>.",
+      "type": "string_t"
+    },
+    "ap_status_id": {
+      "caption": "Access Point Status ID",
+      "description": "The classification assigned to an observed access point by a wireless intrusion detection or prevention system.",
+      "sibling": "ap_status",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The classification is unknown."
+        },
+        "1": {
+          "caption": "Authorized",
+          "description": "The access point is a known, sanctioned device."
+        },
+        "2": {
+          "caption": "Unclassified",
+          "description": "The access point has been observed but not yet classified."
+        },
+        "3": {
+          "caption": "Rogue",
+          "description": "The access point is unsanctioned and is treated as a threat."
+        },
+        "4": {
+          "caption": "Suppressed",
+          "description": "The access point is being actively contained."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The classification is not mapped."
+        }
+      }
+    },
     "api": {
       "caption": "API Details",
       "description": "Describes details about a typical API (Application Programming Interface) call.",
@@ -597,6 +634,39 @@
       "description": "The average time span of an activity.",
       "type": "timespan"
     },
+    "band": {
+      "caption": "Band",
+      "description": "The normalized caption of <code>band_id</code>.",
+      "type": "string_t"
+    },
+    "band_id": {
+      "caption": "Band ID",
+      "description": "The radio frequency band that a wireless link operates in.",
+      "sibling": "band",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The frequency band is unknown."
+        },
+        "1": {
+          "caption": "2.4 GHz"
+        },
+        "2": {
+          "caption": "5 GHz"
+        },
+        "3": {
+          "caption": "6 GHz"
+        },
+        "4": {
+          "caption": "60 GHz"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The frequency band is not mapped."
+        }
+      }
+    },
     "banner": {
       "caption": "Protocol Banner",
       "description": "The initial connection response that a messaging server receives after it connects to an email server.",
@@ -747,6 +817,11 @@
           "description": "The boundary is not mapped. See the <code>boundary</code> attribute, which contains a data source specific value."
         }
       }
+    },
+    "bssid": {
+      "caption": "BSSID",
+      "description": "The Basic Service Set Identifier, the address of the access point radio that serves a wireless network.",
+      "type": "mac_t"
     },
     "build": {
       "caption": "OS Build",
@@ -1187,6 +1262,11 @@
       "caption": "Chain ID",
       "description": "Identifier of an append-only chain, such as a forensic or audit log, that groups a sequence of attested events for independent verification. Stable for the lifetime of the chain.",
       "type": "string_t"
+    },
+    "channel": {
+      "caption": "Channel",
+      "description": "The channel number in use. See specific usage.",
+      "type": "integer_t"
     },
     "charter": {
       "caption": "Charter",
@@ -2024,6 +2104,11 @@
           "description": "The data lifecycle state is not mapped. See the <code>data_lifecycle_state</code> attribute, which contains a data source specific value."
         }
       }
+    },
+    "data_rate": {
+      "caption": "Data Rate",
+      "description": "The negotiated physical layer data rate, in megabits per second.",
+      "type": "integer_t"
     },
     "data_security": {
       "caption": "Data Security",
@@ -3807,6 +3892,11 @@
       "description": "Indicates whether synchronization with an on-premises directory service is enabled. For example, Microsoft Entra Connect.",
       "type": "boolean_t"
     },
+    "is_on_wired_network": {
+      "caption": "On Wired Network",
+      "description": "Indicates that the observed access point was also detected bridged onto the wired network, which distinguishes an adjacent network from one attached to the monitored infrastructure.",
+      "type": "boolean_t"
+    },
     "is_personal": {
       "caption": "Personal Device",
       "description": "The event occurred on a personal device.",
@@ -4658,6 +4748,11 @@
       "description": "The list of node objects that are part of the graph.",
       "type": "node",
       "is_array": true
+    },
+    "noise_floor": {
+      "caption": "Noise Floor",
+      "description": "The measured background noise power, in decibel-milliwatts.",
+      "type": "integer_t"
     },
     "notes": {
       "caption": "Notes",
@@ -6350,6 +6445,52 @@
         }
       }
     },
+    "security_protocol": {
+      "caption": "Security Protocol",
+      "description": "The normalized caption of <code>security_protocol_id</code>.",
+      "type": "string_t"
+    },
+    "security_protocol_id": {
+      "caption": "Security Protocol ID",
+      "description": "The authentication and key management suite that protects a wireless link.",
+      "sibling": "security_protocol",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The security protocol is unknown."
+        },
+        "1": {
+          "caption": "Open",
+          "description": "The wireless network is unauthenticated and unencrypted."
+        },
+        "2": {
+          "caption": "WEP"
+        },
+        "3": {
+          "caption": "WPA"
+        },
+        "4": {
+          "caption": "WPA2-Personal"
+        },
+        "5": {
+          "caption": "WPA2-Enterprise"
+        },
+        "6": {
+          "caption": "WPA3-Personal"
+        },
+        "7": {
+          "caption": "WPA3-Enterprise"
+        },
+        "8": {
+          "caption": "Opportunistic Wireless Encryption"
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The security protocol is not mapped."
+        }
+      }
+    },
     "security_questions": {
       "caption": "Security Questions",
       "description": "The question(s) provided to user for a question-based authentication factor.",
@@ -6588,6 +6729,11 @@
       "description": "The short description that pertains to the object or event. See specific usage.",
       "type": "string_t"
     },
+    "signal_strength": {
+      "caption": "Signal Strength",
+      "description": "The measured power of the received radio signal, in decibel-milliwatts.",
+      "type": "integer_t"
+    },
     "signature": {
       "caption": "Digital Signature",
       "description": "The digital signature of the file.",
@@ -6645,6 +6791,11 @@
       "caption": "Server Name Indication",
       "description": " The Server Name Indication (SNI) extension sent by the client.",
       "type": "string_t"
+    },
+    "snr": {
+      "caption": "SNR",
+      "description": "The Signal to Noise Ratio of the received radio signal, in decibels.",
+      "type": "integer_t"
     },
     "software_components": {
       "caption": "Software Components",
@@ -6723,10 +6874,20 @@
       "description": "The URL pointing towards the source of an entity. See specific usage.",
       "type": "url_t"
     },
+    "ssid": {
+      "caption": "SSID",
+      "description": "The Service Set Identifier, the advertised name of a wireless network.",
+      "type": "string_t"
+    },
     "sso": {
       "caption": "SSO",
       "description": "The Single Sign-On (SSO) object provides a structure for normalizing SSO attributes, configuration, and/or settings from Identity Providers.",
       "type": "sso"
+    },
+    "standard": {
+      "caption": "Standard",
+      "description": "The published standard that the link conforms to. See specific usage.",
+      "type": "string_t"
     },
     "standards": {
       "caption": "Compliance Standards: List",
@@ -7782,6 +7943,11 @@
       "caption": "WHOIS",
       "description": "The resources of a WHOIS record for a given domain. This can include domain names, IP address blocks, autonomous system information, and/or contact and registration information for a domain.",
       "type": "whois"
+    },
+    "wifi": {
+      "caption": "Wireless Network",
+      "description": "The wireless network attributes.",
+      "type": "wifi"
     },
     "working_directory": {
       "caption": "Working Directory",

--- a/objects/device.json
+++ b/objects/device.json
@@ -162,6 +162,10 @@
     "vendor_name": {
       "description": "The vendor for the device. For example <code>Dell</code> or <code>Lenovo</code>.",
       "requirement": "recommended"
+    },
+    "wifi": {
+      "description": "The wireless network that the device is associated with, or that it advertises when it is an access point.",
+      "requirement": "optional"
     }
   },
   "references": [

--- a/objects/network_endpoint.json
+++ b/objects/network_endpoint.json
@@ -45,6 +45,10 @@
     },
     "uid": {
       "observable": 48
+    },
+    "wifi": {
+      "description": "The wireless network that this endpoint is associated with, or that this endpoint advertises when it is an access point.",
+      "requirement": "optional"
     }
   },
   "constraints": {

--- a/objects/wifi.json
+++ b/objects/wifi.json
@@ -1,0 +1,79 @@
+{
+  "caption": "Wireless Network",
+  "description": "The Wireless Network object describes an IEEE 802.11 wireless link: the identity of the network, the radio parameters it operates on, and the security negotiated for it.",
+  "extends": "object",
+  "name": "wifi",
+  "attributes": {
+    "ap_status": {
+      "requirement": "optional"
+    },
+    "ap_status_id": {
+      "requirement": "optional"
+    },
+    "band": {
+      "requirement": "optional"
+    },
+    "band_id": {
+      "requirement": "recommended"
+    },
+    "bssid": {
+      "requirement": "recommended"
+    },
+    "channel": {
+      "caption": "Channel",
+      "description": "The channel number that the wireless link operates on.",
+      "requirement": "optional"
+    },
+    "cipher": {
+      "caption": "Cipher",
+      "description": "The negotiated encryption cipher. For example: <code>AES-CCMP</code>, <code>GCMP-256</code> or <code>TKIP</code>.",
+      "requirement": "optional"
+    },
+    "data_rate": {
+      "requirement": "optional"
+    },
+    "is_on_wired_network": {
+      "requirement": "optional"
+    },
+    "noise_floor": {
+      "requirement": "optional"
+    },
+    "rssi": {
+      "caption": "RSSI",
+      "description": "The Received Signal Strength Indicator reported for the wireless link.",
+      "requirement": "optional"
+    },
+    "security_protocol": {
+      "requirement": "optional"
+    },
+    "security_protocol_id": {
+      "requirement": "recommended"
+    },
+    "signal_strength": {
+      "requirement": "optional"
+    },
+    "snr": {
+      "requirement": "optional"
+    },
+    "ssid": {
+      "requirement": "recommended"
+    },
+    "standard": {
+      "caption": "Standard",
+      "description": "The IEEE 802.11 amendment that the link operates under. For example: <code>802.11ax</code> or <code>802.11ac</code>.",
+      "requirement": "optional"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "ssid",
+      "bssid"
+    ]
+  },
+  "references": [
+    {
+      "description": "IEEE 802.11 Wireless LAN Medium Access Control and Physical Layer Specifications",
+      "url": "https://standards.ieee.org/ieee/802.11/7028/"
+    }
+  ]
+}


### PR DESCRIPTION
#### Related Issue:
Closes #1463

#### Description of changes:

Adds a `wifi` object describing an IEEE 802.11 link, and references it from `network_endpoint` and `device`.

Issue #1463 asks for an `ssid` attribute on `network_endpoint`. This resolves that, and covers the rest of the wireless link at the same time, because the events that carry an SSID also carry the radio and security context that gives it meaning.

Today the schema acknowledges wireless once, through `network_interface.type_id = 2 (Wireless)`, and then provides nothing to describe the link. `ssid`, `bssid`, `wifi`, `band`, `channel`, `snr` and `noise` all return zero hits in the source. `rssi` exists in the dictionary but is reachable only from `airborne_broadcast_activity`.

#### The object

`objects/wifi.json`, extends `object`, 17 attributes, constraint `at_least_one: [ssid, bssid]`:

| attribute | type | requirement |
|---|---|---|
| `ssid` | `string_t` | recommended |
| `bssid` | `mac_t` | recommended |
| `channel` | `integer_t` | optional |
| `band` / `band_id` | `string_t` / `integer_t` | optional / recommended |
| `standard` | `string_t` | optional |
| `rssi` | `integer_t` | optional |
| `snr` | `integer_t` | optional |
| `signal_strength` | `integer_t` | optional |
| `noise_floor` | `integer_t` | optional |
| `data_rate` | `integer_t` | optional |
| `security_protocol` / `security_protocol_id` | `string_t` / `integer_t` | optional / recommended |
| `cipher` | `string_t` | optional |
| `ap_status` / `ap_status_id` | `string_t` / `integer_t` | optional |
| `is_on_wired_network` | `boolean_t` | optional |

`cipher` and `rssi` reuse existing dictionary entries with local description overrides. The rest are new dictionary entries. `band_id`, `security_protocol_id` and `ap_status_id` carry enums with string siblings, matching the convention used elsewhere.

Every attribute appears in a real production log. The samples and a field by field justification are in the comment on #1463.

#### Why the object rather than a single field

In one production deployment the parser writes the BSSID into `src_endpoint.mac` and the SSID into `src_endpoint.name`, purely to satisfy the `network_endpoint` `at_least_one` constraint. A MAC pivot then returns access point radios mixed in with client laptops, with no attribute to tell them apart. A dedicated object keeps the AP radio address distinct from a client MAC, which a single `ssid` field would not.

#### Deliberately out of scope

Class level `wifi` on `network_activity` and `authentication`, and an `ssid` observable type. Both are reasonable follow ups, left out to keep this reviewable.

Files touched: `dictionary.json`, `objects/wifi.json` (new), `objects/network_endpoint.json`, `objects/device.json`, `.github/.project-words.txt`, `CHANGELOG.md`.

The wordlist change adds `BSSID`, `bssid`, `CCMP`, `GCMP`, `TKIP` and `milliwatts`, which are not present in the cspell dictionaries.

#### Confirmations

1. `Unreleased` entry added to `CHANGELOG.md`.
2. Contribution guidelines followed. Attribute names are lower case with underscores, and `ssid`, `bssid` and `rssi` are used as well accepted abbreviations in the same spirit as `ip`, `os` and `cve`.
3. Validated locally:
   - `python -m ocsf_validator .` passes
   - `ocsf-schema-compiler .` compiles with zero errors and zero warnings, in both default and browser mode
   - `python -m ocsf.validate.compatibility` against `main` passes all five checks
   - `cspell` with the repository config reports no unknown words
   - a local `ocsf-server` boots against the compiled schema, serves HTTP 200 on `/objects/wifi` and produces zero log output
4. PR title matches the description.
5. Captions and descriptions follow the normative and neutral style. No authoritative URLs in descriptions, no trademark marks, no company or product names. The IEEE 802.11 reference is in a `references` array.
