### PR TITLE
register PromptShield extension under UID 244

### DIFF
--- a/extensions/promptshield/extension.json
+++ b/extensions/promptshield/extension.json
@@ -1,0 +1,7 @@
+{
+  "name": "promptshield",
+  "uid": 244,
+  "caption": "PromptShield",
+  "description": "Defines prompt injection, jailbreak detection, and LLM guardrail attributes, objects, and event classes.",
+  "version": "1.0.0"
+}


### PR DESCRIPTION
### Summary
Registers the `Promptshield` vendor extension under UID `244` for AI guardrails, LLM jailbreak, and prompt injection detection telemetry.

#### Related Issue: 

#### Description of changes:

### Delete once you have confirmed the following: 
1. Did you add a single line summary of changes to `Unreleased` section in the [CHANGELOG.md](https://github.com/ocsf/ocsf-schema/blob/main/CHANGELOG.md) file?
2. Have you followed the [contribution guidelines](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md)?
3. Did you run a local instance of the [ocsf-server](https://github.com/ocsf/ocsf-server) and ensure it ran without any errors/warnings?
4. Is your PR title in sync with the description?
5. Do new/changed captions and descriptions follow the [normative & neutral style](https://github.com/ocsf/ocsf-schema/blob/main/CONTRIBUTING.md#caption--description-style-normative--neutral)? No authoritative URLs, trademark marks (®/™/℠), or company names in captions/descriptions (use `references` and `examples` instead), and descriptions stay technical rather than personal or political.
