### PR TITLE
Add physical_site profile, site_zone object, and physical site context attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,17 @@ Thankyou! -->
 ## [Unreleased]
 
 ### Added
+* #### Profiles
+  1. Added `physical_site` profile carrying physical site context (`site_uid`, `site_name`, `building`, `floor`, `security_zone`), applied at the base event so any class can carry it, and on the `location` object so devices and endpoints inherit site context through `device.location`.
+* #### Objects
+  1. Added `security_zone` object describing a physical security zone within a site, distinct from the network `zone` attribute.
 * #### Dictionary Attributes
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
+  1. Added `site_uid`, `site_name`, `building`, and `floor` as `string_t` physical site context attributes.
+  1. Added `security_zone` as an object attribute and `is_armed` as a `boolean_t`.
+  1. Added `zone_type_id` as an `integer_t` enum with values Unknown (0), Perimeter (1), Public (2), Restricted (3), Critical (4), Transitional (5), External (6), Other (99), and `zone_type` as its `string_t` sibling.
 
 ### Improved
 * #### Event Classes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,16 +45,16 @@ Thankyou! -->
 
 ### Added
 * #### Profiles
-  1. Added `physical_site` profile carrying physical site context (`site_uid`, `site_name`, `building`, `floor`, `security_zone`), applied at the base event so any class can carry it, and on the `location` object so devices and endpoints inherit site context through `device.location`.
+  1. Added `physical_site` profile carrying physical site context (`site_uid`, `site_name`, `building`, `floor`, `security_zone`), applied at the base event so any class can carry it, and on the `location` object so devices and endpoints inherit site context through `device.location`. [#1750](https://github.com/ocsf/ocsf-schema/pull/1750)
 * #### Objects
-  1. Added `security_zone` object describing a physical security zone within a site, distinct from the network `zone` attribute.
+  1. Added `security_zone` object describing a physical security zone within a site, distinct from the network `zone` attribute. [#1750](https://github.com/ocsf/ocsf-schema/pull/1750)
 * #### Dictionary Attributes
   1. Added `likelihood` as a `string_t`, normalized to the caption of `likelihood_id`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_id` as an `integer_t` enum with values Unknown (0), Very Low (1), Low (2), Moderate (3), High (4), Very High (5), Other (99). [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
   1. Added `likelihood_score` as an `integer_t`, complementing `confidence_score`, `impact_score`, and `risk_score`. [#1715](https://github.com/ocsf/ocsf-schema/pull/1715)
-  1. Added `site_uid`, `site_name`, `building`, and `floor` as `string_t` physical site context attributes.
-  1. Added `security_zone` as an object attribute and `is_armed` as a `boolean_t`.
-  1. Added `zone_type_id` as an `integer_t` enum with values Unknown (0), Perimeter (1), Public (2), Restricted (3), Critical (4), Transitional (5), External (6), Other (99), and `zone_type` as its `string_t` sibling.
+  1. Added `site_uid`, `site_name`, `building`, and `floor` as `string_t` physical site context attributes. [#1750](https://github.com/ocsf/ocsf-schema/pull/1750)
+  1. Added `security_zone` as an object attribute and `is_armed` as a `boolean_t`. [#1750](https://github.com/ocsf/ocsf-schema/pull/1750)
+  1. Added `zone_type_id` as an `integer_t` enum with values Unknown (0), Perimeter (1), Public (2), Restricted (3), Critical (4), Transitional (5), External (6), Other (99), and `zone_type` as its `string_t` sibling. [#1750](https://github.com/ocsf/ocsf-schema/pull/1750)
 
 ### Improved
 * #### Event Classes

--- a/dictionary.json
+++ b/dictionary.json
@@ -753,6 +753,11 @@
       "description": "The operating system build number.",
       "type": "string_t"
     },
+    "building": {
+      "caption": "Building",
+      "description": "The building within the physical site where the activity occurred.",
+      "type": "string_t"
+    },
     "bulletin": {
       "caption": "Patch Bulletin",
       "description": "The vendor bulletin identifier.",
@@ -3134,6 +3139,11 @@
       "type": "string_t",
       "is_array": true
     },
+    "floor": {
+      "caption": "Floor",
+      "description": "The floor or level within the building where the activity occurred.",
+      "type": "string_t"
+    },
     "folder": {
       "caption": "Folder",
       "description": "The folder that pertains to the event.",
@@ -3705,6 +3715,11 @@
     "is_applied": {
       "caption": "Applied",
       "description": "A determination if a policy, rule, or enforcement action was applied.",
+      "type": "boolean_t"
+    },
+    "is_armed": {
+      "caption": "Armed",
+      "description": "Indicates whether the security zone or monitored point was armed at the time of the event.",
       "type": "boolean_t"
     },
     "is_backed_up": {
@@ -6419,6 +6434,11 @@
       "type": "security_state",
       "is_array": true
     },
+    "security_zone": {
+      "caption": "Security Zone",
+      "description": "The physical security zone where the activity occurred.",
+      "type": "security_zone"
+    },
     "sender": {
       "caption": "Sender",
       "description": "The machine readable email address of the system or server that actually transmitted the email message, extracted from the email headers per RFC 5322. This differs from the <code>from</code> field, which shows the message author. The sender field is most commonly used when multiple addresses appear in the <code> from_list </code> field, or when the transmitting system is different from the message author (such as when sending on behalf of someone else).",
@@ -6655,6 +6675,16 @@
       "description": "A collection of <code>Digital Signature</code> objects.",
       "type": "digital_signature",
       "is_array": true
+    },
+    "site_uid": {
+      "caption": "Site UID",
+      "description": "The unique identifier of the physical site where the activity occurred, as defined by the reporting organization.",
+      "type": "string_t"
+    },
+    "site_name": {
+      "caption": "Site Name",
+      "description": "The name of the physical site where the activity occurred.",
+      "type": "string_t"
     },
     "size": {
       "caption": "Size",
@@ -7871,6 +7901,51 @@
       "caption": "Network Zone",
       "description": "The network zone or LAN segment. See specific usage.",
       "type": "string_t"
+    },
+    "zone_type": {
+      "caption": "Security Zone Type",
+      "description": "The security zone type, normalized to the caption of the <code>zone_type_id</code> value.",
+      "type": "string_t"
+    },
+    "zone_type_id": {
+      "caption": "Security Zone Type ID",
+      "description": "The normalized classification of the physical security zone.",
+      "sibling": "zone_type",
+      "type": "integer_t",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The zone type is unknown."
+        },
+        "1": {
+          "caption": "Perimeter",
+          "description": "The outer boundary of the site."
+        },
+        "2": {
+          "caption": "Public",
+          "description": "An area open to the public."
+        },
+        "3": {
+          "caption": "Restricted",
+          "description": "An area restricted to authorized persons."
+        },
+        "4": {
+          "caption": "Critical",
+          "description": "An area containing critical assets."
+        },
+        "5": {
+          "caption": "Transitional",
+          "description": "A lobby, corridor, or other transitional space."
+        },
+        "6": {
+          "caption": "External",
+          "description": "An outdoor area within the site boundary."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The zone type is not mapped. See the <code>zone_type</code> attribute, which contains a data source specific value."
+        }
+      }
     }
   },
   "types": {

--- a/events/base_event.json
+++ b/events/base_event.json
@@ -168,6 +168,7 @@
     "datetime",
     "host",
     "osint",
+    "physical_site",
     "record_integrity",
     "security_control"
   ]

--- a/objects/location.json
+++ b/objects/location.json
@@ -4,6 +4,9 @@
   "description": "The Geo Location object describes a geographical location, usually associated with an IP address.",
   "extends": "object",
   "name": "location",
+  "profiles": [
+    "physical_site"
+  ],
   "attributes": {
     "aerial_height": {
       "requirement": "optional"

--- a/objects/security_zone.json
+++ b/objects/security_zone.json
@@ -1,0 +1,18 @@
+{
+  "caption": "Security Zone",
+  "description": "The Security Zone object describes a physical security zone: a defined area within a site that shares a common security posture, such as a perimeter, a public lobby, or a restricted area. It is distinct from the <code>zone</code> attribute, which describes a network zone.",
+  "extends": "_entity",
+  "name": "security_zone",
+  "attributes": {
+    "zone_type_id": {
+      "group": "classification",
+      "requirement": "recommended"
+    },
+    "zone_type": {
+      "requirement": "optional"
+    },
+    "is_armed": {
+      "requirement": "optional"
+    }
+  }
+}

--- a/profiles/physical_site.json
+++ b/profiles/physical_site.json
@@ -1,0 +1,31 @@
+{
+  "caption": "Physical Site",
+  "description": "Adds physical site context to event classes and objects. Apply this profile when the event is tied to a physical place: it carries the site identity and the in-site location (building, floor, security zone). Applying it to Identity & Access Management classes allows logical access events to be correlated with physical presence at the same site, and applying it to the <code>location</code> object gives any device or endpoint physical site context.",
+  "meta": "profile",
+  "name": "physical_site",
+  "annotations": {
+    "group": "context"
+  },
+  "attributes": {
+    "site_uid": {
+      "description": "The unique identifier of the physical site where the activity occurred, as defined by the reporting organization.",
+      "requirement": "recommended"
+    },
+    "site_name": {
+      "description": "The name of the physical site where the activity occurred.",
+      "requirement": "optional"
+    },
+    "building": {
+      "description": "The building within the physical site.",
+      "requirement": "optional"
+    },
+    "floor": {
+      "description": "The floor or level within the building.",
+      "requirement": "optional"
+    },
+    "security_zone": {
+      "description": "The physical security zone where the activity occurred.",
+      "requirement": "optional"
+    }
+  }
+}


### PR DESCRIPTION
**Part 1 of 3** — 1: this PR, `physical_site` profile and `site_zone` object · 2: #1757 enum values for physical credentials, alarm dispositions, and physical logons · 3: #1758 Physical Security category and classes (stacked on this PR) · design discussion: #1735 · reference implementation: https://github.com/leeandrews9/physec (v0.1.2, ~77,000 live production events)

## Description

Adds a `physical_site` **profile** carrying physical site context — `site_uid`,
`site_name`, `building`, `floor`, and `site_zone` — applied at the base event so
any class can opt in (same pattern as the `record_integrity` profile), and on the
`location` object so devices and endpoints inherit physical site context through
`device.location`.

Adds the **`site_zone` object** (a defined area within a physical site sharing a
common security posture: perimeter, public, restricted, critical, transitional,
external). It sits beside `site_uid` and `site_name`, and the name stays clear of
both the existing `zone` dictionary attribute and the term "security zone", which
already mean a network zone. The `zone_type_id` values are generic tiers by
security posture; the description says how regime-specific tiers (DoD, DOE, NRC
areas) map onto them, with the native tier name carried in `zone_type`.

Adds the supporting **dictionary attributes**: `site_uid`, `site_name`, `building`,
`floor` (`string_t`), `site_zone` (object), `is_armed` (`boolean_t`), and
`zone_type_id`/`zone_type` (enum + sibling).

## Motivation

Physical security telemetry (badge access, alarms, guard operations, cameras) has no
site/place context in the schema today: `location` is geographic, and `zone` is a
network concept. This profile is the smallest change that lets physical events land
in the same normalized stream as logical ones — applying it to IAM/Authentication
classes correlates logical access with physical presence at the same site (the
failed-logons-then-break-in scenario), per the direction discussed in #1735 and on
the 2026-08-20 mappings call.

This is the first of two or three sequenced changes from that discussion; enum
additions (badge/prox/smart-card `auth_factor` values, disposition values) follow
separately.

## Evidence

~73,000 live production events from a US hybrid security firm's guarding and
monitoring operation already carry this profile via the `physec` extension
(https://github.com/leeandrews9/physec — CI validates against upstream; instance
suite green over the live corpus). The attribute names here match what is running
in production ([v0.1.1 changelog](https://github.com/leeandrews9/physec/blob/main/CHANGELOG.md)).

Open to reshaping per review — e.g., folding site identity into an entity object
rather than flat attributes — the production data can be re-emitted either way.



