### PR TITLE
linux: add cgroup object and attach it to Linux Process

### DIFF
--- a/extensions/linux/dictionary.json
+++ b/extensions/linux/dictionary.json
@@ -1,0 +1,12 @@
+{
+  "caption": "Linux Dictionary",
+  "description": "The Linux extension attribute dictionary defines Linux-specific attributes and their types.",
+  "name": "dictionary",
+  "attributes": {
+    "cgroup": {
+      "caption": "cgroup",
+      "description": "The Linux control group (cgroup) associated with the object or activity.",
+      "type": "cgroup"
+    }
+  }
+}

--- a/extensions/linux/objects/cgroup.json
+++ b/extensions/linux/objects/cgroup.json
@@ -1,7 +1,7 @@
 {
   "caption": "cgroup",
   "description": "The cgroup object describes a Linux control group (cgroup), the kernel mechanism that organizes processes into hierarchical groups for resource control and accounting. cgroups are the basis for container and pod isolation, so the cgroup a task belongs to is commonly used to attribute kernel-level (e.g. eBPF/LSM) events to a container or pod.",
-  "extends": "object",
+  "extends": "_entity",
   "name": "cgroup",
   "attributes": {
     "name": {

--- a/extensions/linux/objects/cgroup.json
+++ b/extensions/linux/objects/cgroup.json
@@ -1,0 +1,30 @@
+{
+  "caption": "cgroup",
+  "description": "The cgroup object describes a Linux control group (cgroup), the kernel mechanism that organizes processes into hierarchical groups for resource control and accounting. cgroups are the basis for container and pod isolation, so the cgroup a task belongs to is commonly used to attribute kernel-level (e.g. eBPF/LSM) events to a container or pod.",
+  "extends": "object",
+  "name": "cgroup",
+  "attributes": {
+    "name": {
+      "description": "The cgroup name, typically the last path component of <code>path</code>.",
+      "requirement": "optional"
+    },
+    "path": {
+      "description": "The cgroup filesystem path relative to the cgroup mount, for example <code>/system.slice/docker-1a2b.scope</code>.",
+      "requirement": "recommended"
+    },
+    "uid": {
+      "description": "The kernel-assigned cgroup ID (the cgroup directory's inode number), stable for the lifetime of the cgroup.",
+      "requirement": "recommended"
+    },
+    "version": {
+      "description": "The cgroup hierarchy version, for example <code>1</code> or <code>2</code>.",
+      "requirement": "optional"
+    }
+  },
+  "constraints": {
+    "at_least_one": [
+      "uid",
+      "path"
+    ]
+  }
+}

--- a/extensions/linux/objects/process.json
+++ b/extensions/linux/objects/process.json
@@ -4,13 +4,12 @@
   "extends": "process",
   "attributes": {
     "$include": [
-      "profiles/linux_users.json"
-    ],
-    "cgroup": {
-      "requirement": "recommended"
-    }
+      "profiles/linux_users.json",
+      "profiles/cgroup.json"
+    ]
   },
   "profiles": [
-    "linux/linux_users"
+    "linux/linux_users",
+    "linux/cgroup"
   ]
 }

--- a/extensions/linux/objects/process.json
+++ b/extensions/linux/objects/process.json
@@ -5,7 +5,10 @@
   "attributes": {
     "$include": [
       "profiles/linux_users.json"
-    ]
+    ],
+    "cgroup": {
+      "requirement": "recommended"
+    }
   },
   "profiles": [
     "linux/linux_users"

--- a/extensions/linux/profiles/cgroup.json
+++ b/extensions/linux/profiles/cgroup.json
@@ -1,0 +1,11 @@
+{
+  "caption": "cgroup",
+  "description": "Adds the Linux control group (cgroup) that an object or activity is associated with. Useful for attributing kernel-level events to a container or pod.",
+  "meta": "profile",
+  "name": "cgroup",
+  "attributes": {
+    "cgroup": {
+      "requirement": "recommended"
+    }
+  }
+}


### PR DESCRIPTION
## Description

OCSF currently has **no representation for a Linux control group (cgroup)**. cgroups are the kernel primitive that container and pod isolation are built on, and the cgroup a task belongs to is the natural key for attributing kernel-level events (e.g. eBPF/LSM security telemetry) to a container or pod. Today, producers that have this data (Tetragon, Tracee, KubeArmor, AegisBPF, …) have to stash the cgroup id/path under `unmapped`.

This adds a first-class, reusable `cgroup` representation to the **Linux extension**:

- **`extensions/linux/objects/cgroup.json`** — a new `cgroup` object with `uid` (kernel-assigned cgroup ID / directory inode), `path` (cgroup fs path), `name`, and `version` (1 or 2), reusing existing dictionary attributes. `constraints: at_least_one [uid, path]`.
- **`extensions/linux/dictionary.json`** — new; defines the `cgroup` attribute (`type: cgroup`).
- **`extensions/linux/objects/process.json`** — adds the `cgroup` attribute to the Linux Process object (same pattern as the existing `linux_users` profile), so a process carries the cgroup it runs in.

## Motivation / use case

Any container-aware or eBPF/LSM security tool needs to attribute an event to a cgroup/container. With this, that data lands in `actor.process.cgroup.{uid,path}` instead of `unmapped`. (Motivated by [AegisBPF](https://github.com/ErenAri/Aegis-BPF), an OCSF-native BPF-LSM agent, but the object is vendor-neutral.)

## Validation

- `python -m ocsf_validator .` — **all checks pass** (metaschema match, attribute type references resolve, dictionary attributes used, required keys present, no unrecognized keys).
- `ocsf-schema-compiler .` — **compiles successfully**.

Happy to also add `cgroup` to other Linux activity contexts, or to iterate on attribute names/requirements per review.