### PR TITLE
[draft] Add `AI Agent Activity` event class.

### DIFF
--- a/dictionary.json
+++ b/dictionary.json
@@ -221,6 +221,41 @@
       "description": "An autonomous AI agent that performs tasks under delegated authority. Distinguished from the OCSF <code>agent</code> object, which describes security sensors such as EDR and DLP tools.",
       "type": "ai_agent"
     },
+    "ai_agent_compact_info": {
+      "caption": "AI Agent Compact Information",
+      "description": "Provides detail pertaining to the <code>Compact</code> activity.",
+      "type": "ai_agent_compact_info"
+    },
+    "ai_agent_permission_request_info": {
+      "caption": "AI Agent Permission Request Information",
+      "description": "Provides detail pertaining to the <code>Permission Request</code> activity.",
+      "type": "ai_agent_permission_request_info"
+    },
+    "ai_agent_session_end_info": {
+      "caption": "AI Agent Session End Information",
+      "description": "Provides detail pertaining to the <code>Session End</code> activity.",
+      "type": "ai_agent_session_end_info"
+    },
+    "ai_agent_session_start_info": {
+      "caption": "AI Agent Session Start Information",
+      "description": "Provides detail pertaining to the <code>Session Start</code> activity.",
+      "type": "ai_agent_session_start_info"
+    },
+    "ai_agent_stop_info": {
+      "caption": "AI Agent Stop Information",
+      "description": "Provides detail pertaining to the <code>Stop</code> activity.",
+      "type": "ai_agent_stop_info"
+    },
+    "ai_agent_tool_use_info": {
+      "caption": "AI Agent Tool Use Information",
+      "description": "Provides detail pertaining to the <code>Tool Use</code> activity.",
+      "type": "ai_agent_tool_use_info"
+    },
+    "ai_agent_user_prompt_submit_info": {
+      "caption": "AI Agent User Prompt Submit Information",
+      "description": "Provides detail pertaining to the <code>User Prompt Submit</code> activity.",
+      "type": "ai_agent_user_prompt_submit_info"
+    },
     "ai_model": {
       "caption": "AI Model",
       "description": "The AI Model object describes the characteristics of an AI/ML model. Examples include language models like GPT-4, embedding models like text-embedding-ada-002, and computer vision models like CLIP.",
@@ -241,6 +276,26 @@
       "description": "The originator or target role of the message.",
       "sibling": "ai_role",
       "type": "integer_t"
+    },
+    "ai_subagent_start_info": {
+      "caption": "AI Subagent Start Information",
+      "description": "Provides detail pertaining to the <code>Subagent Start</code> activity.",
+      "type": "ai_subagent_start_info"
+    },
+    "ai_subagent_stop_info": {
+      "caption": "AI Subagent Stop Information",
+      "description": "Provides detail pertaining to the <code>Subagent Stop</code> activity.",
+      "type": "ai_subagent_stop_info"
+    },
+    "ai_tool_input": {
+      "caption": "AI Tool Input",
+      "description": "Describes the input provided to a tool that is invoked by an AI agent.",
+      "type": "json_t"
+    },
+    "ai_tool_response": {
+      "caption": "AI Tool Response",
+      "description": "Describes the response from a tool that is invoked by an AI agent.",
+      "type": "json_t"
     },
     "aircraft": {
       "caption": "Aircraft",
@@ -3810,6 +3865,11 @@
     "is_personal": {
       "caption": "Personal Device",
       "description": "The event occurred on a personal device.",
+      "type": "boolean_t"
+    },
+    "is_pre_occurrence": {
+      "caption": "Is Pre-Occurrence",
+      "description": "The event described has not yet occurred. See specific usage.",
       "type": "boolean_t"
     },
     "is_public": {

--- a/events/application/ai_agent_activity.json
+++ b/events/application/ai_agent_activity.json
@@ -1,0 +1,85 @@
+{
+  "uid": 9,
+  "caption": "AI Agent Activity",
+  "description": "AI Agent Activity events describe the behavior of autonomous AI agents.",
+  "extends": "application",
+  "name": "ai_agent_activity",
+  "attributes": {
+    "activity_id": {
+      "enum": {
+        "1": {
+          "caption": "Session Start",
+          "description": "The agent has started or resumed a session. Refer to the <code>ai_agent_session_start_info</code> object for details."
+        },
+        "2": {
+          "caption": "Session End",
+          "description": "An agent session has ended. Refer to the <code>ai_agent_session_end_info</code> object for details."
+        },
+        "3": {
+          "caption": "Subagent Start",
+          "description": "The agent has started a sub-agent. Refer to the <code>ai_subagent_start_info</code> object for details."
+        },
+        "4": {
+          "caption": "Subagent Stop",
+          "description": "A sub-agent has stopped. Refer to the <code>ai_subagent_stop_info</code> object for details."
+        },
+        "5": {
+          "caption": "User Prompt Submit",
+          "description": "The user has submitted a prompt to the agent. Refer to the <code>ai_agent_user_prompt_submit_info</code> object for details."
+        },
+        "6": {
+          "caption": "Permission Request",
+          "description": "The agent has requested permission to make a tool call. Refer to the <code>ai_agent_permission_request_info</code> object for details."
+        },
+        "7": {
+          "caption": "Tool Use",
+          "description": "The agent has made or is about to make a tool call. Refer to the <code>ai_agent_tool_use_info</code> object for details."
+        },
+        "8": {
+          "caption": "Stop",
+          "description": "A turn has stopped due to natural completion, failure, or interruption by the user. Refer to the <code>ai_agent_stop_info</code> object for details."
+        },
+        "9": {
+          "caption": "Compact",
+          "description": "The agent has compacted or is about to compact its context. Refer to the <code>ai_agent_compact_info</code> object for details."
+        }
+      }
+    },
+    "ai_agent_compact_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_permission_request_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_session_end_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_session_start_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_stop_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_tool_use_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_agent_user_prompt_submit_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_subagent_start_info": {
+      "group": "primary",
+      "requirement": "optional"
+    },
+    "ai_subagent_stop_info": {
+      "group": "primary",
+      "requirement": "optional"
+    }
+  }
+}

--- a/objects/ai_agent_compact_info.json
+++ b/objects/ai_agent_compact_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Agent Compact Information",
+  "description": "The AI Agent Compact Information object provides detail pertaining to the <code>AI Agent Activity: Compact</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_compact_info"
+}

--- a/objects/ai_agent_permission_request_info.json
+++ b/objects/ai_agent_permission_request_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Agent Permission Request Information",
+  "description": "The AI Agent Permission Request Information object provides detail pertaining to the <code>AI Agent Activity: Permission Request</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_permission_request_info"
+}

--- a/objects/ai_agent_session_end_info.json
+++ b/objects/ai_agent_session_end_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Agent Session End Information",
+  "description": "The AI Agent Session End Information object provides detail pertaining to the <code>AI Agent Activity: Session End</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_session_end_info"
+}

--- a/objects/ai_agent_session_start_info.json
+++ b/objects/ai_agent_session_start_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Agent Session Start Information",
+  "description": "The AI Agent Session Start Information object provides detail pertaining to the <code>AI Agent Activity: Session Start</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_session_start_info"
+}

--- a/objects/ai_agent_stop_info.json
+++ b/objects/ai_agent_stop_info.json
@@ -1,0 +1,44 @@
+{
+  "caption": "AI Agent Stop Information",
+  "description": "The AI Agent Stop Information object provides detail pertaining to the <code>AI Agent Activity: Stop</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_stop_info",
+  "attributes": {
+    "type": {
+      "caption": "Stop Type",
+      "description": "The stop type, normalized to the caption of the <code>type_id</code> value. In the case of 'Other', it is defined by the source.",
+      "requirement": "optional"
+    },
+    "type_id": {
+      "caption": "Stop Type ID",
+      "description": "The normalized stop type ID.",
+      "requirement": "required",
+      "enum": {
+        "0": {
+          "caption": "Unknown",
+          "description": "The turn ended for an unknown reason."
+        },
+        "1": {
+          "caption": "End of Turn",
+          "description": "The turn ended naturally. The model has returned a complete response."
+        },
+        "2": {
+          "caption": "Interrupt",
+          "description": "The turn ended prematurely having been interrupted by the user. Any response returned is incomplete."
+        },
+        "3": {
+          "caption": "Token Limit",
+          "description": "The turn ended abnormally due to token exhaustion. Any response returned is incomplete."
+        },
+        "4": {
+          "caption": "Failed",
+          "description": "The turn ended abnormally due to an unrecoverable failure. Any response returned is incomplete."
+        },
+        "99": {
+          "caption": "Other",
+          "description": "The turn ended for a reason that is not mapped. See the <code>type</code> attribute which contains an event source specific value."
+        }
+      }
+    }
+  }
+}

--- a/objects/ai_agent_tool_use_info.json
+++ b/objects/ai_agent_tool_use_info.json
@@ -1,0 +1,24 @@
+{
+  "caption": "AI Agent Tool Use Information",
+  "description": "The AI Agent Tool Use Information object provides detail pertaining to the <code>AI Agent Activity: Tool Use</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_tool_use_info",
+  "attributes": {
+    "ai_tool_input": {
+      "description": "Describes the input provided to the tool by the AI agent.",
+      "requirement": "recommended"
+    },
+    "ai_tool_response": {
+      "description": "Describes the response received by the AI agent from the tool. This attribute is not available when <code>is_pre_occurrence</code> is <code>true</code>.",
+      "requirement": "recommended"
+    },
+    "is_pre_occurrence": {
+      "description": "<code>true</code> indicates that the tool has not yet been invoked. <code>false</code> indicates that the tool use has occurred.",
+      "requirement": "required"
+    },
+    "name": {
+      "description": "The name of the invoked tool, e.g. <code>Bash</code>, <code>apply-patch</code>, <code>mcp__jira__search</code>, etc.",
+      "requirement": "required"
+    }
+  }
+}

--- a/objects/ai_agent_user_prompt_submit_info.json
+++ b/objects/ai_agent_user_prompt_submit_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Agent User Prompt Submit Information",
+  "description": "The AI Agent User Prompt Submit Information object provides detail pertaining to the <code>AI Agent Activity: User Prompt Submit</code> event type.",
+  "extends": "object",
+  "name": "ai_agent_user_prompt_submit_info"
+}

--- a/objects/ai_subagent_start_info.json
+++ b/objects/ai_subagent_start_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Subagent Start Information",
+  "description": "The AI Subagent Start Information object provides detail pertaining to the <code>AI Agent Activity: Subagent Start</code> event type.",
+  "extends": "object",
+  "name": "ai_subagent_start_info"
+}

--- a/objects/ai_subagent_stop_info.json
+++ b/objects/ai_subagent_stop_info.json
@@ -1,0 +1,6 @@
+{
+  "caption": "AI Subagent Stop Information",
+  "description": "The AI Subagent Stop Information object provides detail pertaining to the <code>AI Agent Activity: Subagent Stop</code> event type.",
+  "extends": "object",
+  "name": "ai_subagent_stop_info"
+}


### PR DESCRIPTION
This is work-in-progress.

The `AI Agent Activity` event:

<img width="1377" height="1690" alt="image" src="https://github.com/user-attachments/assets/acaae490-846e-4022-b404-718f65229ceb" />

The `AI Agent Stop Information` object:

<img width="1377" height="574" alt="image" src="https://github.com/user-attachments/assets/8313069e-96d0-4634-a99d-a9011b1caa84" />

The `AI Agent Tool Use Information` object:

<img width="1375" height="351" alt="image" src="https://github.com/user-attachments/assets/a5c276bc-c3bc-4384-bddc-0a8294fd02fb" />
