### PR TITLE
Add progress and throughput attributes to the job object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Thankyou! -->
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
-  1. Added `progress_current`, `progress_total`, `progress_unit`, `bytes_processed`, `bytes_written`, `throughput` and `queue_name` attributes to the `job` object. [#1722](https://github.com/ocsf/ocsf-schema/pull/1722)
+  1. Added `progress_current`, `progress_total`, `progress_unit`, `bytes_processed`, `bytes_written`, `throughput` and `queue_name` attributes. [#1722](https://github.com/ocsf/ocsf-schema/pull/1722)
 
 ### Improved
 * #### Event Classes
@@ -56,6 +56,7 @@ Thankyou! -->
 * #### Objects
   1. Added `labels` to the `node` object for grouping nodes into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `labels` to the `edge` object for grouping edges into named subgraphs. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `progress_current`, `progress_total`, `progress_unit`, `bytes_processed`, `bytes_written`, `throughput` and `queue_name` to the `job` object so a running job can report its progress and throughput. [#1722](https://github.com/ocsf/ocsf-schema/pull/1722)
 
 ## [v1.9.0] - Aug 3rd, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ Thankyou! -->
 
 ## [Unreleased]
 
+### Added
+* #### Dictionary Attributes
+  1. Added `progress_current`, `progress_total`, `progress_unit`, `bytes_processed`, `bytes_written`, `throughput` and `queue_name` attributes to the `job` object. [#1722](https://github.com/ocsf/ocsf-schema/pull/1722)
+
 ## [v1.9.0] - Aug 3rd, 2026
 
 ### Added

--- a/dictionary.json
+++ b/dictionary.json
@@ -827,6 +827,16 @@
       "description": "The number of bytes sent from the source to the destination.",
       "type": "long_t"
     },
+    "bytes_processed": {
+      "caption": "Bytes Processed",
+      "description": "The number of bytes read or examined while the work was performed.",
+      "type": "long_t"
+    },
+    "bytes_written": {
+      "caption": "Bytes Written",
+      "description": "The number of bytes committed to the destination, after any compression or deduplication was applied.",
+      "type": "long_t"
+    },
     "campaign": {
       "caption": "Campaign",
       "description": "The campaign object describes details about the campaign that was the source of the activity.",
@@ -5348,6 +5358,21 @@
       "type": "programmatic_credential",
       "is_array": true
     },
+    "progress_current": {
+      "caption": "Progress Current",
+      "description": "The units of work completed so far, counted in <code>progress_unit</code>.",
+      "type": "long_t"
+    },
+    "progress_total": {
+      "caption": "Progress Total",
+      "description": "The total units of work, counted in <code>progress_unit</code>.",
+      "type": "long_t"
+    },
+    "progress_unit": {
+      "caption": "Progress Unit",
+      "description": "The unit that <code>progress_current</code> and <code>progress_total</code> are counted in. For example: <code>bytes</code>, <code>files</code> or <code>items</code>.",
+      "type": "string_t"
+    },
     "project_uid": {
       "caption": "Project ID",
       "description": "The unique identifier of a Cloud project.",
@@ -5654,6 +5679,11 @@
           "description": "The query type was not mapped to a standard category. See the query_type attribute for source-specific value."
         }
       }
+    },
+    "queue_name": {
+      "caption": "Queue Name",
+      "description": "The name of the scheduler queue that the work was dispatched to.",
+      "type": "string_t"
     },
     "radius": {
       "caption": "Radius",
@@ -7167,6 +7197,11 @@
           "url": "https://stixproject.github.io/data-model/1.2/ta/ThreatActorType/"
         }
       ]
+    },
+    "throughput": {
+      "caption": "Throughput",
+      "description": "The rate at which data was processed, in bytes per second.",
+      "type": "long_t"
     },
     "ticket": {
       "caption": "Ticket",

--- a/dictionary.json
+++ b/dictionary.json
@@ -829,12 +829,12 @@
     },
     "bytes_processed": {
       "caption": "Bytes Processed",
-      "description": "The number of bytes read or examined while the work was performed.",
+      "description": "The number of bytes read or examined. See specific usage.",
       "type": "long_t"
     },
     "bytes_written": {
       "caption": "Bytes Written",
-      "description": "The number of bytes committed to the destination, after any compression or deduplication was applied.",
+      "description": "The number of bytes written to the destination. See specific usage.",
       "type": "long_t"
     },
     "campaign": {
@@ -5682,7 +5682,7 @@
     },
     "queue_name": {
       "caption": "Queue Name",
-      "description": "The name of the scheduler queue that the work was dispatched to.",
+      "description": "The name of the queue that the work was dispatched to. See specific usage.",
       "type": "string_t"
     },
     "radius": {
@@ -7200,7 +7200,7 @@
     },
     "throughput": {
       "caption": "Throughput",
-      "description": "The rate at which data was processed, in bytes per second.",
+      "description": "The rate at which data was processed. See specific usage.",
       "type": "long_t"
     },
     "ticket": {

--- a/objects/job.json
+++ b/objects/job.json
@@ -4,6 +4,12 @@
   "extends": "object",
   "name": "job",
   "attributes": {
+    "bytes_processed": {
+      "requirement": "optional"
+    },
+    "bytes_written": {
+      "requirement": "optional"
+    },
     "cmd_line": {
       "description": "The job command line.",
       "requirement": "recommended",
@@ -61,6 +67,18 @@
         ]
       }
     },
+    "progress_current": {
+      "requirement": "optional"
+    },
+    "progress_total": {
+      "requirement": "optional"
+    },
+    "progress_unit": {
+      "requirement": "optional"
+    },
+    "queue_name": {
+      "requirement": "optional"
+    },
     "run_state": {
       "description": "The run state of the job.",
       "requirement": "optional"
@@ -91,6 +109,9 @@
           "caption": "Other"
         }
       }
+    },
+    "throughput": {
+      "requirement": "optional"
     },
     "type": {
       "description": "The job type, normalized to the caption of the <code>type_id</code> value. In the case of 'Other', it is defined by the event source.",

--- a/objects/job.json
+++ b/objects/job.json
@@ -5,9 +5,11 @@
   "name": "job",
   "attributes": {
     "bytes_processed": {
+      "description": "The number of bytes the job read or examined while performing its work.",
       "requirement": "optional"
     },
     "bytes_written": {
+      "description": "The number of bytes the job committed to the destination, after any compression or deduplication was applied.",
       "requirement": "optional"
     },
     "cmd_line": {
@@ -68,15 +70,19 @@
       }
     },
     "progress_current": {
+      "description": "The units of work the job has completed so far, counted in <code>progress_unit</code>.",
       "requirement": "optional"
     },
     "progress_total": {
+      "description": "The total units of work the job is expected to perform, counted in <code>progress_unit</code>.",
       "requirement": "optional"
     },
     "progress_unit": {
+      "description": "The unit that the job's <code>progress_current</code> and <code>progress_total</code> are counted in. For example: <code>bytes</code>, <code>files</code> or <code>items</code>.",
       "requirement": "optional"
     },
     "queue_name": {
+      "description": "The name of the queue that the job was dispatched to.",
       "requirement": "optional"
     },
     "run_state": {
@@ -111,6 +117,7 @@
       }
     },
     "throughput": {
+      "description": "The rate at which the job processed data, in bytes per second.",
       "requirement": "optional"
     },
     "type": {


### PR DESCRIPTION
#### Related Issue:
Closes #1718

#### Description of changes:

Adds seven optional attributes to the `job` object so that long running work can report what it actually did, not just that it finished.

| attribute | type | requirement |
|---|---|---|
| `progress_current` | `long_t` | optional |
| `progress_total` | `long_t` | optional |
| `progress_unit` | `string_t` | optional |
| `bytes_processed` | `long_t` | optional |
| `bytes_written` | `long_t` | optional |
| `throughput` | `long_t` | optional |
| `queue_name` | `string_t` | optional |

Seven matching entries are added to `dictionary.json`.

`job` currently holds the name, command line, run state and timestamps. It has no way to say how much work was done. A job that moved 4.59 GB and a job that completed having written nothing produce the same OCSF event today.

Sample event and full rationale are in #1718. In short, `bytes_processed` against `bytes_written` is the deduplication and compression ratio, and a collapse in that ratio is what mass encryption looks like from a data protection system's point of view.

These are generic execution metrics rather than domain specific ones. The same seven serve a vulnerability scan, a replication job, a search index rebuild or a bulk transfer.

#### Scope

Deliberately class free, so it can be evaluated on its own. Whether OCSF needs a data protection event class, given that `device.is_backed_up` is currently the schema's only acknowledgement of backup, is a separate question I will raise as its own issue.

Files touched: `dictionary.json`, `objects/job.json`, `CHANGELOG.md`.

#### Confirmations

1. `Unreleased` entry added to `CHANGELOG.md`.
2. Contribution guidelines followed. Names avoid abbreviations, which is why the pair is `progress_current` and `progress_total` with an explicit `progress_unit`, rather than a percentage field.
3. Validated locally:
   - `python -m ocsf_validator .` passes
   - `ocsf-schema-compiler .` compiles with zero errors and zero warnings, in both default and browser mode
   - `python -m ocsf.validate.compatibility` against `main` passes all five checks
   - `cspell` with the repository config reports no unknown words
   - a local `ocsf-server` boots against the compiled schema, serves HTTP 200 and produces zero log output
4. PR title matches the description.
5. Captions and descriptions follow the normative and neutral style.
