### PR TITLE
DefenXee Extension Registration 

### DIFF
--- a/extensions.md
+++ b/extensions.md
@@ -6,6 +6,7 @@ The purpose of this file is to keep track of and avoid collisions in Extension `
 
 | Caption     | Name     | UID | Notes | Repository |
 |-------------|----------|-----|-------|------------|
+| DefenXee    | defenxee | **987** | The DefenXee vendor extension| | 
 | Trellix     | trellix  | **988** | The Trellix schema extension | |
 | Synqly      | synqly   | **989** | The Synqly schema extension | |
 | US GOV      | usg1     | **990** | The USG-1 schema extension | |


### PR DESCRIPTION
| DefenXee    | defenxee | **987** | Vendor extension defining metadata for AI-governed cybersecurity telemetry, threat detection artifacts, and governance-aligned security events. |

Adds DefenXee vendor entry to extensions.md for UID 987.
No schema changes.